### PR TITLE
bugfix: we don't need to dereference the surface when getting the rectangle for our outlines

### DIFF
--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -60,7 +60,7 @@ auto make_output_current(std::unique_ptr<mg::gl::OutputSurface> output) -> std::
 class OutlineRenderable : public mir::graphics::Renderable
 {
 public:
-    OutlineRenderable(mir::graphics::Renderable const& renderable, int outline_width_px, float alpha) :
+    OutlineRenderable(Renderable const& renderable, int outline_width_px, float alpha) :
         renderable { renderable },
         outline_width_px { outline_width_px },
         _alpha { alpha }
@@ -83,8 +83,7 @@ public:
         if (!surface)
             return {};
 
-        return get_rectangle({ surface.value()->top_left(),
-            surface.value()->window_size() });
+        return get_rectangle(renderable.screen_position());
     }
 
     [[nodiscard]] geom::RectangleD src_bounds() const override


### PR DESCRIPTION
Fixes a bunch of weirdness found when deleting lines quickly in neovim