### PR TITLE
Fix compile with glm 1.0.0+ and musl libc

### DIFF
--- a/src/animator.cpp
+++ b/src/animator.cpp
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <mir/log.h>
 #define _USE_MATH_DEFINES
 #include <cmath>
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/transform.hpp>
 #include <utility>
 

--- a/src/animator.cpp
+++ b/src/animator.cpp
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <mir/server_action_queue.h>
 #define MIR_LOG_COMPONENT "animator"
 #include <mir/log.h>
-#define _USE_MATH_DEFINES
-#include <cmath>
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/transform.hpp>
 #include <utility>
@@ -43,7 +41,7 @@ inline float get_percent_complete(float target, float real)
         return 1.f;
 
     float percent = real / target;
-    if (isinff(percent) != 0 || percent > 1.f)
+    if (std::isinf(percent) != 0 || percent > 1.f)
         return 1.f;
     else
         return percent;
@@ -141,11 +139,11 @@ inline float ease(AnimationDefinition const& defintion, float t)
     case EaseFunction::linear:
         return t;
     case EaseFunction::ease_in_sine:
-        return 1 - cosf((t * M_PIf) / 2.f);
+        return 1 - cosf((t * M_PI) / 2.f);
     case EaseFunction::ease_in_out_sine:
-        return -(cosf(M_PIf * t) - 1) / 2;
+        return -(cosf(M_PI * t) - 1) / 2;
     case EaseFunction::ease_out_sine:
-        return sinf((t * M_PIf) / 2.f);
+        return sinf((t * M_PI) / 2.f);
     case EaseFunction::ease_in_quad:
         return t * t;
     case EaseFunction::ease_out_quad:

--- a/src/output_content.cpp
+++ b/src/output_content.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "output_content.h"
 #include "window_helpers.h"
 #include "workspace_manager.h"
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/transform.hpp>
 #include <mir/log.h>
 #include <mir/scene/surface.h>

--- a/src/window_metadata.cpp
+++ b/src/window_metadata.cpp
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "window_metadata.h"
 #include "output_content.h"
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/transform.hpp>
 
 using namespace miracle;


### PR DESCRIPTION
Attempting to build on a full LLVM 18.1.8 toolchain on Chimera Linux I encountered the following errors:
```
FAILED: CMakeFiles/miracle-wm-implementation.dir/src/window_metadata.cpp.o 
/usr/bin/clang++  -I/builddir/miracle-wm-0.2.1_git20240629/SYSTEM -I/usr/include/miral -I/usr/include/mircommon -I/usr/include/mircore -I/usr/include/miroil -I/usr/include/mirrenderer -I/usr/include/mirplatform -I/usr/include/mircommon-internal -I/usr/include/mirserver-internal -I/usr/include/mirserver -I/usr/include/uuid -I/builddir/miracle-wm-0.2.1_git20240629/include -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/libevdev-1.0 -isystem /usr/include/gdk-pixbuf-2.0 -isystem /usr/include/libpng16 -isystem /usr/include/libmount -isystem /usr/include/blkid -isystem /usr/include/libdrm -ffile-prefix-map=/builddir/miracle-wm-0.2.1_git20240629=. -Wformat -Werror=format-security -ftrivial-auto-var-init=zero -fstack-clash-protection -fno-omit-frame-pointer -fsanitize=signed-integer-overflow,integer-divide-by-zero -fsanitize-trap=signed-integer-overflow,integer-divide-by-zero -fno-sanitize-recover -flto=thin -O2 -g2 -std=c++23 -pthread -DWITH_GZFILEOP -MD -MT CMakeFiles/miracle-wm-implementation.dir/src/window_metadata.cpp.o -MF CMakeFiles/miracle-wm-implementation.dir/src/window_metadata.cpp.o.d -o CMakeFiles/miracle-wm-implementation.dir/src/window_metadata.cpp.o -c /builddir/miracle-wm-0.2.1_git20240629/src/window_metadata.cpp
In file included from /builddir/miracle-wm-0.2.1_git20240629/src/window_metadata.cpp:20:
/usr/include/glm/gtx/transform.hpp:23:3: error: "GLM: GLM_GTX_transform is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."
   23 | #       error "GLM: GLM_GTX_transform is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."
      |         ^
```
`GLM_ENABLE_EXPERIMENTAL` has guarded inclusion of [`glm/gtx/transform.hpp`](https://github.com/g-truc/glm/blame/1.0.1/glm/gtx/transform.hpp#L23) since [glm 1.0.0](https://github.com/g-truc/glm/releases/tag/1.0.0). Should be reproducible on e.g. arch which ships a modern glm version too.

```
FAILED: CMakeFiles/miracle-wm-implementation.dir/src/animator.cpp.o 
/usr/bin/clang++  -I/builddir/miracle-wm-0.2.1_git20240629/SYSTEM -I/usr/include/miral -I/usr/include/mircommon -I/usr/include/mircore -I/usr/include/miroil -I/usr/include/mirrenderer -I/usr/include/mirplatform -I/usr/include/mircommon-internal -I/usr/include/mirserver-internal -I/usr/include/mirserver -I/usr/include/uuid -I/builddir/miracle-wm-0.2.1_git20240629/include -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/libevdev-1.0 -isystem /usr/include/gdk-pixbuf-2.0 -isystem /usr/include/libpng16 -isystem /usr/include/libmount -isystem /usr/include/blkid -isystem /usr/include/libdrm -ffile-prefix-map=/builddir/miracle-wm-0.2.1_git20240629=. -Wformat -Werror=format-security -ftrivial-auto-var-init=zero -fstack-clash-protection -fno-omit-frame-pointer -fsanitize=signed-integer-overflow,integer-divide-by-zero -fsanitize-trap=signed-integer-overflow,integer-divide-by-zero -fno-sanitize-recover -flto=thin -O2 -g2 -std=c++23 -pthread -DWITH_GZFILEOP -MD -MT CMakeFiles/miracle-wm-implementation.dir/src/animator.cpp.o -MF CMakeFiles/miracle-wm-implementation.dir/src/animator.cpp.o.d -o CMakeFiles/miracle-wm-implementation.dir/src/animator.cpp.o -c /builddir/miracle-wm-0.2.1_git20240629/src/animator.cpp
/builddir/miracle-wm-0.2.1_git20240629/src/animator.cpp:46:9: error: use of undeclared identifier 'isinff'; did you mean 'isinf'?
   46 |     if (isinff(percent) != 0 || percent > 1.f)
      |         ^~~~~~
      |         isinf
/usr/bin/../include/c++/v1/math.h:422:20: note: 'isinf' declared here
  422 | using std::__math::isinf;
      |                    ^
/builddir/miracle-wm-0.2.1_git20240629/src/animator.cpp:144:30: error: use of undeclared identifier 'M_PIf'
  144 |         return 1 - cosf((t * M_PIf) / 2.f);
      |                              ^
/builddir/miracle-wm-0.2.1_git20240629/src/animator.cpp:146:23: error: use of undeclared identifier 'M_PIf'
  146 |         return -(cosf(M_PIf * t) - 1) / 2;
      |                       ^
/builddir/miracle-wm-0.2.1_git20240629/src/animator.cpp:148:26: error: use of undeclared identifier 'M_PIf'
  148 |         return sinf((t * M_PIf) / 2.f);
      |                          ^
```
`isinff` is deprecated since C99 (see notes on https://linux.die.net/man/3/isinff) and only glibc still implements it nowadays while musl libc doesn't, replace it with the modern counterpart and start using [the C++ overload](https://en.cppreference.com/w/cpp/numeric/math/isinf)

`M_PIf` is [a glibc 2.35+ macro](https://github.com/bminor/glibc/commit/347a5b5) which doesn't exist on [musl libc `math.h`](https://git.musl-libc.org/cgit/musl/tree/include/math.h), so just use `M_PI` which seems to work the same in this case. Alternatively e.g. [`std::numbers::pi`](https://en.cppreference.com/w/cpp/numeric/constants) could be used instead perhaps.

After these fixes only 3 warnings similar to this one are printed from [`ease_out_bounce()`](https://github.com/mattkae/miracle-wm/blob/458b5cc/src/animator.cpp#L121-L132) but I left these untouched for now:
```
/builddir/miracle-wm-0.2.1_git20240629/src/animator.cpp:122:34: warning: unsequenced modification and access to 'x' [-Wunsequenced]
  122 |         return defintion.n1 * (x -= 1.5f / defintion.d1) * x + 0.75f;
      |                                  ^                         ~
```