### PR TITLE
feature: if a container is being dragged and focus is lost to it, then we end the drag and return to the normal mode

### DIFF
--- a/src/compositor_state.cpp
+++ b/src/compositor_state.cpp
@@ -15,7 +15,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
+#define MIR_LOG_COMPONENT "compositor_state"
+
 #include "compositor_state.h"
+#include <mir/log.h>
 
 using namespace miracle;
 
@@ -80,7 +83,8 @@ void CompositorState::unfocus_output(std::shared_ptr<Output> const& prev)
 
 void CompositorState::add(std::shared_ptr<Container> const& container)
 {
-    CompositorState::focus_order.push_back(container);
+    focus_order.push_back(container);
+    mir::log_debug("add: there are now %zu surfaces in the focus order", focus_order.size());
 }
 
 void CompositorState::remove(std::shared_ptr<Container> const& container)
@@ -89,6 +93,7 @@ void CompositorState::remove(std::shared_ptr<Container> const& container)
     {
         return !element.expired() && element.lock() == container;
     }));
+    mir::log_debug("remove: there are now %zu surfaces in the focus order", focus_order.size());
 }
 
 std::shared_ptr<Container> CompositorState::get_first_with_type(ContainerType type) const

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -551,6 +551,13 @@ void Policy::advise_focus_lost(const miral::WindowInfo& window_info)
         return;
     }
 
+    if (state.mode() == WindowManagerMode::dragging)
+    {
+        command_controller.set_mode(WindowManagerMode::normal);
+        if (state.focused_container())
+            state.focused_container()->drag_stop();
+    }
+
     state.unfocus_container(container);
     container->on_focus_lost();
 }
@@ -582,7 +589,10 @@ void Policy::advise_delete_window(const miral::WindowInfo& window_info)
 
     animator->remove_by_animation_handle(container->animation_handle());
     surface_tracker.remove(window_info.window());
-    state.unfocus_container(container);
+    if (container == state.focused_container())
+        state.unfocus_container(container);
+
+    state.remove(container);
 }
 
 void Policy::advise_move_to(miral::WindowInfo const& window_info, geom::Point top_left)


### PR DESCRIPTION
## What's new?
- `Policy::advise_focus_lost` will change the mode of the compositor to normal if we're in the middle of a drag
- `Policy::advise_delete_window` ensures that a window is removed from the container list when it is destroyed
- Added logging to `CompositorState` for the number of containers that it is managing