### PR TITLE
bugfix: Reverse the order of command checking in `matches_key_command`

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -884,7 +884,7 @@ FilesystemConfiguration::matches_custom_key_command(MirKeyboardAction action, in
 
 bool FilesystemConfiguration::matches_key_command(MirKeyboardAction action, int scan_code, unsigned int modifiers, std::function<bool(DefaultKeyCommand)> const& f) const
 {
-    for (int i = 0; i < static_cast<int>(DefaultKeyCommand::MAX); i++)
+    for (int i = static_cast<int>(DefaultKeyCommand::MAX) - 1; i >= 0; i--)
     {
         for (auto command : options.key_commands[i])
         {


### PR DESCRIPTION
Should now give precedence for custom/user commands instead of the built-in ones.