### PR TITLE
Fix unpinning a window to a new workspace

### DIFF
--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -360,7 +360,7 @@ void Workspace::transfer_pinned_windows_to(std::shared_ptr<Workspace> const& oth
         auto floating = Container::as_floating(container);
         if (floating && floating->pinned())
         {
-            other->floating_windows.push_back(floating);
+            other->graft(floating);
             it = floating_windows.erase(it);
         }
         else


### PR DESCRIPTION
When a pinned window is transferred to another workspace, the `workspace` property on the `FloatingWindowContainer` was not updated.

This PR adds a call to `Workspace::graft` on the destination workspace when transferring a pinned window.

Fix #277 