### PR TITLE
fix: Drop broken method for seeding default configuration

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -37,7 +37,6 @@ using namespace miracle;
 
 namespace
 {
-const char* MIRACLE_DEFAULT_CONFIG_FILE = "/usr/share/miracle-wm/config/default.yaml";
 const char* MIRACLE_DEFAULT_CONFIG_DIR = "/usr/share/miracle-wm/default-config";
 
 int program_exists(std::string const& name)
@@ -230,13 +229,6 @@ void FilesystemConfiguration::_init(std::optional<StartupApp> const& startup_app
                 mir::log_info("Configuration hierarchy being copied from %s", MIRACLE_DEFAULT_CONFIG_DIR);
                 const auto fs_copyopts = std::filesystem::copy_options::recursive;
                 std::filesystem::copy(MIRACLE_DEFAULT_CONFIG_DIR, std::filesystem::path(config_path).parent_path(), fs_copyopts);
-            }
-            else if (std::filesystem::exists(MIRACLE_DEFAULT_CONFIG_FILE))
-            {
-                mir::log_info("Configuration being copied from %s", MIRACLE_DEFAULT_CONFIG_FILE);
-                std::filesystem::copy_file(
-                    MIRACLE_DEFAULT_CONFIG_FILE,
-                    config_path);
             }
             else
             {


### PR DESCRIPTION
With b4fa88e9facd312c6944a6e9e44c02bd4ad54ccc, the main method for initializing default configuration copies over a whole configuration directory for the purpose of being able to handle a full set of configuration all at once. This is the much more coherent and expected method for seeding default configuration.

Thus, we do not need the method for copying a single file anymore, and this change drops it to simplify the understanding of seeding configuration in MiracleWM.