### PR TITLE
bugfix: tiled windows now always get forced into an initial size and windows that are default to maximized/fullscreened are floating by default

### DIFF
--- a/src/leaf_container.cpp
+++ b/src/leaf_container.cpp
@@ -145,8 +145,6 @@ void LeafContainer::handle_modify(miral::WindowSpecification const& modification
 {
     auto const& info = window_controller.info_for(window_);
 
-    // TODO: Check if the current workspace is active. If not, return early.
-
     auto mods = modifications;
     if (mods.state().is_set() && mods.state().value() != info.state())
     {

--- a/src/tiling_window_tree.cpp
+++ b/src/tiling_window_tree.cpp
@@ -66,22 +66,23 @@ miral::WindowSpecification TilingWindowTree::place_new_window(
     const miral::WindowSpecification& requested_specification,
     std::shared_ptr<ParentContainer> const& parent_)
 {
+    assert(
+        !requested_specification.state().is_set()
+        || requested_specification.state() == mir_window_state_restored
+        || requested_specification.state() == mir_window_state_unknown);
+
     auto parent = parent_ ? parent_ : root_lane;
+    auto container = parent->create_space_for_window();
+    auto rect = container->get_visible_area();
+
     miral::WindowSpecification new_spec = requested_specification;
     new_spec.server_side_decorated() = false;
     new_spec.min_width() = geom::Width { 0 };
     new_spec.max_width() = geom::Width { std::numeric_limits<int>::max() };
     new_spec.min_height() = geom::Height { 0 };
     new_spec.max_height() = geom::Height { std::numeric_limits<int>::max() };
-    auto container = parent->create_space_for_window();
-    auto rect = container->get_visible_area();
-
-    if (!new_spec.state().is_set() || !window_helpers::is_window_fullscreen(new_spec.state().value()))
-    {
-        // We only set the size immediately if we have no strong opinions about the size
-        new_spec.size() = rect.size;
-        new_spec.top_left() = rect.top_left;
-    }
+    new_spec.size() = rect.size;
+    new_spec.top_left() = rect.top_left;
 
     return new_spec;
 }

--- a/src/window_helpers.h
+++ b/src/window_helpers.h
@@ -39,6 +39,9 @@ namespace window_helpers
         if (has_exclusive_rect || is_attached)
             return ContainerType::shell;
 
+        if (requested_specification.state().is_set() && requested_specification.state().value() > (int)mir_window_state_restored)
+            return ContainerType::floating_window;
+
         auto t = requested_specification.type();
         if (t == mir_window_type_normal || t == mir_window_type_freestyle)
         {


### PR DESCRIPTION
## What's new?
- We always set the initial size when placing in the tiling grid
- We always place windows that want to be in any state other than "regular" as floating windows