### PR TITLE
Allow using custom mir libraries directory

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,7 +32,7 @@ jobs:
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 --slave /usr/bin/g++ g++ /usr/bin/g++-13
         sudo apt install libmiral-dev libmircommon-internal-dev libmircommon-dev libmirserver-internal-dev \
           libgtest-dev libyaml-cpp-dev libglib2.0-dev libevdev-dev nlohmann-json3-dev libnotify-dev pcre2-utils \
-          libmiroil-dev libmirrenderer-dev libgles2-mesa-dev
+          libmiroil-dev libmirrenderer-dev libgles2-mesa-dev libmirwayland-dev
 
 
     - name: Configure CMake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,17 +8,14 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(ENV{PKG_CONFIG_PATH} "/usr/local/lib/pkgconfig/")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+set(MIR_LIBRARIES_PKGCONFIG_DIRECTORY "" CACHE STRING "Search for Mir libraries pc files in this directory")
 option(SNAP_BUILD "Building as a snap?" OFF)
 
-set(MIR_LIBRARIES_PKGCONFIG_DIRECTORY "" CACHE STRING "Search for Mir libraries pc files in this directory")
-if(MIR_LIBRARIES_PKGCONFIG_DIRECTORY)
-    set(ENV{PKG_CONFIG_PATH} "${MIR_LIBRARIES_PKGCONFIG_DIRECTORY}:/usr/local/lib/pkgconfig/")
-endif()
+set(ENV{PKG_CONFIG_PATH} "${MIR_LIBRARIES_PKGCONFIG_DIRECTORY}:/usr/local/lib/pkgconfig/")
 
 find_package(PkgConfig)
 pkg_check_modules(MIRAL miral REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 option(SNAP_BUILD "Building as a snap?" OFF)
 
+set(MIR_LIBRARIES_PKGCONFIG_DIRECTORY "" CACHE STRING "Search for Mir libraries pc files in this directory")
+if(MIR_LIBRARIES_PKGCONFIG_DIRECTORY)
+    set(ENV{PKG_CONFIG_PATH} "${MIR_LIBRARIES_PKGCONFIG_DIRECTORY}:/usr/local/lib/pkgconfig/")
+endif()
+
 find_package(PkgConfig)
 pkg_check_modules(MIRAL miral REQUIRED)
 pkg_check_modules(MIROIL miroil REQUIRED)
@@ -24,6 +29,7 @@ pkg_check_modules(MIRCOMMON mircommon REQUIRED)
 pkg_check_modules(MIRCOMMON_INTERNAL mircommon-internal REQUIRED)
 pkg_check_modules(MIRSERVER mirserver REQUIRED)
 pkg_check_modules(MIRSERVER_INTERNAL mirserver-internal REQUIRED)
+pkg_check_modules(MIRWAYLAND mirwayland REQUIRED)
 pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
 pkg_check_modules(YAML REQUIRED IMPORTED_TARGET yaml-cpp)
 pkg_check_modules(LIBEVDEV REQUIRED IMPORTED_TARGET libevdev)
@@ -91,6 +97,7 @@ target_link_libraries(miracle-wm-implementation
     ${MIRPLATFORM_LDFLAGS}
     ${MIRSERVER_LDFLAGS}
     ${MIRSERVER_INTERNAL_LDFLAGS}
+    ${MIRWAYLAND_LDFLAGS}
     PkgConfig::YAML
     PkgConfig::GLIB
     PkgConfig::LIBEVDEV

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,6 +75,7 @@ parts:
       - libnotify-dev
       - libgles2-mesa-dev
       - libmirrenderer-dev
+      - libmirwayland-dev
     stage-packages:
       - libmiral7
       - libmiroil5

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,11 @@ pkg_check_modules(MIRSERVER mirserver REQUIRED)
 find_package(GTest REQUIRED)
 pkg_check_modules(YAML REQUIRED IMPORTED_TARGET yaml-cpp)
 
+if(MIR_LIBRARIES_PKGCONFIG_DIRECTORY)
+    list( PREPEND CMAKE_INSTALL_RPATH ${MIRAL_LIBRARY_DIRS} )
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+endif()
+
 add_executable(miracle-wm-tests
     filesystem_configuration_test.cpp
     tiling_window_tree_test.cpp


### PR DESCRIPTION
Allow invoking cmake with `-DMIR_LIBRARIES_PKGCONFIG_DIRECTORY=<dir>` to search Mir pc files in a custom directory.
If `-DMIR_LIBRARIES_PKGCONFIG_DIRECTORY` is not set, behavior remains unchanged.

Note: to successfully build locally, linking to libmirwayland.so was neeeded, so I added it to `target_link_libraries`.

Building on Debian with a local build of the Mir main branch works now without modifying miracle-wm sources.

Fix #196.