### PR TITLE
feature: implement the core drag and drop functionality

### DIFF
--- a/src/command_controller.cpp
+++ b/src/command_controller.cpp
@@ -1034,7 +1034,8 @@ void CommandController::drag_to(
 
     // TODO: Assuming that these containers are in the same tiling tree for now
     auto to_leaf = Container::as_leaf(to);
-    to_leaf->get_tree()->move_to(*dragging, *to);
+    auto tree = to_leaf->get_tree();
+    tree->move_to(*dragging, *to);
 }
 
 nlohmann::json CommandController::to_json() const

--- a/src/command_controller.cpp
+++ b/src/command_controller.cpp
@@ -1034,7 +1034,7 @@ void CommandController::drag_to(
 
     // TODO: Assuming that these containers are in the same tiling tree for now
     auto to_leaf = Container::as_leaf(to);
-    auto tree = to_leaf->get_tree();
+    auto tree = to_leaf->tree();
     tree->move_to(*dragging, *to);
 }
 

--- a/src/command_controller.cpp
+++ b/src/command_controller.cpp
@@ -19,7 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "command_controller.h"
 #include "config.h"
-#include "leaf_container.h"
 #include "mode_observer.h"
 #include "parent_container.h"
 #include "scratchpad.h"
@@ -1032,9 +1031,7 @@ void CommandController::drag_to(
     if (!to->is_leaf() || !dragging->is_leaf())
         return;
 
-    // TODO: Assuming that these containers are in the same tiling tree for now
-    auto to_leaf = Container::as_leaf(to);
-    auto tree = to_leaf->tree();
+    auto tree = to->tree();
     tree->move_to(*dragging, *to);
 }
 

--- a/src/command_controller.h
+++ b/src/command_controller.h
@@ -115,6 +115,7 @@ public:
     bool reload_config();
     void set_mode(WindowManagerMode mode);
     void select_container(std::shared_ptr<Container> const&);
+    void drag_to(std::shared_ptr<Container> const& dragging, std::shared_ptr<Container> const& to);
     [[nodiscard]] nlohmann::json to_json() const;
     [[nodiscard]] nlohmann::json outputs_json() const;
     [[nodiscard]] nlohmann::json workspaces_json() const;

--- a/src/container.h
+++ b/src/container.h
@@ -42,6 +42,7 @@ class FloatingWindowContainer;
 class ContainerGroupContainer;
 class Workspace;
 class Output;
+class TilingWindowTree;
 
 enum class ContainerType
 {
@@ -104,6 +105,8 @@ public:
         = 0;
     virtual Workspace* get_workspace() const = 0;
     virtual Output* get_output() const = 0;
+    virtual TilingWindowTree* tree() const = 0;
+    virtual void tree(TilingWindowTree*) = 0;
     virtual glm::mat4 get_transform() const = 0;
     virtual void set_transform(glm::mat4 transform) = 0;
     virtual glm::mat4 get_workspace_transform() const;

--- a/src/container_group_container.h
+++ b/src/container_group_container.h
@@ -92,6 +92,8 @@ public:
     void drag(int, int) override { }
     bool drag_stop() override { return false; }
     bool set_layout(LayoutScheme scheme) override { return false; }
+    void tree(TilingWindowTree*) override { }
+    TilingWindowTree* tree() const override { return nullptr; }
     LayoutScheme get_layout() const override { return LayoutScheme::none; }
     nlohmann::json to_json() const override { return {}; }
 

--- a/src/debug_helper.h
+++ b/src/debug_helper.h
@@ -54,12 +54,12 @@ std::string size_to_string(mir::optional_value<mir::geometry::Size> const& size)
     return ss.str();
 }
 
-void print_specification(std::string const& label, miral::WindowSpecification const& spec)
+void print_specification(std::string const& label, mir::geometry::Rectangle const& spec)
 {
     std::stringstream ss;
     ss << label << ": \n";
-    ss << "  top_left(): " << point_to_string(spec.top_left()) << "\n";
-    ss << "  size(): " << size_to_string(spec.size()) << "\n";
+    ss << "  top_left(): " << point_to_string(spec.top_left) << "\n";
+    ss << "  size(): " << size_to_string(spec.size) << "\n";
     mir::log_info(ss.str());
 }
 }

--- a/src/feature_flags.h
+++ b/src/feature_flags.h
@@ -19,6 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MIRACLE_WM_FEATURE_FLAGS_H
 
 #define MIRACLE_FEATURE_FLAG_MULTI_SELECT false
-#define MIRACLE_FEATURE_FLAG_DRAG_AND_DROP false
+#define MIRACLE_FEATURE_FLAG_DRAG_AND_DROP true
 
 #endif // MIRACLE_WM_FEATURE_FLAGS_H

--- a/src/feature_flags.h
+++ b/src/feature_flags.h
@@ -19,6 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MIRACLE_WM_FEATURE_FLAGS_H
 
 #define MIRACLE_FEATURE_FLAG_MULTI_SELECT false
-#define MIRACLE_FEATURE_FLAG_DRAG_AND_DROP true
+#define MIRACLE_FEATURE_FLAG_DRAG_AND_DROP false
 
 #endif // MIRACLE_WM_FEATURE_FLAGS_H

--- a/src/floating_tree_container.cpp
+++ b/src/floating_tree_container.cpp
@@ -52,7 +52,7 @@ FloatingTreeContainer::FloatingTreeContainer(
     WindowController& window_controller,
     CompositorState const& compositor_state,
     std::shared_ptr<Config> const& config) :
-    tree {
+    tree_ {
         std::make_unique<TilingWindowTree>(
             std::make_unique<FloatingTreeTilingWindowTreeInterface>(workspace),
             window_controller,
@@ -72,12 +72,12 @@ ContainerType FloatingTreeContainer::get_type() const
 
 void FloatingTreeContainer::show()
 {
-    tree->show();
+    tree_->show();
 }
 
 void FloatingTreeContainer::hide()
 {
-    tree->hide();
+    tree_->hide();
 }
 
 void FloatingTreeContainer::commit_changes()
@@ -86,12 +86,12 @@ void FloatingTreeContainer::commit_changes()
 
 mir::geometry::Rectangle FloatingTreeContainer::get_logical_area() const
 {
-    return tree->get_area();
+    return tree_->get_area();
 }
 
 void FloatingTreeContainer::set_logical_area(mir::geometry::Rectangle const& rectangle)
 {
-    tree->set_area(rectangle);
+    tree_->set_area(rectangle);
 }
 
 mir::geometry::Rectangle FloatingTreeContainer::get_visible_area() const
@@ -189,9 +189,9 @@ void FloatingTreeContainer::on_focus_lost()
 
 void FloatingTreeContainer::on_move_to(mir::geometry::Point const& top_left)
 {
-    auto area = tree->get_area();
+    auto area = tree_->get_area();
     area.top_left = top_left;
-    tree->set_area(area);
+    tree_->set_area(area);
 }
 
 mir::geometry::Rectangle
@@ -286,9 +286,9 @@ bool FloatingTreeContainer::move_by(Direction direction, int pixels)
 
 bool FloatingTreeContainer::move_to(int x, int y)
 {
-    auto area = tree->get_area();
+    auto area = tree_->get_area();
     area.top_left = geom::Point { x, y };
-    tree->set_area(area);
+    tree_->set_area(area);
     return true;
 }
 } // miracle

--- a/src/floating_tree_container.h
+++ b/src/floating_tree_container.h
@@ -37,7 +37,6 @@ public:
         WindowController&,
         CompositorState const&,
         std::shared_ptr<Config> const&);
-    [[nodiscard]] TilingWindowTree* get_tree() const { return tree.get(); }
 
     ContainerType get_type() const override;
     void show() override;
@@ -91,11 +90,13 @@ public:
     void drag(int, int) override { }
     bool drag_stop() override { return false; }
     bool set_layout(LayoutScheme) override { return false; }
+    void tree(TilingWindowTree*) override { }
+    TilingWindowTree* tree() const override { return tree_.get(); }
     LayoutScheme get_layout() const override { return LayoutScheme::none; }
     nlohmann::json to_json() const override { return {}; }
 
 private:
-    std::unique_ptr<TilingWindowTree> tree;
+    std::unique_ptr<TilingWindowTree> tree_;
     Workspace* workspace_;
 };
 

--- a/src/floating_window_container.h
+++ b/src/floating_window_container.h
@@ -99,6 +99,8 @@ public:
     bool set_layout(LayoutScheme scheme) override { return false; }
     LayoutScheme get_layout() const override { return LayoutScheme::none; }
     std::weak_ptr<ParentContainer> get_parent() const override;
+    void tree(TilingWindowTree*) override { }
+    TilingWindowTree* tree() const override { return nullptr; }
     void set_scratchpad_state(ScratchpadState state);
     nlohmann::json to_json() const override;
 

--- a/src/leaf_container.cpp
+++ b/src/leaf_container.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "compositor_state.h"
 #include "config.h"
 #include "container_group_container.h"
+#include "debug_helper.h"
 #include "output.h"
 #include "parent_container.h"
 #include "tiling_window_tree.h"

--- a/src/leaf_container.cpp
+++ b/src/leaf_container.cpp
@@ -21,7 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "compositor_state.h"
 #include "config.h"
 #include "container_group_container.h"
-#include "debug_helper.h"
 #include "output.h"
 #include "parent_container.h"
 #include "tiling_window_tree.h"
@@ -46,7 +45,7 @@ LeafContainer::LeafContainer(
     window_controller { node_interface },
     logical_area { std::move(area) },
     config { config },
-    tree { tree },
+    tree_ { tree },
     parent { parent },
     state { state }
 {
@@ -143,7 +142,7 @@ size_t LeafContainer::get_min_height() const
 
 void LeafContainer::handle_ready()
 {
-    tree->handle_container_ready(*this);
+    tree_->handle_container_ready(*this);
     get_workspace()->handle_ready_hack(*this);
     if (window_controller.is_fullscreen(window_))
         toggle_fullscreen();
@@ -163,9 +162,9 @@ void LeafContainer::handle_modify(miral::WindowSpecification const& modification
         commit_changes();
 
         if (window_helpers::is_window_fullscreen(mods.state().value()))
-            tree->advise_fullscreen_container(*this);
+            tree_->advise_fullscreen_container(*this);
         else if (mods.state().value() == mir_window_state_restored)
-            tree->advise_restored_container(*this);
+            tree_->advise_restored_container(*this);
     }
 
     window_controller.modify(window_, mods);
@@ -178,12 +177,12 @@ void LeafContainer::handle_raise()
 
 bool LeafContainer::resize(miracle::Direction direction, int pixels)
 {
-    return tree->resize_container(direction, pixels, *this);
+    return tree_->resize_container(direction, pixels, *this);
 }
 
 bool LeafContainer::set_size(std::optional<int> const& width, std::optional<int> const& height)
 {
-    return tree->set_size(width, height, *this);
+    return tree_->set_size(width, height, *this);
 }
 
 void LeafContainer::show()
@@ -210,14 +209,14 @@ bool LeafContainer::toggle_fullscreen()
         next_state = mir_window_state_fullscreen;
 
     commit_changes();
-    return tree->toggle_fullscreen(*this);
+    return tree_->toggle_fullscreen(*this);
 }
 
 mir::geometry::Rectangle LeafContainer::confirm_placement(
     MirWindowState state, mir::geometry::Rectangle const& placement)
 {
     auto new_placement = placement;
-    tree->confirm_placement_on_display(*this, state, new_placement);
+    tree_->confirm_placement_on_display(*this, state, new_placement);
     return new_placement;
 }
 
@@ -228,7 +227,7 @@ void LeafContainer::on_open()
 
 void LeafContainer::on_focus_gained()
 {
-    tree->advise_focus_gained(*this);
+    tree_->advise_focus_gained(*this);
 }
 
 void LeafContainer::on_focus_lost()
@@ -273,27 +272,32 @@ void LeafContainer::handle_request_resize(MirInputEvent const* input_event, MirR
 
 void LeafContainer::request_horizontal_layout()
 {
-    tree->request_horizontal_layout(*this);
+    tree_->request_horizontal_layout(*this);
 }
 
 void LeafContainer::request_vertical_layout()
 {
-    tree->request_vertical_layout(*this);
+    tree_->request_vertical_layout(*this);
 }
 
 void LeafContainer::toggle_layout(bool cycle_thru_all)
 {
-    tree->toggle_layout(*this, cycle_thru_all);
+    tree_->toggle_layout(*this, cycle_thru_all);
 }
 
-void LeafContainer::set_tree(TilingWindowTree* tree_)
+TilingWindowTree* LeafContainer::tree() const
 {
-    tree = tree_;
+    return tree_;
+}
+
+void LeafContainer::tree(TilingWindowTree* in)
+{
+    tree_ = in;
 }
 
 Workspace* LeafContainer::get_workspace() const
 {
-    return tree->get_workspace();
+    return tree_->get_workspace();
 }
 
 Output* LeafContainer::get_output() const
@@ -344,7 +348,7 @@ ContainerType LeafContainer::get_type() const
 
 bool LeafContainer::select_next(miracle::Direction direction)
 {
-    return tree->select_next(direction, *this);
+    return tree_->select_next(direction, *this);
 }
 
 bool LeafContainer::pinned(bool)
@@ -359,7 +363,7 @@ bool LeafContainer::pinned() const
 
 bool LeafContainer::move(miracle::Direction direction)
 {
-    return tree->move_container(direction, *this);
+    return tree_->move_container(direction, *this);
 }
 
 bool LeafContainer::move_by(Direction, int)
@@ -377,9 +381,9 @@ bool LeafContainer::toggle_tabbing()
     if (auto sh_parent = parent.lock())
     {
         if (sh_parent->get_direction() == LayoutScheme::tabbing)
-            tree->request_horizontal_layout(*this);
+            tree_->request_horizontal_layout(*this);
         else
-            tree->request_tabbing_layout(*this);
+            tree_->request_tabbing_layout(*this);
     }
     return true;
 }
@@ -389,9 +393,9 @@ bool LeafContainer::toggle_stacking()
     if (auto sh_parent = parent.lock())
     {
         if (sh_parent->get_direction() == LayoutScheme::stacking)
-            tree->request_horizontal_layout(*this);
+            tree_->request_horizontal_layout(*this);
         else
-            tree->request_stacking_layout(*this);
+            tree_->request_stacking_layout(*this);
     }
     return true;
 }
@@ -431,7 +435,7 @@ bool LeafContainer::drag_stop()
 
 bool LeafContainer::set_layout(LayoutScheme scheme)
 {
-    tree->request_layout(*this, scheme);
+    tree_->request_layout(*this, scheme);
     return true;
 }
 

--- a/src/leaf_container.h
+++ b/src/leaf_container.h
@@ -74,9 +74,8 @@ public:
     void request_horizontal_layout() override;
     void request_vertical_layout() override;
     void toggle_layout(bool cycle_thru_all) override;
-    void set_tree(TilingWindowTree* tree);
-
-    [[nodiscard]] TilingWindowTree* get_tree() const { return tree; }
+    [[nodiscard]] TilingWindowTree* tree() const override;
+    void tree(TilingWindowTree* tree) override;
     [[nodiscard]] std::optional<miral::Window> window() const override { return window_; }
     void commit_changes() override;
     void show() override;
@@ -109,7 +108,7 @@ private:
     geom::Rectangle logical_area;
     std::optional<geom::Rectangle> next_logical_area;
     std::shared_ptr<Config> config;
-    TilingWindowTree* tree;
+    TilingWindowTree* tree_;
     miral::Window window_;
     std::weak_ptr<ParentContainer> parent;
     CompositorState const& state;

--- a/src/parent_container.cpp
+++ b/src/parent_container.cpp
@@ -94,7 +94,7 @@ ParentContainer::ParentContainer(
     CompositorState const& state) :
     node_interface { node_interface },
     logical_area { std::move(area) },
-    tree { tree },
+    tree_ { tree },
     config { config },
     parent { parent },
     state { state },
@@ -217,7 +217,7 @@ std::shared_ptr<LeafContainer> ParentContainer::create_space_for_window(int pend
         node_interface,
         create_space(pending_index),
         config,
-        tree,
+        tree_,
         as_parent(shared_from_this()),
         state);
     sub_nodes.insert(sub_nodes.begin() + pending_index, pending_node);
@@ -263,7 +263,7 @@ std::shared_ptr<ParentContainer> ParentContainer::convert_to_parent(std::shared_
         node_interface,
         container->get_logical_area(),
         config,
-        tree,
+        tree_,
         Container::as_parent(shared_from_this()),
         state);
     new_parent_node->sub_nodes.push_back(container);
@@ -634,9 +634,14 @@ void ParentContainer::toggle_layout(bool cycle_thru_all)
     relayout();
 }
 
-void ParentContainer::set_tree(TilingWindowTree* tree_)
+TilingWindowTree* ParentContainer::tree() const
 {
-    tree = tree_;
+    return tree_;
+}
+
+void ParentContainer::tree(TilingWindowTree* in)
+{
+    tree_ = in;
 }
 
 void ParentContainer::on_focus_gained()
@@ -688,12 +693,12 @@ void ParentContainer::on_open()
 
 Workspace* ParentContainer::get_workspace() const
 {
-    return tree->get_workspace();
+    return tree_->get_workspace();
 }
 
 Output* ParentContainer::get_output() const
 {
-    return tree->get_workspace()->get_output();
+    return tree_->get_workspace()->get_output();
 }
 
 glm::mat4 ParentContainer::get_transform() const

--- a/src/parent_container.h
+++ b/src/parent_container.h
@@ -79,7 +79,8 @@ public:
     void request_horizontal_layout() override;
     void request_vertical_layout() override;
     void toggle_layout(bool cycle_thru_all) override;
-    void set_tree(TilingWindowTree*);
+    TilingWindowTree* tree() const override;
+    void tree(TilingWindowTree*) override;
     void on_focus_gained() override;
     void on_focus_lost() override;
     void on_move_to(mir::geometry::Point const& top_left) override;
@@ -119,7 +120,7 @@ public:
 private:
     WindowController& node_interface;
     geom::Rectangle logical_area;
-    TilingWindowTree* tree;
+    TilingWindowTree* tree_;
     std::shared_ptr<Config> config;
     std::weak_ptr<ParentContainer> parent;
     CompositorState const& state;

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -292,7 +292,8 @@ bool Policy::handle_pointer_event(MirPointerEvent const* event)
         }
     }
 
-    handle_drag_and_drop_pointer_event(event);
+    if (handle_drag_and_drop_pointer_event(event))
+        return true;
 
     if (state.focused_output() && state.mode() != WindowManagerMode::resizing)
     {
@@ -357,10 +358,10 @@ bool Policy::handle_pointer_event(MirPointerEvent const* event)
     return false;
 }
 
-void Policy::handle_drag_and_drop_pointer_event(MirPointerEvent const* event)
+bool Policy::handle_drag_and_drop_pointer_event(MirPointerEvent const* event)
 {
     if (!MIRACLE_FEATURE_FLAG_DRAG_AND_DROP || !config->drag_and_drop().enabled)
-        return;
+        return false;
 
     auto x = static_cast<int>(miral::toolkit::mir_pointer_event_axis_value(event, MirPointerAxis::mir_pointer_axis_x));
     auto y = static_cast<int>(miral::toolkit::mir_pointer_event_axis_value(event, MirPointerAxis::mir_pointer_axis_y));
@@ -372,13 +373,13 @@ void Policy::handle_drag_and_drop_pointer_event(MirPointerEvent const* event)
             command_controller.set_mode(WindowManagerMode::normal);
             if (state.focused_container())
                 state.focused_container()->drag_stop();
-            return;
+            return true;
         }
 
         if (!state.focused_container())
         {
             mir::log_warning("handle_drag_and_drop_pointer_event: focused container no longer exists while dragging");
-            return;
+            return false;
         }
 
         // Drag the container to the new position
@@ -392,26 +393,27 @@ void Policy::handle_drag_and_drop_pointer_event(MirPointerEvent const* event)
         // a leaf container, as those would be the only one in the grid.
         std::shared_ptr<Container> intersected = state.focused_output()->intersect(event);
         if (!intersected)
-            return;
+            return true;
 
         command_controller.drag_to(state.focused_container(), intersected);
+        return true;
     }
     else if (action == mir_pointer_action_button_down)
     {
         if (state.mode() != WindowManagerMode::normal)
         {
             mir::log_warning("Must be in normal mode before we can start dragging");
-            return;
+            return false;
         }
 
         std::shared_ptr<Container> intersected = state.focused_output()->intersect(event);
         if (!intersected)
-            return;
+            return false;
 
         if (!intersected->drag_start())
         {
             mir::log_warning("Cannot drag container of type %d", (int)intersected->get_type());
-            return;
+            return false;
         }
 
         command_controller.select_container(intersected);
@@ -420,7 +422,10 @@ void Policy::handle_drag_and_drop_pointer_event(MirPointerEvent const* event)
             .cursor_start_y = y,
             .container_start_x = intersected->get_visible_area().top_left.x.as_int(),
             .container_start_y = intersected->get_visible_area().top_left.y.as_int() });
+        return true;
     }
+
+    return false;
 }
 
 auto Policy::place_new_window(

--- a/src/policy.h
+++ b/src/policy.h
@@ -103,7 +103,7 @@ public:
 private:
     class Self;
 
-    void handle_drag_and_drop_pointer_event(MirPointerEvent const* event);
+    bool handle_drag_and_drop_pointer_event(MirPointerEvent const* event);
 
     AutoRestartingLauncher& external_client_launcher;
     std::shared_ptr<Config> config;

--- a/src/shell_component_container.h
+++ b/src/shell_component_container.h
@@ -84,6 +84,8 @@ public:
     bool drag_stop() override { return false; }
     bool set_layout(LayoutScheme scheme) override { return false; }
     LayoutScheme get_layout() const override { return LayoutScheme::none; }
+    void tree(TilingWindowTree*) override { }
+    TilingWindowTree* tree() const override { return nullptr; }
     bool is_fullscreen() const override;
     nlohmann::json to_json() const override;
 

--- a/src/tiling_window_tree.cpp
+++ b/src/tiling_window_tree.cpp
@@ -168,31 +168,7 @@ bool TilingWindowTree::move_container(miracle::Direction direction, Container& c
     {
     case MoveResult::traversal_type_insert:
     {
-        auto target_node = traversal_result.node;
-        if (!target_node)
-        {
-            mir::log_warning("Unable to move active window: target_window not found");
-            return false;
-        }
-
-        auto target_parent = target_node->get_parent().lock();
-        if (!target_parent)
-        {
-            mir::log_warning("Unable to move active window: second_window has no second_parent");
-            return false;
-        }
-
-        auto active_parent = Container::as_parent(container.get_parent().lock());
-        if (active_parent == target_parent)
-        {
-            active_parent->swap_nodes(container.shared_from_this(), target_node);
-            active_parent->commit_changes();
-            break;
-        }
-
-        auto [first, second] = transfer_node(container.shared_from_this(), target_node);
-        first->commit_changes();
-        second->commit_changes();
+        move_to(container, *traversal_result.node);
         break;
     }
     case MoveResult::traversal_type_append:

--- a/src/tiling_window_tree.cpp
+++ b/src/tiling_window_tree.cpp
@@ -740,7 +740,7 @@ std::shared_ptr<Container> foreach_node_internal(
 }
 }
 
-void TilingWindowTree::foreach_node(std::function<void(std::shared_ptr<Container> const&)> const& f)
+void TilingWindowTree::foreach_node(std::function<void(std::shared_ptr<Container> const&)> const& f) const
 {
     foreach_node_internal(
         [&](auto const& node)
@@ -748,7 +748,7 @@ void TilingWindowTree::foreach_node(std::function<void(std::shared_ptr<Container
         root_lane);
 }
 
-bool TilingWindowTree::foreach_node_pred(std::function<bool(std::shared_ptr<Container> const&)> const& f)
+bool TilingWindowTree::foreach_node_pred(std::function<bool(std::shared_ptr<Container> const&)> const& f) const
 {
     return foreach_node_internal(
                [&](auto const& node)

--- a/src/tiling_window_tree.h
+++ b/src/tiling_window_tree.h
@@ -74,8 +74,7 @@ public:
         miral::WindowInfo const&,
         std::shared_ptr<ParentContainer> const& container);
 
-    void graft(std::shared_ptr<ParentContainer> const&, std::shared_ptr<ParentContainer> const& parent, int index = -1);
-    void graft(std::shared_ptr<LeafContainer> const&, std::shared_ptr<ParentContainer> const& parent, int index = -1);
+    void graft(std::shared_ptr<Container> const&, std::shared_ptr<ParentContainer> const& parent, int index = -1);
 
     /// Try to resize the current active window in the provided direction
     bool resize_container(Direction direction, int pixels, Container&);
@@ -85,7 +84,8 @@ public:
     /// Move the active window in the provided direction
     bool move_container(Direction direction, Container&);
 
-    /// Move [to_move] to the current position of [target].
+    /// Move [to_move] to the current position of [target]. [target] does
+    /// not have to be in the tree.
     bool move_to(Container& to_move, Container& target);
 
     /// Select the next window in the provided direction

--- a/src/tiling_window_tree.h
+++ b/src/tiling_window_tree.h
@@ -47,6 +47,12 @@ public:
     virtual Workspace* get_workspace() const = 0;
 };
 
+struct GraftRequest
+{
+    std::shared_ptr<Container> const& parent;
+    int index = -1;
+};
+
 class TilingWindowTree
 {
 public:
@@ -68,8 +74,8 @@ public:
         miral::WindowInfo const&,
         std::shared_ptr<ParentContainer> const& container);
 
-    void graft(std::shared_ptr<ParentContainer> const&);
-    void graft(std::shared_ptr<LeafContainer> const&);
+    void graft(std::shared_ptr<ParentContainer> const&, std::shared_ptr<ParentContainer> const& parent, int index = -1);
+    void graft(std::shared_ptr<LeafContainer> const&, std::shared_ptr<ParentContainer> const& parent, int index = -1);
 
     /// Try to resize the current active window in the provided direction
     bool resize_container(Direction direction, int pixels, Container&);
@@ -78,6 +84,9 @@ public:
 
     /// Move the active window in the provided direction
     bool move_container(Direction direction, Container&);
+
+    /// Move [to_move] to the current position of [target].
+    bool move_to(Container& to_move, Container& target);
 
     /// Select the next window in the provided direction
     bool select_next(Direction direction, Container&);

--- a/src/tiling_window_tree.h
+++ b/src/tiling_window_tree.h
@@ -47,12 +47,6 @@ public:
     virtual Workspace* get_workspace() const = 0;
 };
 
-struct GraftRequest
-{
-    std::shared_ptr<Container> const& parent;
-    int index = -1;
-};
-
 class TilingWindowTree
 {
 public:

--- a/src/tiling_window_tree.h
+++ b/src/tiling_window_tree.h
@@ -131,8 +131,8 @@ public:
         MirWindowState new_state,
         mir::geometry::Rectangle& new_placement);
 
-    void foreach_node(std::function<void(std::shared_ptr<Container> const&)> const&);
-    bool foreach_node_pred(std::function<bool(std::shared_ptr<Container> const&)> const&);
+    void foreach_node(std::function<void(std::shared_ptr<Container> const&)> const&) const;
+    bool foreach_node_pred(std::function<bool(std::shared_ptr<Container> const&)> const&) const;
 
     /// Shows the containers in this tree and returns a fullscreen container, if any
     std::shared_ptr<LeafContainer> show();

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -413,10 +413,10 @@ void Workspace::graft(std::shared_ptr<Container> const& container)
         break;
     }
     case ContainerType::parent:
-        tree->graft(Container::as_parent(container));
+        tree->graft(Container::as_parent(container), tree->get_root());
         break;
     case ContainerType::leaf:
-        tree->graft(Container::as_leaf(container));
+        tree->graft(Container::as_leaf(container), tree->get_root());
         break;
     default:
         mir::log_error("Workspace::graft: ungraftable container type: %d", (int)container->get_type());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ target_include_directories(miracle-wm-tests PUBLIC SYSTEM
 
 target_link_libraries(miracle-wm-tests
     GTest::gtest_main
+    GTest::GTest
     miracle-wm-implementation
     ${GTEST_LIBRARIES}
     ${MIRAL_LDFLAGS}

--- a/tests/test_tiling_window_tree.cpp
+++ b/tests/test_tiling_window_tree.cpp
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "compositor_state.h"
 #include "leaf_container.h"
+#include "parent_container.h"
 #include "stub_configuration.h"
 #include "stub_session.h"
 #include "stub_surface.h"
@@ -30,9 +31,12 @@ using namespace miracle;
 
 namespace
 {
-geom::Rectangle r {
+const float OUTPUT_WIDTH = 1280;
+const float OUTPUT_HEIGHT = 720;
+
+const geom::Rectangle TREE_BOUNDS {
     geom::Point(0, 0),
-    geom::Size(1280, 720)
+    geom::Size(OUTPUT_WIDTH, OUTPUT_HEIGHT)
 };
 }
 
@@ -50,7 +54,7 @@ public:
     }
 
 private:
-    std::vector<miral::Zone> zones = { r };
+    std::vector<miral::Zone> zones = { TREE_BOUNDS };
 };
 
 class TilingWindowTreeTest : public testing::Test
@@ -62,14 +66,14 @@ public:
             window_controller,
             state,
             std::make_shared<test::StubConfiguration>(),
-            r)
+            TREE_BOUNDS)
     {
     }
 
-    std::shared_ptr<LeafContainer> create_leaf()
+    std::shared_ptr<LeafContainer> create_leaf(std::shared_ptr<ParentContainer> parent = nullptr)
     {
         miral::WindowSpecification spec;
-        spec = tree.place_new_window(spec, nullptr);
+        spec = tree.place_new_window(spec, parent);
 
         auto session = std::make_shared<test::StubSession>();
         sessions.push_back(session);
@@ -79,7 +83,7 @@ public:
         miral::Window window(session, surface);
         miral::WindowInfo info(window, spec);
 
-        auto leaf = tree.confirm_window(info, nullptr);
+        auto leaf = tree.confirm_window(info, parent);
         pairs.push_back({ window, leaf });
 
         state.add(leaf);
@@ -99,7 +103,7 @@ public:
 TEST_F(TilingWindowTreeTest, can_add_single_window_without_border_and_gaps)
 {
     auto leaf = create_leaf();
-    ASSERT_EQ(leaf->get_logical_area().size, geom::Size(1280, 720));
+    ASSERT_EQ(leaf->get_logical_area().size, geom::Size(OUTPUT_WIDTH, OUTPUT_HEIGHT));
     ASSERT_EQ(leaf->get_logical_area().top_left, geom::Point(0, 0));
 }
 
@@ -108,11 +112,11 @@ TEST_F(TilingWindowTreeTest, can_add_two_windows_horizontally_without_border_and
     auto leaf1 = create_leaf();
     auto leaf2 = create_leaf();
 
-    ASSERT_EQ(leaf1->get_logical_area().size, geom::Size(1280 / 2.f, 720));
+    ASSERT_EQ(leaf1->get_logical_area().size, geom::Size(OUTPUT_WIDTH / 2.f, OUTPUT_HEIGHT));
     ASSERT_EQ(leaf1->get_logical_area().top_left, geom::Point(0, 0));
 
-    ASSERT_EQ(leaf2->get_logical_area().size, geom::Size(1280 / 2.f, 720));
-    ASSERT_EQ(leaf2->get_logical_area().top_left, geom::Point(1280 / 2.f, 0));
+    ASSERT_EQ(leaf2->get_logical_area().size, geom::Size(OUTPUT_WIDTH / 2.f, OUTPUT_HEIGHT));
+    ASSERT_EQ(leaf2->get_logical_area().top_left, geom::Point(OUTPUT_WIDTH / 2.f, 0));
 }
 
 TEST_F(TilingWindowTreeTest, can_add_two_windows_vertically_without_border_and_gaps)
@@ -122,11 +126,11 @@ TEST_F(TilingWindowTreeTest, can_add_two_windows_vertically_without_border_and_g
     tree.request_vertical_layout(*leaf1);
 
     auto leaf2 = create_leaf();
-    ASSERT_EQ(leaf1->get_logical_area().size, geom::Size(1280, 720 / 2.f));
+    ASSERT_EQ(leaf1->get_logical_area().size, geom::Size(OUTPUT_WIDTH, OUTPUT_HEIGHT / 2.f));
     ASSERT_EQ(leaf1->get_logical_area().top_left, geom::Point(0, 0));
 
-    ASSERT_EQ(leaf2->get_logical_area().size, geom::Size(1280, 720 / 2.f));
-    ASSERT_EQ(leaf2->get_logical_area().top_left, geom::Point(0, 720 / 2.f));
+    ASSERT_EQ(leaf2->get_logical_area().size, geom::Size(OUTPUT_WIDTH, OUTPUT_HEIGHT / 2.f));
+    ASSERT_EQ(leaf2->get_logical_area().top_left, geom::Point(0, OUTPUT_HEIGHT / 2.f));
 }
 
 TEST_F(TilingWindowTreeTest, can_add_three_windows_horizontally_without_border_and_gaps)
@@ -135,14 +139,14 @@ TEST_F(TilingWindowTreeTest, can_add_three_windows_horizontally_without_border_a
     auto leaf2 = create_leaf();
     auto leaf3 = create_leaf();
 
-    ASSERT_EQ(leaf1->get_logical_area().size, geom::Size(ceilf(1280 / 3.f), 720));
+    ASSERT_EQ(leaf1->get_logical_area().size, geom::Size(ceilf(OUTPUT_WIDTH / 3.f), OUTPUT_HEIGHT));
     ASSERT_EQ(leaf1->get_logical_area().top_left, geom::Point(0, 0));
 
-    ASSERT_EQ(leaf2->get_logical_area().size, geom::Size(ceilf(1280 / 3.f), 720));
-    ASSERT_EQ(leaf2->get_logical_area().top_left, geom::Point(ceilf(1280 / 3.f), 0));
+    ASSERT_EQ(leaf2->get_logical_area().size, geom::Size(ceilf(OUTPUT_WIDTH / 3.f), OUTPUT_HEIGHT));
+    ASSERT_EQ(leaf2->get_logical_area().top_left, geom::Point(ceilf(OUTPUT_WIDTH / 3.f), 0));
 
-    ASSERT_EQ(leaf3->get_logical_area().size, geom::Size(floorf(1280 / 3.f), 720));
-    ASSERT_EQ(leaf3->get_logical_area().top_left, geom::Point(floorf(1280 * (2.f / 3.f)) - 1, 0));
+    ASSERT_EQ(leaf3->get_logical_area().size, geom::Size(floorf(OUTPUT_WIDTH / 3.f), OUTPUT_HEIGHT));
+    ASSERT_EQ(leaf3->get_logical_area().top_left, geom::Point(floorf(OUTPUT_WIDTH * (2.f / 3.f)) - 1, 0));
 }
 
 TEST_F(TilingWindowTreeTest, can_start_dragging_a_leaf)
@@ -170,4 +174,31 @@ TEST_F(TilingWindowTreeTest, can_stop_dragging_a_leaf)
     auto const& data = window_controller.get_window_data(leaf1);
     ASSERT_EQ(data.rectangle.top_left.x.as_int(), 0);
     ASSERT_EQ(data.rectangle.top_left.y.as_int(), 0);
+}
+
+TEST_F(TilingWindowTreeTest, can_move_container_to_sibling)
+{
+    auto leaf1 = create_leaf();
+    auto leaf2 = create_leaf();
+
+    ASSERT_TRUE(tree.move_to(*leaf1, *leaf2));
+
+    // Assert that leaf2 is in the first position
+    ASSERT_EQ(leaf2->get_logical_area().top_left, geom::Point(0, 0));
+    ASSERT_EQ(leaf1->get_logical_area().top_left, geom::Point(OUTPUT_WIDTH / 2.f, 0));
+}
+
+TEST_F(TilingWindowTreeTest, can_move_container_to_different_parent)
+{
+    auto leaf1 = create_leaf();
+    auto leaf2 = create_leaf();
+    tree.request_vertical_layout(*leaf2);
+    auto leaf3 = create_leaf(leaf2->get_parent().lock());
+
+    ASSERT_TRUE(tree.move_to(*leaf1, *leaf3));
+
+    ASSERT_EQ(leaf2->get_logical_area().top_left, geom::Point(0, 0));
+    ASSERT_EQ(leaf3->get_logical_area().top_left, geom::Point(0, ceilf(OUTPUT_HEIGHT / 3.f)));
+    ASSERT_EQ(leaf1->get_logical_area().top_left, geom::Point(0, ceilf(OUTPUT_HEIGHT * (2.f / 3.f))));
+    ASSERT_EQ(tree.get_root()->num_nodes(), 3);
 }


### PR DESCRIPTION
## What's new?
- Added `CommandController::drag_to` which updates whenever a dragged container intersects any other container (only leaves for now!)
- Added a setter and getter for `Container::tree`
- Changed how `Output::intersect` works so that we only intersect with tiles and not windows themselves
- Added `TilingWindowTree::move_to`
- `TilingWindowTree::transfer_node` can now transfer a node to a different tree seamlessly
- `Policy::handle_drag_and_drop_pointer_event` consumes pointer events to avoid spreading them to other windows