### PR TITLE
refactor: prepare `CommandController` such that it can more easily be tested

### DIFF
--- a/src/command_controller.cpp
+++ b/src/command_controller.cpp
@@ -37,7 +37,7 @@ CommandController::CommandController(
     WindowController& window_controller,
     WorkspaceManager& workspace_manager,
     ModeObserverRegistrar& mode_observer_registrar,
-    miral::MirRunner& runner,
+    std::unique_ptr<CommandControllerInterface> interface,
     Scratchpad& scratchpad_) :
     config { config },
     mutex { mutex },
@@ -45,7 +45,7 @@ CommandController::CommandController(
     window_controller { window_controller },
     workspace_manager { workspace_manager },
     mode_observer_registrar { mode_observer_registrar },
-    runner { runner },
+    interface { std::move(interface) },
     scratchpad_ { scratchpad_ }
 {
 }
@@ -319,7 +319,7 @@ bool CommandController::try_close_window()
 bool CommandController::quit()
 {
     std::lock_guard lock(mutex);
-    runner.stop();
+    interface->quit();
     return true;
 }
 

--- a/src/command_controller.h
+++ b/src/command_controller.h
@@ -38,6 +38,7 @@ class ModeObserverRegistrar;
 class CommandControllerInterface
 {
 public:
+    virtual ~CommandControllerInterface() = default;
     virtual void quit() = 0;
 };
 

--- a/src/command_controller.h
+++ b/src/command_controller.h
@@ -35,6 +35,12 @@ namespace miracle
 class Scratchpad;
 class ModeObserverRegistrar;
 
+class CommandControllerInterface
+{
+public:
+    virtual void quit() = 0;
+};
+
 /// Responsible for fielding requests from the system and forwarding
 /// them to an appropriate handler. Requests can come from any thread
 /// (e.g. the keyboard input thread, the ipc thread, etc.).
@@ -52,8 +58,8 @@ public:
         WindowController& window_controller,
         WorkspaceManager& workspace_manager,
         ModeObserverRegistrar& mode_observer_registrar,
-        miral::MirRunner& runner,
-        Scratchpad& scratchpad_);
+        std::unique_ptr<CommandControllerInterface> interface,
+        Scratchpad& scratchpad);
 
     bool try_request_horizontal();
     bool try_request_vertical();
@@ -121,7 +127,7 @@ private:
     WindowController& window_controller;
     WorkspaceManager& workspace_manager;
     ModeObserverRegistrar& mode_observer_registrar;
-    miral::MirRunner& runner;
+    std::unique_ptr<CommandControllerInterface> interface;
     Scratchpad& scratchpad_;
 
     bool can_move_container() const;

--- a/src/feature_flags.h
+++ b/src/feature_flags.h
@@ -19,6 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MIRACLE_WM_FEATURE_FLAGS_H
 
 #define MIRACLE_FEATURE_FLAG_MULTI_SELECT false
-#define MIRACLE_FEATURE_FLAG_DRAG_AND_DROP false
+#define MIRACLE_FEATURE_FLAG_DRAG_AND_DROP true
 
 #endif // MIRACLE_WM_FEATURE_FLAGS_H

--- a/src/feature_flags.h
+++ b/src/feature_flags.h
@@ -19,6 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MIRACLE_WM_FEATURE_FLAGS_H
 
 #define MIRACLE_FEATURE_FLAG_MULTI_SELECT false
-#define MIRACLE_FEATURE_FLAG_DRAG_AND_DROP true
+#define MIRACLE_FEATURE_FLAG_DRAG_AND_DROP false
 
 #endif // MIRACLE_WM_FEATURE_FLAGS_H

--- a/src/output.h
+++ b/src/output.h
@@ -51,7 +51,6 @@ public:
         miral::Output const& output,
         WorkspaceManager& workspace_manager,
         geom::Rectangle const& area,
-        miral::WindowManagerTools const& tools,
         std::shared_ptr<MinimalWindowManager> const& floating_window_manager,
         CompositorState& state,
         std::shared_ptr<Config> const& options,
@@ -133,7 +132,6 @@ private:
 
     miral::Output output;
     WorkspaceManager& workspace_manager;
-    miral::WindowManagerTools tools;
     std::shared_ptr<MinimalWindowManager> floating_window_manager;
     CompositorState& state;
     geom::Rectangle area;

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -50,8 +50,8 @@ const int MODIFIER_MASK = mir_input_event_modifier_alt | mir_input_event_modifie
 class MirRunnerCommandControllerInterface : public CommandControllerInterface
 {
 public:
-    explicit MirRunnerCommandControllerInterface(miral::MirRunner& runner)
-      : runner {runner}
+    explicit MirRunnerCommandControllerInterface(miral::MirRunner& runner) :
+        runner { runner }
     {
     }
 

--- a/src/policy.h
+++ b/src/policy.h
@@ -66,8 +66,6 @@ public:
         std::shared_ptr<WindowToolsAccessor> const&);
     ~Policy() override;
 
-    // Interactions with the engine
-
     bool handle_keyboard_event(MirKeyboardEvent const* event) override;
     bool handle_pointer_event(MirPointerEvent const* event) override;
     auto place_new_window(
@@ -102,26 +100,21 @@ public:
     void advise_application_zone_delete(miral::Zone const& application_zone) override;
     void advise_end() override;
 
-    // Getters
-
-    [[nodiscard]] Output const* get_active_output() const { return state.focused_output().get(); }
-    [[nodiscard]] std::vector<std::shared_ptr<Output>> const& get_output_list() const { return state.output_list; }
-    [[nodiscard]] geom::Point const& get_cursor_position() const { return state.cursor_position; }
-    [[nodiscard]] CompositorState const& get_state() const { return state; }
-
 private:
     class Self;
 
     void handle_drag_and_drop_pointer_event(MirPointerEvent const* event);
 
-    bool is_starting_ = true;
-    CompositorState& state;
-    AllocationHint pending_allocation;
-    std::vector<miral::Window> orphaned_window_list;
-    miral::WindowManagerTools window_manager_tools;
-    std::shared_ptr<MinimalWindowManager> floating_window_manager;
     AutoRestartingLauncher& external_client_launcher;
     std::shared_ptr<Config> config;
+    std::shared_ptr<Animator> animator;
+    SurfaceTracker& surface_tracker;
+    CompositorState& state;
+
+    bool is_starting_ = true;
+    AllocationHint pending_allocation;
+    std::vector<miral::Window> orphaned_window_list;
+    std::shared_ptr<MinimalWindowManager> floating_window_manager;
     WorkspaceObserverRegistrar workspace_observer_registrar;
     ModeObserverRegistrar mode_observer_registrar;
     WorkspaceManager workspace_manager;
@@ -129,13 +122,10 @@ private:
     Scratchpad scratchpad_;
     CommandController command_controller;
     std::shared_ptr<Ipc> ipc;
-    std::shared_ptr<Animator> animator;
     std::unique_ptr<AnimatorLoop> animator_loop;
     WindowManagerToolsWindowController window_controller;
     IpcCommandExecutor i3_command_executor;
-    SurfaceTracker& surface_tracker;
     std::shared_ptr<ContainerGroupContainer> group_selection;
-    mir::Server const& server;
 };
 }
 

--- a/src/window_controller.h
+++ b/src/window_controller.h
@@ -57,6 +57,7 @@ public:
     virtual miral::ApplicationInfo& app_info(miral::Window const&) = 0;
     virtual void move_cursor_to(float x, float y) = 0;
     virtual void set_size_hack(AnimationHandle handle, geom::Size const& size) = 0;
+    virtual miral::Window window_at(float x, float y) = 0;
 };
 
 }

--- a/src/window_manager_tools_window_controller.cpp
+++ b/src/window_manager_tools_window_controller.cpp
@@ -300,3 +300,8 @@ void WindowManagerToolsWindowController::set_size_hack(AnimationHandle handle, m
 {
     animator.set_size_hack(handle, size);
 }
+
+miral::Window WindowManagerToolsWindowController::window_at(float x, float y)
+{
+    return tools.window_at({ x, y });
+}

--- a/src/window_manager_tools_window_controller.h
+++ b/src/window_manager_tools_window_controller.h
@@ -59,6 +59,7 @@ public:
     void close(miral::Window const& window) override;
     void move_cursor_to(float x, float y) override;
     void set_size_hack(AnimationHandle handle, mir::geometry::Size const& size) override;
+    miral::Window window_at(float x, float y) override;
 
 private:
     miral::WindowManagerTools tools;

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -66,7 +66,6 @@ private:
 
 Workspace::Workspace(
     miracle::Output* output,
-    miral::WindowManagerTools const& tools,
     uint32_t id,
     std::optional<int> num,
     std::optional<std::string> name,
@@ -75,7 +74,6 @@ Workspace::Workspace(
     CompositorState const& state,
     std::shared_ptr<MinimalWindowManager> const& floating_window_manager) :
     output { output },
-    tools { tools },
     id_ { id },
     num_ { num },
     name_ { name },

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -49,7 +49,6 @@ class Workspace
 public:
     Workspace(
         Output* output,
-        miral::WindowManagerTools const& tools,
         uint32_t id,
         std::optional<int> num,
         std::optional<std::string> name,
@@ -99,7 +98,6 @@ public:
 
 private:
     Output* output;
-    miral::WindowManagerTools tools;
     uint32_t id_;
     std::optional<int> num_;
     std::optional<std::string> name_;

--- a/src/workspace_manager.h
+++ b/src/workspace_manager.h
@@ -32,6 +32,7 @@ namespace miracle
 
 class Output;
 class Config;
+class CompositorState;
 
 /// A central place to request operations on workspaces.
 /// [Workspace] objects are held in their [Output] containers.
@@ -39,11 +40,9 @@ class WorkspaceManager
 {
 public:
     WorkspaceManager(
-        miral::WindowManagerTools const& tools,
         WorkspaceObserverRegistrar& registry,
         std::shared_ptr<Config> const& config,
-        std::function<Output const*()> const& get_active,
-        std::function<std::vector<std::shared_ptr<Output>>()> const& get_outputs);
+        CompositorState const& state);
     WorkspaceManager(WorkspaceManager const&) = delete;
     virtual ~WorkspaceManager() = default;
 
@@ -103,11 +102,9 @@ private:
     Workspace* workspace(int num) const;
     Workspace* workspace(std::string const& name) const;
 
-    miral::WindowManagerTools tools_;
     WorkspaceObserverRegistrar& registry;
     std::shared_ptr<Config> config;
-    std::function<Output const*()> get_active;
-    std::function<std::vector<std::shared_ptr<Output>>()> get_outputs;
+    CompositorState const& state;
     std::optional<Workspace*> last_selected;
 };
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,8 @@ add_executable(miracle-wm-tests
     stub_configuration.h
     stub_session.h
     stub_surface.h
-    stub_window_controller.h)
+    stub_window_controller.h
+    stub_container.h)
 
 target_include_directories(miracle-wm-tests PUBLIC SYSTEM
     ${GTEST_INCLUDE_DIRS}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(miracle-wm-tests
     test_ipc_command_parser.cpp
     test_animator.cpp
     test_feature_flags.cpp
+    test_command_controller.cpp
     stub_configuration.h
     stub_session.h
     stub_surface.h

--- a/tests/stub_container.h
+++ b/tests/stub_container.h
@@ -24,275 +24,254 @@ namespace miracle
 {
 namespace test
 {
-class StubContainer : public Container
-{
-public:
-    ContainerType get_type() const override
+    class StubContainer : public Container
     {
-        return ContainerType::parent;
-    }
-
-    void show() override
-    {
-
-    }
-
-    void hide() override
-    {
-
-    }
-
-    void commit_changes() override
-    {
-
-    }
-
-    mir::geometry::Rectangle get_logical_area() const override
-    {
-        return {};
-    }
-
-    void set_logical_area(mir::geometry::Rectangle const &rectangle) override
-    {
-
-    }
-
-    mir::geometry::Rectangle get_visible_area() const override
-    {
-        return {};
-    }
-
-    void constrain() override
-    {
-
-    }
-
-    std::weak_ptr<ParentContainer> get_parent() const override
-    {
-        return {};
-    }
-
-    void set_parent(std::shared_ptr<ParentContainer> const &ptr) override
-    {
-
-    }
-
-    size_t get_min_height() const override
-    {
-        return 0;
-    }
-
-    size_t get_min_width() const override
-    {
-        return 0;
-    }
-
-    void handle_ready() override
-    {
-
-    }
-
-    void handle_modify(miral::WindowSpecification const &specification) override
-    {
-
-    }
-
-    void handle_request_move(MirInputEvent const *input_event) override
-    {
-
-    }
-
-    void handle_request_resize(MirInputEvent const *input_event, MirResizeEdge edge) override
-    {
-
-    }
-
-    void handle_raise() override
-    {
-
-    }
-
-    bool resize(Direction direction, int pixels) override
-    {
-        return false;
-    }
-
-    bool set_size(std::optional<int> const &width, std::optional<int> const &height) override
-    {
-        return false;
-    }
-
-    bool toggle_fullscreen() override
-    {
-        return false;
-    }
-
-    void request_horizontal_layout() override
-    {
-
-    }
-
-    void request_vertical_layout() override
-    {
-
-    }
-
-    void toggle_layout(bool cycle_thru_all) override
-    {
-
-    }
-
-    void on_open() override
-    {
-
-    }
-
-    void on_focus_gained() override
-    {
-
-    }
-
-    void on_focus_lost() override
-    {
-
-    }
-
-    void on_move_to(mir::geometry::Point const &top_left) override
-    {
-
-    }
-
-    mir::geometry::Rectangle confirm_placement(MirWindowState state, mir::geometry::Rectangle const &rectangle) override
-    {
-        return {};
-    }
-
-    Workspace *get_workspace() const override
-    {
-        return nullptr;
-    }
-
-    Output *get_output() const override
-    {
-        return nullptr;
-    }
-
-    glm::mat4 get_transform() const override
-    {
-        return glm::mat4(1.f);
-    }
-
-    void set_transform(glm::mat4 transform) override
-    {
-
-    }
-
-    glm::mat4 get_workspace_transform() const override
-    {
-        return Container::get_workspace_transform();
-    }
-
-    glm::mat4 get_output_transform() const override
-    {
-        return Container::get_output_transform();
-    }
-
-    uint32_t animation_handle() const override
-    {
-        return 0;
-    }
-
-    void animation_handle(uint32_t uint32) override
-    {
-
-    }
-
-    bool is_focused() const override
-    {
-        return false;
-    }
-
-    bool is_fullscreen() const override
-    {
-        return false;
-    }
-
-    std::optional<miral::Window> window() const override
-    {
-        return std::nullopt;
-    }
-
-    bool select_next(Direction direction) override
-    {
-        return false;
-    }
-
-    bool pinned() const override
-    {
-        return false;
-    }
-
-    bool pinned(bool b) override
-    {
-        return false;
-    }
-
-    bool move(Direction direction) override
-    {
-        return false;
-    }
-
-    bool move_by(Direction direction, int pixels) override
-    {
-        return false;
-    }
-
-    bool move_to(int x, int y) override
-    {
-        return false;
-    }
-
-    bool toggle_tabbing() override
-    {
-        return false;
-    }
-
-    bool toggle_stacking() override
-    {
-        return false;
-    }
-
-    bool drag_start() override
-    {
-        return false;
-    }
-
-    void drag(int x, int y) override
-    {
-
-    }
-
-    bool drag_stop() override
-    {
-        return false;
-    }
-
-    bool set_layout(LayoutScheme scheme) override
-    {
-        return false;
-    }
-
-    LayoutScheme get_layout() const override
-    {
-        return LayoutScheme::horizontal;
-    }
-
-    nlohmann::json to_json() const override
-    {
-        return {};
-    }
-};
+    public:
+        ContainerType get_type() const override
+        {
+            return ContainerType::parent;
+        }
+
+        void show() override
+        {
+        }
+
+        void hide() override
+        {
+        }
+
+        void commit_changes() override
+        {
+        }
+
+        mir::geometry::Rectangle get_logical_area() const override
+        {
+            return {};
+        }
+
+        void set_logical_area(mir::geometry::Rectangle const& rectangle) override
+        {
+        }
+
+        mir::geometry::Rectangle get_visible_area() const override
+        {
+            return {};
+        }
+
+        void constrain() override
+        {
+        }
+
+        std::weak_ptr<ParentContainer> get_parent() const override
+        {
+            return {};
+        }
+
+        void set_parent(std::shared_ptr<ParentContainer> const& ptr) override
+        {
+        }
+
+        size_t get_min_height() const override
+        {
+            return 0;
+        }
+
+        size_t get_min_width() const override
+        {
+            return 0;
+        }
+
+        void handle_ready() override
+        {
+        }
+
+        void handle_modify(miral::WindowSpecification const& specification) override
+        {
+        }
+
+        void handle_request_move(MirInputEvent const* input_event) override
+        {
+        }
+
+        void handle_request_resize(MirInputEvent const* input_event, MirResizeEdge edge) override
+        {
+        }
+
+        void handle_raise() override
+        {
+        }
+
+        bool resize(Direction direction, int pixels) override
+        {
+            return false;
+        }
+
+        bool set_size(std::optional<int> const& width, std::optional<int> const& height) override
+        {
+            return false;
+        }
+
+        bool toggle_fullscreen() override
+        {
+            return false;
+        }
+
+        void request_horizontal_layout() override
+        {
+        }
+
+        void request_vertical_layout() override
+        {
+        }
+
+        void toggle_layout(bool cycle_thru_all) override
+        {
+        }
+
+        void on_open() override
+        {
+        }
+
+        void on_focus_gained() override
+        {
+        }
+
+        void on_focus_lost() override
+        {
+        }
+
+        void on_move_to(mir::geometry::Point const& top_left) override
+        {
+        }
+
+        mir::geometry::Rectangle confirm_placement(MirWindowState state, mir::geometry::Rectangle const& rectangle) override
+        {
+            return {};
+        }
+
+        Workspace* get_workspace() const override
+        {
+            return nullptr;
+        }
+
+        Output* get_output() const override
+        {
+            return nullptr;
+        }
+
+        glm::mat4 get_transform() const override
+        {
+            return glm::mat4(1.f);
+        }
+
+        void set_transform(glm::mat4 transform) override
+        {
+        }
+
+        glm::mat4 get_workspace_transform() const override
+        {
+            return Container::get_workspace_transform();
+        }
+
+        glm::mat4 get_output_transform() const override
+        {
+            return Container::get_output_transform();
+        }
+
+        uint32_t animation_handle() const override
+        {
+            return 0;
+        }
+
+        void animation_handle(uint32_t uint32) override
+        {
+        }
+
+        bool is_focused() const override
+        {
+            return false;
+        }
+
+        bool is_fullscreen() const override
+        {
+            return false;
+        }
+
+        std::optional<miral::Window> window() const override
+        {
+            return std::nullopt;
+        }
+
+        bool select_next(Direction direction) override
+        {
+            return false;
+        }
+
+        bool pinned() const override
+        {
+            return false;
+        }
+
+        bool pinned(bool b) override
+        {
+            return false;
+        }
+
+        bool move(Direction direction) override
+        {
+            return false;
+        }
+
+        bool move_by(Direction direction, int pixels) override
+        {
+            return false;
+        }
+
+        bool move_to(int x, int y) override
+        {
+            return false;
+        }
+
+        bool toggle_tabbing() override
+        {
+            return false;
+        }
+
+        bool toggle_stacking() override
+        {
+            return false;
+        }
+
+        bool drag_start() override
+        {
+            return false;
+        }
+
+        void drag(int x, int y) override
+        {
+        }
+
+        bool drag_stop() override
+        {
+            return false;
+        }
+
+        bool set_layout(LayoutScheme scheme) override
+        {
+            return false;
+        }
+
+        LayoutScheme get_layout() const override
+        {
+            return LayoutScheme::horizontal;
+        }
+
+        nlohmann::json to_json() const override
+        {
+            return {};
+        }
+    };
 }
 }
 
-#endif //MIRACLE_WM_STUB_CONTAINER_H
+#endif // MIRACLE_WM_STUB_CONTAINER_H

--- a/tests/stub_container.h
+++ b/tests/stub_container.h
@@ -1,0 +1,298 @@
+/**
+Copyright (C) 2024  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef MIRACLE_WM_STUB_CONTAINER_H
+#define MIRACLE_WM_STUB_CONTAINER_H
+
+#include "container.h"
+
+namespace miracle
+{
+namespace test
+{
+class StubContainer : public Container
+{
+public:
+    ContainerType get_type() const override
+    {
+        return ContainerType::parent;
+    }
+
+    void show() override
+    {
+
+    }
+
+    void hide() override
+    {
+
+    }
+
+    void commit_changes() override
+    {
+
+    }
+
+    mir::geometry::Rectangle get_logical_area() const override
+    {
+        return {};
+    }
+
+    void set_logical_area(mir::geometry::Rectangle const &rectangle) override
+    {
+
+    }
+
+    mir::geometry::Rectangle get_visible_area() const override
+    {
+        return {};
+    }
+
+    void constrain() override
+    {
+
+    }
+
+    std::weak_ptr<ParentContainer> get_parent() const override
+    {
+        return {};
+    }
+
+    void set_parent(std::shared_ptr<ParentContainer> const &ptr) override
+    {
+
+    }
+
+    size_t get_min_height() const override
+    {
+        return 0;
+    }
+
+    size_t get_min_width() const override
+    {
+        return 0;
+    }
+
+    void handle_ready() override
+    {
+
+    }
+
+    void handle_modify(miral::WindowSpecification const &specification) override
+    {
+
+    }
+
+    void handle_request_move(MirInputEvent const *input_event) override
+    {
+
+    }
+
+    void handle_request_resize(MirInputEvent const *input_event, MirResizeEdge edge) override
+    {
+
+    }
+
+    void handle_raise() override
+    {
+
+    }
+
+    bool resize(Direction direction, int pixels) override
+    {
+        return false;
+    }
+
+    bool set_size(std::optional<int> const &width, std::optional<int> const &height) override
+    {
+        return false;
+    }
+
+    bool toggle_fullscreen() override
+    {
+        return false;
+    }
+
+    void request_horizontal_layout() override
+    {
+
+    }
+
+    void request_vertical_layout() override
+    {
+
+    }
+
+    void toggle_layout(bool cycle_thru_all) override
+    {
+
+    }
+
+    void on_open() override
+    {
+
+    }
+
+    void on_focus_gained() override
+    {
+
+    }
+
+    void on_focus_lost() override
+    {
+
+    }
+
+    void on_move_to(mir::geometry::Point const &top_left) override
+    {
+
+    }
+
+    mir::geometry::Rectangle confirm_placement(MirWindowState state, mir::geometry::Rectangle const &rectangle) override
+    {
+        return {};
+    }
+
+    Workspace *get_workspace() const override
+    {
+        return nullptr;
+    }
+
+    Output *get_output() const override
+    {
+        return nullptr;
+    }
+
+    glm::mat4 get_transform() const override
+    {
+        return glm::mat4(1.f);
+    }
+
+    void set_transform(glm::mat4 transform) override
+    {
+
+    }
+
+    glm::mat4 get_workspace_transform() const override
+    {
+        return Container::get_workspace_transform();
+    }
+
+    glm::mat4 get_output_transform() const override
+    {
+        return Container::get_output_transform();
+    }
+
+    uint32_t animation_handle() const override
+    {
+        return 0;
+    }
+
+    void animation_handle(uint32_t uint32) override
+    {
+
+    }
+
+    bool is_focused() const override
+    {
+        return false;
+    }
+
+    bool is_fullscreen() const override
+    {
+        return false;
+    }
+
+    std::optional<miral::Window> window() const override
+    {
+        return std::nullopt;
+    }
+
+    bool select_next(Direction direction) override
+    {
+        return false;
+    }
+
+    bool pinned() const override
+    {
+        return false;
+    }
+
+    bool pinned(bool b) override
+    {
+        return false;
+    }
+
+    bool move(Direction direction) override
+    {
+        return false;
+    }
+
+    bool move_by(Direction direction, int pixels) override
+    {
+        return false;
+    }
+
+    bool move_to(int x, int y) override
+    {
+        return false;
+    }
+
+    bool toggle_tabbing() override
+    {
+        return false;
+    }
+
+    bool toggle_stacking() override
+    {
+        return false;
+    }
+
+    bool drag_start() override
+    {
+        return false;
+    }
+
+    void drag(int x, int y) override
+    {
+
+    }
+
+    bool drag_stop() override
+    {
+        return false;
+    }
+
+    bool set_layout(LayoutScheme scheme) override
+    {
+        return false;
+    }
+
+    LayoutScheme get_layout() const override
+    {
+        return LayoutScheme::horizontal;
+    }
+
+    nlohmann::json to_json() const override
+    {
+        return {};
+    }
+};
+}
+}
+
+#endif //MIRACLE_WM_STUB_CONTAINER_H

--- a/tests/stub_window_controller.h
+++ b/tests/stub_window_controller.h
@@ -133,6 +133,11 @@ public:
         throw std::runtime_error("get_window_data should resolve");
     }
 
+    miral::Window window_at(float x, float y)
+    {
+        return miral::Window();
+    }
+
 private:
     std::vector<StubWindowData>& pairs;
     miral::WindowInfo stub_win_info;

--- a/tests/test_command_controller.cpp
+++ b/tests/test_command_controller.cpp
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using namespace miracle;
 
-class StubCommandControllerInteface : public CommandControllerInterface
+class StubCommandControllerInterface : public CommandControllerInterface
 {
 public:
     void quit() override { }
@@ -50,7 +50,7 @@ public:
             window_controller,
             workspace_manager,
             mode_observer_registrar,
-            std::make_unique<StubCommandControllerInteface>(),
+            std::make_unique<StubCommandControllerInterface>(),
             scratchpad)
     {
     }

--- a/tests/test_command_controller.cpp
+++ b/tests/test_command_controller.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "scratchpad.h"
 #include "stub_configuration.h"
 #include "stub_window_controller.h"
+#include "stub_container.h"
 #include "workspace_manager.h"
 #include "workspace_observer.h"
 
@@ -66,8 +67,3 @@ public:
     Scratchpad scratchpad;
     CommandController command_controller;
 };
-
-TEST_F(CommandControllerTest, x)
-{
-
-}

--- a/tests/test_command_controller.cpp
+++ b/tests/test_command_controller.cpp
@@ -1,0 +1,73 @@
+/**
+Copyright (C) 2024  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#include "command_controller.h"
+#include "mode_observer.h"
+#include "scratchpad.h"
+#include "stub_configuration.h"
+#include "stub_window_controller.h"
+#include "workspace_manager.h"
+#include "workspace_observer.h"
+
+#include <gtest/gtest.h>
+#include <miral/runner.h>
+
+using namespace miracle;
+
+class StubCommandControllerInteface : public CommandControllerInterface
+{
+public:
+    void quit() override {}
+};
+
+class CommandControllerTest : public testing::Test
+{
+public:
+    CommandControllerTest()
+    : config(std::make_shared<test::StubConfiguration>()),
+      window_controller(data),
+      workspace_manager(workspace_registry, config, state),
+      scratchpad(window_controller, state),
+      command_controller(
+        config,
+        mutex,
+        state,
+        window_controller,
+        workspace_manager,
+        mode_observer_registrar,
+        std::make_unique<StubCommandControllerInteface>(),
+        scratchpad
+      )
+    {
+    }
+
+    std::shared_ptr<Config> config;
+    std::recursive_mutex mutex;
+    CompositorState state;
+    std::vector<StubWindowData> data;
+    StubWindowController window_controller;
+    WorkspaceObserverRegistrar workspace_registry;
+    WorkspaceManager workspace_manager;
+    ModeObserverRegistrar mode_observer_registrar;
+    Scratchpad scratchpad;
+    CommandController command_controller;
+};
+
+TEST_F(CommandControllerTest, x)
+{
+
+}

--- a/tests/test_command_controller.cpp
+++ b/tests/test_command_controller.cpp
@@ -19,8 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "mode_observer.h"
 #include "scratchpad.h"
 #include "stub_configuration.h"
-#include "stub_window_controller.h"
 #include "stub_container.h"
+#include "stub_window_controller.h"
 #include "workspace_manager.h"
 #include "workspace_observer.h"
 
@@ -32,27 +32,26 @@ using namespace miracle;
 class StubCommandControllerInteface : public CommandControllerInterface
 {
 public:
-    void quit() override {}
+    void quit() override { }
 };
 
 class CommandControllerTest : public testing::Test
 {
 public:
-    CommandControllerTest()
-    : config(std::make_shared<test::StubConfiguration>()),
-      window_controller(data),
-      workspace_manager(workspace_registry, config, state),
-      scratchpad(window_controller, state),
-      command_controller(
-        config,
-        mutex,
-        state,
-        window_controller,
-        workspace_manager,
-        mode_observer_registrar,
-        std::make_unique<StubCommandControllerInteface>(),
-        scratchpad
-      )
+    CommandControllerTest() :
+        config(std::make_shared<test::StubConfiguration>()),
+        window_controller(data),
+        workspace_manager(workspace_registry, config, state),
+        scratchpad(window_controller, state),
+        command_controller(
+            config,
+            mutex,
+            state,
+            window_controller,
+            workspace_manager,
+            mode_observer_registrar,
+            std::make_unique<StubCommandControllerInteface>(),
+            scratchpad)
     {
     }
 


### PR DESCRIPTION
## What's new?
- Remove more usages of WindowManagerTools to decouple from miral
- Remove unused getter methods on Policy
- Create the `StubContainer`
- Create `CommandControllerTest` with no tests quite yet