### PR TITLE
CMakeLists.txt: Drop PKG_CONFIG_PATH modification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-set(MIR_LIBRARIES_PKGCONFIG_DIRECTORY "" CACHE STRING "Search for Mir libraries pc files in this directory")
 option(SNAP_BUILD "Building as a snap?" OFF)
-
-set(ENV{PKG_CONFIG_PATH} "${MIR_LIBRARIES_PKGCONFIG_DIRECTORY}:/usr/local/lib/pkgconfig/")
 
 find_package(PkgConfig)
 pkg_check_modules(MIRAL miral REQUIRED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,11 +14,6 @@ pkg_check_modules(MIRSERVER mirserver REQUIRED)
 find_package(GTest REQUIRED)
 pkg_check_modules(YAML REQUIRED IMPORTED_TARGET yaml-cpp)
 
-if(MIR_LIBRARIES_PKGCONFIG_DIRECTORY)
-    list( PREPEND CMAKE_INSTALL_RPATH ${MIRAL_LIBRARY_DIRS} )
-    set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
-endif()
-
 add_executable(miracle-wm-tests
     filesystem_configuration_test.cpp
     tiling_window_tree_test.cpp


### PR DESCRIPTION
Fix https://github.com/mattkae/miracle-wm/pull/198#discussion_r1721453027

Setting up `PKG_CONFIG_PATH` with `/usr/local/lib/pkgconfig`, or ensuring that the correct Mir is on said path, shouldn't be this project's responsibility.