### PR TITLE
testing: implement tets for the DragAndDropService

### DIFF
--- a/src/drag_and_drop_service.cpp
+++ b/src/drag_and_drop_service.cpp
@@ -65,11 +65,11 @@ bool DragAndDropService::handle_pointer_event(CompositorState& state, float x, f
         current_y = y;
 
         // Drag the container to the new position
-        int const diff_x = x - cursor_start_x;
-        int const diff_y = y - cursor_start_y;
+        float const diff_x = x - cursor_start_x;
+        float const diff_y = y - cursor_start_y;
         state.focused_container()->drag(
-            container_start_x + diff_x,
-            container_start_y + diff_y);
+            static_cast<int>(container_start_x + diff_x),
+            static_cast<int>(container_start_y + diff_y));
 
         if (state.focused_output()->active()->get_tree()->is_empty())
         {
@@ -102,6 +102,9 @@ bool DragAndDropService::handle_pointer_event(CompositorState& state, float x, f
             return false;
         }
 
+        if (state.focused_output() == nullptr)
+            return false;
+
         std::shared_ptr<Container> intersected = state.focused_output()->intersect(x, y);
         if (!intersected)
             return false;
@@ -116,8 +119,8 @@ bool DragAndDropService::handle_pointer_event(CompositorState& state, float x, f
         command_controller.set_mode(WindowManagerMode::dragging);
         cursor_start_x = x;
         cursor_start_y = y;
-        container_start_x = intersected->get_visible_area().top_left.x.as_int();
-        container_start_y = intersected->get_visible_area().top_left.y.as_int();
+        container_start_x = static_cast<float>(intersected->get_visible_area().top_left.x.as_int());
+        container_start_y = static_cast<float>(intersected->get_visible_area().top_left.y.as_int());
         current_x = x;
         current_y = y;
         return true;

--- a/src/drag_and_drop_service.cpp
+++ b/src/drag_and_drop_service.cpp
@@ -35,15 +35,10 @@ DragAndDropService::DragAndDropService(CommandController& command_controller, st
 {
 }
 
-bool DragAndDropService::handle_pointer_event(CompositorState& state, const MirPointerEvent* event)
+bool DragAndDropService::handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, uint modifiers)
 {
     if (!MIRACLE_FEATURE_FLAG_DRAG_AND_DROP || !config->drag_and_drop().enabled)
         return false;
-
-    auto x = static_cast<int>(miral::toolkit::mir_pointer_event_axis_value(event, MirPointerAxis::mir_pointer_axis_x));
-    auto y = static_cast<int>(miral::toolkit::mir_pointer_event_axis_value(event, MirPointerAxis::mir_pointer_axis_y));
-    auto action = miral::toolkit::mir_pointer_event_action(event);
-    auto const modifiers = miral::toolkit::mir_pointer_event_modifiers(event) & MODIFIER_MASK;
 
     if (state.mode() == WindowManagerMode::dragging)
     {
@@ -84,7 +79,7 @@ bool DragAndDropService::handle_pointer_event(CompositorState& state, const MirP
 
         // Get the intersection and try to move ourselves there. We only care if we're intersecting
         // a leaf container, as those would be the only one in the grid.
-        std::shared_ptr<Container> intersected = state.focused_output()->intersect(event);
+        std::shared_ptr<Container> intersected = state.focused_output()->intersect(x, y);
         if (!intersected)
             return true;
 
@@ -107,7 +102,7 @@ bool DragAndDropService::handle_pointer_event(CompositorState& state, const MirP
             return false;
         }
 
-        std::shared_ptr<Container> intersected = state.focused_output()->intersect(event);
+        std::shared_ptr<Container> intersected = state.focused_output()->intersect(x, y);
         if (!intersected)
             return false;
 

--- a/src/drag_and_drop_service.h
+++ b/src/drag_and_drop_service.h
@@ -33,8 +33,8 @@ class TilingWindowTree;
 class DragAndDropService
 {
 public:
-    explicit DragAndDropService(CommandController& command_controller, std::shared_ptr<Config> const& config);
-    bool handle_pointer_event(CompositorState& state, const MirPointerEvent* event);
+    DragAndDropService(CommandController& command_controller, std::shared_ptr<Config> const& config);
+    bool handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, uint modifiers);
 
 private:
     CommandController& command_controller;

--- a/src/drag_and_drop_service.h
+++ b/src/drag_and_drop_service.h
@@ -40,12 +40,12 @@ private:
     CommandController& command_controller;
     std::shared_ptr<Config> config;
 
-    int cursor_start_x = 0;
-    int cursor_start_y = 0;
-    int container_start_x = 0;
-    int container_start_y = 0;
-    int current_x = 0;
-    int current_y = 0;
+    float cursor_start_x = 0;
+    float cursor_start_y = 0;
+    float container_start_x = 0;
+    float container_start_y = 0;
+    float current_x = 0;
+    float current_y = 0;
     std::weak_ptr<Container> last_intersected;
 
     void drag_to(

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -67,16 +67,13 @@ Workspace* Output::active() const
     return active_workspace.lock().get();
 }
 
-std::shared_ptr<Container> Output::intersect(const MirPointerEvent* event)
+std::shared_ptr<Container> Output::intersect(float x, float y)
 {
     if (active_workspace.expired())
     {
         mir::log_error("Output::handle_pointer_event: unexpectedly trying to handle a pointer event when we lack workspaces");
         return nullptr;
     }
-
-    auto x = miral::toolkit::mir_pointer_event_axis_value(event, MirPointerAxis::mir_pointer_axis_x);
-    auto y = miral::toolkit::mir_pointer_event_axis_value(event, MirPointerAxis::mir_pointer_axis_y);
 
     std::shared_ptr<Container> result = nullptr;
     for (auto const& workspace : workspaces)

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -38,7 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using namespace miracle;
 
-Output::Output(
+MiralWrapperOutput::MiralWrapperOutput(
     miral::Output const& output,
     WorkspaceManager& workspace_manager,
     geom::Rectangle const& area,
@@ -59,7 +59,7 @@ Output::Output(
 {
 }
 
-Workspace* Output::active() const
+Workspace* MiralWrapperOutput::active() const
 {
     if (active_workspace.expired())
         return nullptr;
@@ -67,11 +67,11 @@ Workspace* Output::active() const
     return active_workspace.lock().get();
 }
 
-std::shared_ptr<Container> Output::intersect(float x, float y)
+std::shared_ptr<Container> MiralWrapperOutput::intersect(float x, float y)
 {
     if (active_workspace.expired())
     {
-        mir::log_error("Output::handle_pointer_event: unexpectedly trying to handle a pointer event when we lack workspaces");
+        mir::log_error("MiralWrapperOutput::handle_pointer_event: unexpectedly trying to handle a pointer event when we lack workspaces");
         return nullptr;
     }
 
@@ -104,7 +104,7 @@ std::shared_ptr<Container> Output::intersect(float x, float y)
     return result;
 }
 
-AllocationHint Output::allocate_position(
+AllocationHint MiralWrapperOutput::allocate_position(
     miral::ApplicationInfo const& app_info,
     miral::WindowSpecification& requested_specification,
     AllocationHint hint)
@@ -118,13 +118,13 @@ AllocationHint Output::allocate_position(
     return active()->allocate_position(app_info, requested_specification, hint);
 }
 
-std::shared_ptr<Container> Output::create_container(
+std::shared_ptr<Container> MiralWrapperOutput::create_container(
     miral::WindowInfo const& window_info, AllocationHint const& hint) const
 {
     return active()->create_container(window_info, hint);
 }
 
-void Output::delete_container(std::shared_ptr<miracle::Container> const& container)
+void MiralWrapperOutput::delete_container(std::shared_ptr<miracle::Container> const& container)
 {
     auto workspace = container->get_workspace();
     if (!workspace)
@@ -133,7 +133,7 @@ void Output::delete_container(std::shared_ptr<miracle::Container> const& contain
     workspace->delete_container(container);
 }
 
-void Output::advise_new_workspace(WorkspaceCreationData const&& data)
+void MiralWrapperOutput::advise_new_workspace(WorkspaceCreationData const&& data)
 {
     // Workspaces are always kept in sorted order with numbered workspaces in front followed by all other workspaces
     auto new_workspace = std::make_shared<Workspace>(
@@ -151,7 +151,7 @@ void Output::advise_new_workspace(WorkspaceCreationData const&& data)
     });
 }
 
-void Output::advise_workspace_deleted(uint32_t id)
+void MiralWrapperOutput::advise_workspace_deleted(uint32_t id)
 {
     for (auto it = workspaces.begin(); it != workspaces.end(); it++)
     {
@@ -163,7 +163,7 @@ void Output::advise_workspace_deleted(uint32_t id)
     }
 }
 
-bool Output::advise_workspace_active(uint32_t id)
+bool MiralWrapperOutput::advise_workspace_active(uint32_t id)
 {
     std::shared_ptr<Workspace> from = nullptr;
     std::shared_ptr<Workspace> to = nullptr;
@@ -264,7 +264,7 @@ bool Output::advise_workspace_active(uint32_t id)
     return true;
 }
 
-Output::WorkspaceAnimation::WorkspaceAnimation(
+MiralWrapperOutput::WorkspaceAnimation::WorkspaceAnimation(
     AnimationHandle handle,
     AnimationDefinition definition,
     mir::geometry::Rectangle const& from,
@@ -272,7 +272,7 @@ Output::WorkspaceAnimation::WorkspaceAnimation(
     mir::geometry::Rectangle const& current,
     std::shared_ptr<Workspace> const& to_workspace,
     std::shared_ptr<Workspace> const& from_workspace,
-    Output* output) :
+    MiralWrapperOutput* output) :
     Animation(handle, definition, from, to, current),
     to_workspace { to_workspace },
     from_workspace { from_workspace },
@@ -280,12 +280,12 @@ Output::WorkspaceAnimation::WorkspaceAnimation(
 {
 }
 
-void Output::WorkspaceAnimation::on_tick(miracle::AnimationStepResult const& asr)
+void MiralWrapperOutput::WorkspaceAnimation::on_tick(miracle::AnimationStepResult const& asr)
 {
     output->on_workspace_animation(asr, to_workspace, from_workspace);
 }
 
-void Output::on_workspace_animation(
+void MiralWrapperOutput::on_workspace_animation(
     AnimationStepResult const& asr,
     std::shared_ptr<Workspace> const& to,
     std::shared_ptr<Workspace> const& from)
@@ -316,7 +316,7 @@ void Output::on_workspace_animation(
         workspace->trigger_rerender();
 }
 
-void Output::advise_application_zone_create(miral::Zone const& application_zone)
+void MiralWrapperOutput::advise_application_zone_create(miral::Zone const& application_zone)
 {
     if (application_zone.extents().contains(area))
     {
@@ -326,7 +326,7 @@ void Output::advise_application_zone_create(miral::Zone const& application_zone)
     }
 }
 
-void Output::advise_application_zone_update(miral::Zone const& updated, miral::Zone const& original)
+void MiralWrapperOutput::advise_application_zone_update(miral::Zone const& updated, miral::Zone const& original)
 {
     for (auto& zone : application_zone_list)
         if (zone == original)
@@ -338,7 +338,7 @@ void Output::advise_application_zone_update(miral::Zone const& updated, miral::Z
         }
 }
 
-void Output::advise_application_zone_delete(miral::Zone const& application_zone)
+void MiralWrapperOutput::advise_application_zone_delete(miral::Zone const& application_zone)
 {
     auto const original_size = application_zone_list.size();
     application_zone_list.erase(
@@ -352,19 +352,19 @@ void Output::advise_application_zone_delete(miral::Zone const& application_zone)
     }
 }
 
-bool Output::point_is_in_output(int x, int y)
+bool MiralWrapperOutput::point_is_in_output(int x, int y)
 {
     return area.contains(geom::Point(x, y));
 }
 
-void Output::update_area(geom::Rectangle const& new_area)
+void MiralWrapperOutput::update_area(geom::Rectangle const& new_area)
 {
     area = new_area;
     for (auto& workspace : workspaces)
         workspace->set_area(area);
 }
 
-std::vector<miral::Window> Output::collect_all_windows() const
+std::vector<miral::Window> MiralWrapperOutput::collect_all_windows() const
 {
     std::vector<miral::Window> windows;
     for (auto& workspace : get_workspaces())
@@ -379,7 +379,7 @@ std::vector<miral::Window> Output::collect_all_windows() const
     return windows;
 }
 
-void Output::add_immediately(miral::Window& window, AllocationHint hint)
+void MiralWrapperOutput::add_immediately(miral::Window& window, AllocationHint hint)
 {
     auto& prev_info = window_controller.info_for(window);
     miral::WindowSpecification spec = window_helpers::copy_from(prev_info);
@@ -394,12 +394,12 @@ void Output::add_immediately(miral::Window& window, AllocationHint hint)
     container->handle_ready();
 }
 
-void Output::graft(std::shared_ptr<Container> const& container)
+void MiralWrapperOutput::graft(std::shared_ptr<Container> const& container)
 {
     active()->graft(container);
 }
 
-geom::Rectangle Output::get_workspace_rectangle(size_t i) const
+geom::Rectangle MiralWrapperOutput::get_workspace_rectangle(size_t i) const
 {
     // TODO: Support vertical workspaces one day in the future
     auto const& workspace = workspaces[i];
@@ -425,7 +425,7 @@ geom::Rectangle Output::get_workspace_rectangle(size_t i) const
     };
 }
 
-[[nodiscard]] Workspace const* Output::workspace(uint32_t id) const
+[[nodiscard]] Workspace const* MiralWrapperOutput::workspace(uint32_t id) const
 {
     for (auto const& workspace : workspaces)
     {
@@ -436,29 +436,29 @@ geom::Rectangle Output::get_workspace_rectangle(size_t i) const
     return nullptr;
 }
 
-bool Output::is_active() const
+bool MiralWrapperOutput::is_active() const
 {
     return state.focused_output().get() == this;
 }
 
-glm::mat4 Output::get_transform() const
+glm::mat4 MiralWrapperOutput::get_transform() const
 {
     return final_transform;
 }
 
-void Output::set_transform(glm::mat4 const& in)
+void MiralWrapperOutput::set_transform(glm::mat4 const& in)
 {
     transform = in;
     final_transform = glm::translate(transform, glm::vec3(position_offset.x, position_offset.y, 0));
 }
 
-void Output::set_position(glm::vec2 const& v)
+void MiralWrapperOutput::set_position(glm::vec2 const& v)
 {
     position_offset = v;
     final_transform = glm::translate(transform, glm::vec3(position_offset.x, position_offset.y, 0));
 }
 
-nlohmann::json Output::to_json() const
+nlohmann::json MiralWrapperOutput::to_json() const
 {
     nlohmann::json nodes = nlohmann::json::array();
     for (auto const& workspace : workspaces)

--- a/src/output.h
+++ b/src/output.h
@@ -58,7 +58,7 @@ public:
         Animator&);
     ~Output() = default;
 
-    std::shared_ptr<Container> intersect(MirPointerEvent const* event);
+    std::shared_ptr<Container> intersect(float x, float y);
     AllocationHint allocate_position(
         miral::ApplicationInfo const& app_info,
         miral::WindowSpecification& requested_specification,

--- a/src/output.h
+++ b/src/output.h
@@ -47,7 +47,57 @@ struct WorkspaceCreationData
 class Output
 {
 public:
-    Output(
+    virtual ~Output() = default;
+
+    virtual std::shared_ptr<Container> intersect(float x, float y) = 0;
+    virtual AllocationHint allocate_position(
+        miral::ApplicationInfo const& app_info,
+        miral::WindowSpecification& requested_specification,
+        AllocationHint hint = AllocationHint())
+        = 0;
+    [[nodiscard]] virtual std::shared_ptr<Container> create_container(
+        miral::WindowInfo const& window_info, AllocationHint const& hint) const
+        = 0;
+    virtual void delete_container(std::shared_ptr<Container> const& container) = 0;
+    virtual void advise_new_workspace(WorkspaceCreationData const&&) = 0;
+    virtual void advise_workspace_deleted(uint32_t id) = 0;
+    virtual bool advise_workspace_active(uint32_t id) = 0;
+    virtual void advise_application_zone_create(miral::Zone const& application_zone) = 0;
+    virtual void advise_application_zone_update(miral::Zone const& updated, miral::Zone const& original) = 0;
+    virtual void advise_application_zone_delete(miral::Zone const& application_zone) = 0;
+    virtual bool point_is_in_output(int x, int y) = 0;
+    virtual void update_area(geom::Rectangle const& area) = 0;
+
+    /// Immediately requests that the provided window be added to the output
+    /// with the provided type. This is a deviation away from the typical
+    /// window-adding flow where you first call 'place_new_window' followed
+    /// by 'create_container'.
+    virtual void add_immediately(miral::Window& window, AllocationHint hint = AllocationHint()) = 0;
+
+    /// Takes an existing [Container] object and places it in an appropriate position
+    /// on the active [Workspace].
+    virtual void graft(std::shared_ptr<Container> const& container) = 0;
+    virtual void set_transform(glm::mat4 const& in) = 0;
+    virtual void set_position(glm::vec2 const&) = 0;
+
+    // Getters
+    [[nodiscard]] virtual std::vector<miral::Window> collect_all_windows() const = 0;
+    [[nodiscard]] virtual Workspace* active() const = 0;
+    [[nodiscard]] virtual std::vector<std::shared_ptr<Workspace>> const& get_workspaces() const = 0;
+    [[nodiscard]] virtual geom::Rectangle const& get_area() const = 0;
+    [[nodiscard]] virtual std::vector<miral::Zone> const& get_app_zones() const = 0;
+    [[nodiscard]] virtual miral::Output const& get_output() const = 0;
+    [[nodiscard]] virtual bool is_active() const = 0;
+    [[nodiscard]] virtual glm::mat4 get_transform() const = 0;
+    [[nodiscard]] virtual geom::Rectangle get_workspace_rectangle(size_t i) const = 0;
+    [[nodiscard]] virtual Workspace const* workspace(uint32_t id) const = 0;
+    [[nodiscard]] virtual nlohmann::json to_json() const = 0;
+};
+
+class MiralWrapperOutput : public Output
+{
+public:
+    MiralWrapperOutput(
         miral::Output const& output,
         WorkspaceManager& workspace_manager,
         geom::Rectangle const& area,
@@ -56,52 +106,44 @@ public:
         std::shared_ptr<Config> const& options,
         WindowController&,
         Animator&);
-    ~Output() = default;
+    ~MiralWrapperOutput() = default;
 
-    std::shared_ptr<Container> intersect(float x, float y);
+    std::shared_ptr<Container> intersect(float x, float y) override;
     AllocationHint allocate_position(
         miral::ApplicationInfo const& app_info,
         miral::WindowSpecification& requested_specification,
-        AllocationHint hint = AllocationHint());
+        AllocationHint hint = AllocationHint()) override;
     [[nodiscard]] std::shared_ptr<Container> create_container(
-        miral::WindowInfo const& window_info, AllocationHint const& hint) const;
-    void delete_container(std::shared_ptr<Container> const& container);
-    void advise_new_workspace(WorkspaceCreationData const&&);
-    void advise_workspace_deleted(uint32_t id);
-    bool advise_workspace_active(uint32_t id);
-    void advise_application_zone_create(miral::Zone const& application_zone);
-    void advise_application_zone_update(miral::Zone const& updated, miral::Zone const& original);
-    void advise_application_zone_delete(miral::Zone const& application_zone);
-    bool point_is_in_output(int x, int y);
-    void update_area(geom::Rectangle const& area);
-
-    /// Immediately requests that the provided window be added to the output
-    /// with the provided type. This is a deviation away from the typical
-    /// window-adding flow where you first call 'place_new_window' followed
-    /// by 'create_container'.
-    void add_immediately(miral::Window& window, AllocationHint hint = AllocationHint());
-
-    /// Takes an existing [Container] object and places it in an appropriate position
-    /// on the active [Workspace].
-    void graft(std::shared_ptr<Container> const& container);
-    void set_transform(glm::mat4 const& in);
-    void set_position(glm::vec2 const&);
+        miral::WindowInfo const& window_info, AllocationHint const& hint) const override;
+    void delete_container(std::shared_ptr<Container> const& container) override;
+    void advise_new_workspace(WorkspaceCreationData const&&) override;
+    void advise_workspace_deleted(uint32_t id) override;
+    bool advise_workspace_active(uint32_t id) override;
+    void advise_application_zone_create(miral::Zone const& application_zone) override;
+    void advise_application_zone_update(miral::Zone const& updated, miral::Zone const& original) override;
+    void advise_application_zone_delete(miral::Zone const& application_zone) override;
+    bool point_is_in_output(int x, int y) override;
+    void update_area(geom::Rectangle const& area) override;
+    void add_immediately(miral::Window& window, AllocationHint hint = AllocationHint()) override;
+    void graft(std::shared_ptr<Container> const& container) override;
+    void set_transform(glm::mat4 const& in) override;
+    void set_position(glm::vec2 const&) override;
 
     // Getters
 
-    [[nodiscard]] std::vector<miral::Window> collect_all_windows() const;
-    [[nodiscard]] Workspace* active() const;
-    [[nodiscard]] std::vector<std::shared_ptr<Workspace>> const& get_workspaces() const { return workspaces; }
-    [[nodiscard]] geom::Rectangle const& get_area() const { return area; }
-    [[nodiscard]] std::vector<miral::Zone> const& get_app_zones() const { return application_zone_list; }
-    [[nodiscard]] miral::Output const& get_output() const { return output; }
-    [[nodiscard]] bool is_active() const;
-    [[nodiscard]] glm::mat4 get_transform() const;
+    [[nodiscard]] std::vector<miral::Window> collect_all_windows() const override;
+    [[nodiscard]] Workspace* active() const override;
+    [[nodiscard]] std::vector<std::shared_ptr<Workspace>> const& get_workspaces() const override { return workspaces; }
+    [[nodiscard]] geom::Rectangle const& get_area() const override { return area; }
+    [[nodiscard]] std::vector<miral::Zone> const& get_app_zones() const override { return application_zone_list; }
+    [[nodiscard]] miral::Output const& get_output() const override { return output; }
+    [[nodiscard]] bool is_active() const override;
+    [[nodiscard]] glm::mat4 get_transform() const override;
     /// Gets the relative position of the current rectangle (e.g. the active
     /// rectangle with be at position (0, 0))
-    [[nodiscard]] geom::Rectangle get_workspace_rectangle(size_t i) const;
-    [[nodiscard]] Workspace const* workspace(uint32_t id) const;
-    [[nodiscard]] nlohmann::json to_json() const;
+    [[nodiscard]] geom::Rectangle get_workspace_rectangle(size_t i) const override;
+    [[nodiscard]] Workspace const* workspace(uint32_t id) const override;
+    [[nodiscard]] nlohmann::json to_json() const override;
 
 private:
     class WorkspaceAnimation : public Animation
@@ -115,14 +157,14 @@ private:
             mir::geometry::Rectangle const& current,
             std::shared_ptr<Workspace> const& to_workspace,
             std::shared_ptr<Workspace> const& from_workspace,
-            Output* output);
+            MiralWrapperOutput* output);
 
         void on_tick(AnimationStepResult const&) override;
 
     private:
         std::shared_ptr<Workspace> to_workspace;
         std::shared_ptr<Workspace> from_workspace;
-        Output* output;
+        MiralWrapperOutput* output;
     };
 
     void on_workspace_animation(

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -273,6 +273,7 @@ bool Policy::handle_pointer_event(MirPointerEvent const* event)
     auto x = miral::toolkit::mir_pointer_event_axis_value(event, MirPointerAxis::mir_pointer_axis_x);
     auto y = miral::toolkit::mir_pointer_event_axis_value(event, MirPointerAxis::mir_pointer_axis_y);
     auto action = miral::toolkit::mir_pointer_event_action(event);
+    auto const modifiers = miral::toolkit::mir_pointer_event_modifiers(event) & MODIFIER_MASK;
     state.cursor_position = { x, y };
 
     // Select the output first
@@ -292,7 +293,7 @@ bool Policy::handle_pointer_event(MirPointerEvent const* event)
         }
     }
 
-    if (drag_and_drop_service.handle_pointer_event(state, event))
+    if (drag_and_drop_service.handle_pointer_event(state, x, y, action, modifiers))
         return true;
 
     if (state.focused_output() && state.mode() != WindowManagerMode::resizing)
@@ -319,7 +320,7 @@ bool Policy::handle_pointer_event(MirPointerEvent const* event)
         }
 
         // Get Container intersection. Depending on the state, do something with that Container
-        std::shared_ptr<Container> intersected = state.focused_output()->intersect(event);
+        std::shared_ptr<Container> intersected = state.focused_output()->intersect(x, y);
         switch (state.mode())
         {
         case WindowManagerMode::normal:

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -542,7 +542,7 @@ void Policy::advise_move_to(miral::WindowInfo const& window_info, geom::Point to
 void Policy::advise_output_create(miral::Output const& output)
 {
     std::lock_guard lock(self->mutex);
-    auto output_content = std::make_shared<Output>(
+    auto output_content = std::make_shared<MiralWrapperOutput>(
         output, workspace_manager, output.extents(), floating_window_manager,
         state, config, window_controller, *animator);
     state.output_list.push_back(output_content);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,7 +20,8 @@ add_executable(miracle-wm-tests
     test_ipc_command_parser.cpp
     test_animator.cpp
     test_feature_flags.cpp
-    test_command_controller.cpp
+    test_drag_and_drop_service.cpp
+    with_command_controller.h
     stub_configuration.h
     stub_session.h
     stub_surface.h

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,9 @@ pkg_check_modules(MIRSERVER mirserver REQUIRED)
 pkg_check_modules(YAML REQUIRED IMPORTED_TARGET yaml-cpp)
 
 add_executable(miracle-wm-tests
+    mock_configuration.h
+    mock_container.h
+    mock_output.h
     test_filesystem_configuration.cpp
     test_tiling_window_tree.cpp
     test_ipc_command_parser.cpp

--- a/tests/mock_configuration.h
+++ b/tests/mock_configuration.h
@@ -1,0 +1,60 @@
+/**
+Copyright (C) 2024  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef MIRACLE_WM_MOCK_CONFIGURATION_H
+#define MIRACLE_WM_MOCK_CONFIGURATION_H
+
+#include "config.h"
+#include <gmock/gmock.h>
+
+namespace miracle
+{
+namespace test
+{
+    class MockConfig : public Config
+    {
+    public:
+        MOCK_METHOD(void, load, (mir::Server & server), (override));
+        MOCK_METHOD(void, reload, (), (override));
+        MOCK_METHOD(std::string const&, get_filename, (), (const, override));
+        MOCK_METHOD(MirInputEventModifier, get_input_event_modifier, (), (const, override));
+        MOCK_METHOD(CustomKeyCommand const*, matches_custom_key_command, (MirKeyboardAction action, int scan_code, unsigned int modifiers), (const, override));
+        MOCK_METHOD(bool, matches_key_command, (MirKeyboardAction action, int scan_code, unsigned int modifiers, std::function<bool(DefaultKeyCommand)> const& f), (const, override));
+        MOCK_METHOD(int, get_inner_gaps_x, (), (const, override));
+        MOCK_METHOD(int, get_inner_gaps_y, (), (const, override));
+        MOCK_METHOD(int, get_outer_gaps_x, (), (const, override));
+        MOCK_METHOD(int, get_outer_gaps_y, (), (const, override));
+        MOCK_METHOD(std::vector<StartupApp> const&, get_startup_apps, (), (const, override));
+        MOCK_METHOD(std::optional<std::string> const&, get_terminal_command, (), (const, override));
+        MOCK_METHOD(int, get_resize_jump, (), (const, override));
+        MOCK_METHOD(std::vector<EnvironmentVariable> const&, get_env_variables, (), (const, override));
+        MOCK_METHOD(BorderConfig const&, get_border_config, (), (const, override));
+        MOCK_METHOD((std::array<AnimationDefinition, static_cast<int>(AnimateableEvent::max)> const&), get_animation_definitions, (), (const, override));
+        MOCK_METHOD(bool, are_animations_enabled, (), (const, override));
+        MOCK_METHOD(WorkspaceConfig, get_workspace_config, (std::optional<int> const& num, std::optional<std::string> const& name), (const, override));
+        MOCK_METHOD(LayoutScheme, get_default_layout_scheme, (), (const, override));
+        MOCK_METHOD(DragAndDropConfiguration, drag_and_drop, (), (const, override));
+        MOCK_METHOD(int, register_listener, (std::function<void(miracle::Config&)> const&), (override));
+        MOCK_METHOD(int, register_listener, (std::function<void(miracle::Config&)> const&, int priority), (override));
+        MOCK_METHOD(void, unregister_listener, (int handle), (override));
+        MOCK_METHOD(void, try_process_change, (), (override));
+        MOCK_METHOD(uint, get_primary_modifier, (), (const, override));
+    };
+}
+}
+
+#endif // MIRACLE_WM_MOCK_CONFIGURATION_H

--- a/tests/mock_container.h
+++ b/tests/mock_container.h
@@ -1,0 +1,94 @@
+/**
+Copyright (C) 2024  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef MIRACLE_WM_MOCK_CONTAINER_H
+#define MIRACLE_WM_MOCK_CONTAINER_H
+
+#include "container.h"
+#include <gmock/gmock.h>
+
+namespace miracle
+{
+namespace test
+{
+    class MockContainer : public Container
+    {
+    public:
+        MOCK_METHOD(ContainerType, get_type, (), (const, override));
+        MOCK_METHOD(void, show, (), (override));
+        MOCK_METHOD(void, hide, (), (override));
+        MOCK_METHOD(void, commit_changes, (), (override));
+        MOCK_METHOD(geom::Rectangle, get_logical_area, (), (const, override));
+        MOCK_METHOD(void, set_logical_area, (geom::Rectangle const&), (override));
+        MOCK_METHOD(geom::Rectangle, get_visible_area, (), (const, override));
+        MOCK_METHOD(void, constrain, (), (override));
+        MOCK_METHOD(std::weak_ptr<ParentContainer>, get_parent, (), (const, override));
+        MOCK_METHOD(void, set_parent, (std::shared_ptr<ParentContainer> const&), (override));
+        MOCK_METHOD(size_t, get_min_height, (), (const, override));
+        MOCK_METHOD(size_t, get_min_width, (), (const, override));
+        MOCK_METHOD(void, handle_ready, (), (override));
+        MOCK_METHOD(void, handle_modify, (miral::WindowSpecification const&), (override));
+        MOCK_METHOD(void, handle_request_move, (MirInputEvent const* input_event), (override));
+        MOCK_METHOD(void, handle_request_resize,
+            (MirInputEvent const* input_event, MirResizeEdge edge), (override));
+        MOCK_METHOD(void, handle_raise, (), (override));
+        MOCK_METHOD(bool, resize, (Direction direction, int pixels), (override));
+        MOCK_METHOD(bool, set_size,
+            (std::optional<int> const& width, std::optional<int> const& height), (override));
+        MOCK_METHOD(bool, toggle_fullscreen, (), (override));
+        MOCK_METHOD(void, request_horizontal_layout, (), (override));
+        MOCK_METHOD(void, request_vertical_layout, (), (override));
+        MOCK_METHOD(void, toggle_layout, (bool cycle_thru_all), (override));
+        MOCK_METHOD(void, on_open, (), (override));
+        MOCK_METHOD(void, on_focus_gained, (), (override));
+        MOCK_METHOD(void, on_focus_lost, (), (override));
+        MOCK_METHOD(void, on_move_to, (geom::Point const& top_left), (override));
+        MOCK_METHOD(mir::geometry::Rectangle, confirm_placement,
+            (MirWindowState, mir::geometry::Rectangle const&),
+            (override));
+        MOCK_METHOD(Workspace*, get_workspace, (), (const, override));
+        MOCK_METHOD(Output*, get_output, (), (const, override));
+        MOCK_METHOD(TilingWindowTree*, tree, (), (const, override));
+        MOCK_METHOD(void, tree, (TilingWindowTree*), (override));
+        MOCK_METHOD(glm::mat4, get_transform, (), (const, override));
+        MOCK_METHOD(void, set_transform, (glm::mat4 transform), (override));
+        MOCK_METHOD(glm::mat4, get_workspace_transform, (), (const, override));
+        MOCK_METHOD(glm::mat4, get_output_transform, (), (const, override));
+        MOCK_METHOD(uint32_t, animation_handle, (), (const, override));
+        MOCK_METHOD(void, animation_handle, (uint32_t), (override));
+        MOCK_METHOD(bool, is_focused, (), (const, override));
+        MOCK_METHOD(bool, is_fullscreen, (), (const, override));
+        MOCK_METHOD(std::optional<miral::Window>, window, (), (const, override));
+        MOCK_METHOD(bool, select_next, (Direction), (override));
+        MOCK_METHOD(bool, pinned, (), (const, override));
+        MOCK_METHOD(bool, pinned, (bool), (override));
+        MOCK_METHOD(bool, move, (Direction), (override));
+        MOCK_METHOD(bool, move_by, (Direction, int pixels), (override));
+        MOCK_METHOD(bool, move_to, (int x, int y), (override));
+        MOCK_METHOD(bool, toggle_tabbing, (), (override));
+        MOCK_METHOD(bool, toggle_stacking, (), (override));
+        MOCK_METHOD(bool, drag_start, (), (override));
+        MOCK_METHOD(void, drag, (int x, int y), (override));
+        MOCK_METHOD(bool, drag_stop, (), (override));
+        MOCK_METHOD(bool, set_layout, (LayoutScheme scheme), (override));
+        MOCK_METHOD(LayoutScheme, get_layout, (), (const, override));
+        MOCK_METHOD(nlohmann::json, to_json, (), (const, override));
+    };
+}
+}
+
+#endif // MIRACLE_WM_MOCK_CONTAINER_H

--- a/tests/mock_output.h
+++ b/tests/mock_output.h
@@ -1,0 +1,73 @@
+/**
+Copyright (C) 2024  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef MIRACLE_WM_MOCK_OUTPUT_H
+#define MIRACLE_WM_MOCK_OUTPUT_H
+
+#include "output.h"
+#include <gmock/gmock.h>
+
+namespace miracle
+{
+namespace test
+{
+    class MockOutput : public Output
+    {
+    public:
+        MOCK_METHOD(std::shared_ptr<Container>, intersect, (float x, float y), (override));
+        MOCK_METHOD(AllocationHint, allocate_position,
+            (miral::ApplicationInfo const& app_info,
+                miral::WindowSpecification& requested_specification,
+                AllocationHint hint),
+            (override));
+        MOCK_METHOD(std::shared_ptr<Container>, create_container,
+            (miral::WindowInfo const& window_info, AllocationHint const& hint),
+            (const, override));
+        MOCK_METHOD(void, delete_container, (std::shared_ptr<Container> const& container), (override));
+        MOCK_METHOD(void, advise_new_workspace, (WorkspaceCreationData const&&), (override));
+        MOCK_METHOD(void, advise_workspace_deleted, (uint32_t id), (override));
+        MOCK_METHOD(bool, advise_workspace_active, (uint32_t id), (override));
+        MOCK_METHOD(void, advise_application_zone_create, (miral::Zone const& application_zone), (override));
+        MOCK_METHOD(void, advise_application_zone_update,
+            (miral::Zone const& updated, miral::Zone const& original),
+            (override));
+        MOCK_METHOD(void, advise_application_zone_delete, (miral::Zone const& application_zone), (override));
+        MOCK_METHOD(bool, point_is_in_output, (int x, int y), (override));
+        MOCK_METHOD(void, update_area, (geom::Rectangle const& area), (override));
+        MOCK_METHOD(void, add_immediately,
+            (miral::Window & window, AllocationHint hint),
+            (override));
+        MOCK_METHOD(void, graft, (std::shared_ptr<Container> const& container), (override));
+        MOCK_METHOD(void, set_transform, (glm::mat4 const& in), (override));
+        MOCK_METHOD(void, set_position, (glm::vec2 const&), (override));
+        MOCK_METHOD(std::vector<miral::Window>, collect_all_windows, (), (const, override));
+        MOCK_METHOD(Workspace*, active, (), (const, override));
+        MOCK_METHOD(std::vector<std::shared_ptr<Workspace>> const&, get_workspaces, (), (const, override));
+        MOCK_METHOD(geom::Rectangle const&, get_area, (), (const, override));
+        MOCK_METHOD(std::vector<miral::Zone> const&, get_app_zones, (), (const, override));
+        MOCK_METHOD(miral::Output const&, get_output, (), (const, override));
+        MOCK_METHOD(bool, is_active, (), (const, override));
+        MOCK_METHOD(glm::mat4, get_transform, (), (const, override));
+        MOCK_METHOD(geom::Rectangle, get_workspace_rectangle, (size_t i), (const, override));
+        MOCK_METHOD(Workspace const*, workspace, (uint32_t id), (const, override));
+        MOCK_METHOD(nlohmann::json, to_json, (), (const, override));
+    };
+
+}
+}
+
+#endif // MIRACLE_WM_MOCK_OUTPUT_H

--- a/tests/test_drag_and_drop_service.cpp
+++ b/tests/test_drag_and_drop_service.cpp
@@ -16,6 +16,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
 #include "drag_and_drop_service.h"
+#include "mock_configuration.h"
+#include "mock_container.h"
+#include "mock_output.h"
 #include "with_command_controller.h"
 #include <gtest/gtest.h>
 
@@ -23,21 +26,77 @@ using namespace miracle;
 
 class DragAndDropServiceTest : public testing::Test, public test::WithCommandController
 {
+
 public:
     DragAndDropServiceTest() :
+        config(std::make_shared<::testing::NiceMock<test::MockConfig>>()),
         service(command_controller, config)
     {
+        ON_CALL(*config, drag_and_drop())
+            .WillByDefault(::testing::Return(DragAndDropConfiguration {
+                .enabled = true,
+                .modifiers = mir_input_event_modifier_meta }));
     }
+
+    std::shared_ptr<::testing::NiceMock<test::MockConfig>> config;
     DragAndDropService service;
 };
 
 TEST_F(DragAndDropServiceTest, can_start_dragging)
 {
+    auto output = std::make_shared<::testing::NiceMock<test::MockOutput>>();
+    state.output_list.push_back(output);
+    state.focus_output(output);
+
+    auto container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
+    state.add(container);
+    state.focus_container(container);
+    ON_CALL(*output, intersect(::testing::_, ::testing::_))
+        .WillByDefault(::testing::Return(container));
+
+    ON_CALL(*container, drag_start())
+        .WillByDefault(::testing::Return(true));
+
+    ASSERT_TRUE(service.handle_pointer_event(
+        state,
+        100,
+        100,
+        mir_pointer_action_button_down,
+        mir_input_event_modifier_meta));
+
+    ASSERT_EQ(state.mode(), WindowManagerMode::dragging);
+}
+
+TEST_F(DragAndDropServiceTest, can_stop_dragging)
+{
+    auto output = std::make_shared<::testing::NiceMock<test::MockOutput>>();
+    state.output_list.push_back(output);
+    state.focus_output(output);
+
+    auto container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
+    state.add(container);
+    state.focus_container(container);
+    ON_CALL(*output, intersect(::testing::_, ::testing::_))
+        .WillByDefault(::testing::Return(container));
+
+    ON_CALL(*container, drag_start())
+        .WillByDefault(::testing::Return(true));
+
     service.handle_pointer_event(
         state,
         100,
         100,
         mir_pointer_action_button_down,
-        mir_input_event_modifier_meta
-    );
+        mir_input_event_modifier_meta);
+
+    ASSERT_EQ(state.mode(), WindowManagerMode::dragging);
+
+    service.handle_pointer_event(
+        state,
+        100,
+        100,
+        mir_pointer_action_button_up,
+        mir_input_event_modifier_meta);
+
+    ASSERT_EQ(state.mode(), WindowManagerMode::normal);
 }

--- a/tests/test_drag_and_drop_service.cpp
+++ b/tests/test_drag_and_drop_service.cpp
@@ -15,10 +15,29 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
-#ifndef MIRACLE_WM_FEATURE_FLAGS_H
-#define MIRACLE_WM_FEATURE_FLAGS_H
+#include "drag_and_drop_service.h"
+#include "with_command_controller.h"
+#include <gtest/gtest.h>
 
-#define MIRACLE_FEATURE_FLAG_MULTI_SELECT false
-#define MIRACLE_FEATURE_FLAG_DRAG_AND_DROP true
+using namespace miracle;
 
-#endif // MIRACLE_WM_FEATURE_FLAGS_H
+class DragAndDropServiceTest : public testing::Test, public test::WithCommandController
+{
+public:
+    DragAndDropServiceTest() :
+        service(command_controller, config)
+    {
+    }
+    DragAndDropService service;
+};
+
+TEST_F(DragAndDropServiceTest, can_start_dragging)
+{
+    service.handle_pointer_event(
+        state,
+        100,
+        100,
+        mir_pointer_action_button_down,
+        mir_input_event_modifier_meta
+    );
+}

--- a/tests/test_feature_flags.cpp
+++ b/tests/test_feature_flags.cpp
@@ -25,5 +25,5 @@ public:
 
 TEST_F(FeatureFlagsTest, DragAndDropIsFalse)
 {
-    EXPECT_EQ(MIRACLE_FEATURE_FLAG_DRAG_AND_DROP, false);
+    EXPECT_EQ(MIRACLE_FEATURE_FLAG_DRAG_AND_DROP, true);
 }

--- a/tests/with_command_controller.h
+++ b/tests/with_command_controller.h
@@ -55,15 +55,18 @@ public:
     {
     }
 
+protected:
+    CommandController command_controller;
+    CompositorState state;
+
+private:
     std::shared_ptr<Config> config;
     std::recursive_mutex mutex;
-    CompositorState state;
     std::vector<StubWindowData> data;
     StubWindowController window_controller;
     WorkspaceObserverRegistrar workspace_registry;
     WorkspaceManager workspace_manager;
     ModeObserverRegistrar mode_observer_registrar;
     Scratchpad scratchpad;
-    CommandController command_controller;
 };
 }

--- a/tests/with_command_controller.h
+++ b/tests/with_command_controller.h
@@ -27,18 +27,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <gtest/gtest.h>
 #include <miral/runner.h>
 
-using namespace miracle;
-
+namespace miracle::test
+{
 class StubCommandControllerInterface : public CommandControllerInterface
 {
 public:
     void quit() override { }
 };
 
-class CommandControllerTest : public testing::Test
+class WithCommandController
 {
 public:
-    CommandControllerTest() :
+    WithCommandController() :
         config(std::make_shared<test::StubConfiguration>()),
         window_controller(data),
         workspace_manager(workspace_registry, config, state),
@@ -66,3 +66,4 @@ public:
     Scratchpad scratchpad;
     CommandController command_controller;
 };
+}


### PR DESCRIPTION
## What's new?
- Implemented tests for the `DragAndDropService`
- Made `Output` an interface so that it can be mocked
- Turned on the drag and drop feature flag
- Added a bunch of new mock classes