### PR TITLE
(#394) bugfix: properly selecting the last selected container when switching to a workspace

### DIFF
--- a/src/leaf_container.cpp
+++ b/src/leaf_container.cpp
@@ -448,7 +448,6 @@ void LeafContainer::show()
     next_state = before_shown_state;
     before_shown_state.reset();
     commit_changes();
-    window_controller->raise(window_);
 }
 
 void LeafContainer::hide()
@@ -456,7 +455,6 @@ void LeafContainer::hide()
     before_shown_state = window_controller->get_state(window_);
     next_state = mir_window_state_hidden;
     commit_changes();
-    window_controller->send_to_back(window_);
 }
 
 bool LeafContainer::toggle_fullscreen()

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -228,6 +228,15 @@ void Workspace::advise_focus_gained(std::shared_ptr<Container> const& container)
 
 void Workspace::show()
 {
+    if (auto const last_selected = last_selected_container.lock())
+    {
+        /// The BasicWindowManager will attempt to show a window that is being shown if one is
+        /// not selected. Hence, we always show and try to select the last selected window
+        /// first so that we don't accidentally show the first window on the workspace.
+        last_selected->show();
+        if (last_selected->window().has_value())
+            window_controller->select_active_window(last_selected->window().value());
+    }
     root->show();
     for (auto const& floating : floating_trees)
         floating->show();
@@ -386,38 +395,6 @@ Workspace::MoveResult Workspace::handle_move(Container& from, Direction directio
             MoveResult::traversal_type_append,
             root
         };
-}
-
-void Workspace::select_first_window()
-{
-    // Check if the selected container is already on this workspace
-    if (state->focused_container() && state->focused_container()->get_workspace() == this)
-        return;
-
-    // First, try and select the previously selected container if it is still around
-    if (!last_selected_container.expired())
-    {
-        for_each_window([&](std::shared_ptr<Container> const& container)
-        {
-            if (container == last_selected_container.lock())
-            {
-                window_controller->select_active_window(container->window().value());
-                return true;
-            }
-
-            return false;
-        });
-    }
-
-    if (!for_each_window([&](std::shared_ptr<Container> const& container)
-    {
-        window_controller->select_active_window(container->window().value());
-        return true;
-    }))
-    {
-        // If all fails, select nothing
-        window_controller->select_active_window(miral::Window {});
-    }
 }
 
 OutputInterface* Workspace::get_output() const

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -62,7 +62,6 @@ public:
     bool for_each_window(std::function<bool(std::shared_ptr<Container>)> const&) const override;
     std::shared_ptr<ParentContainer> create_floating_tree(mir::geometry::Rectangle const& area) override;
     void advise_focus_gained(std::shared_ptr<Container> const& container) override;
-    void select_first_window() override;
     OutputInterface* get_output() const override;
     void set_output(OutputInterface*) override;
     void workspace_transform_change_hack() override;

--- a/src/workspace_interface.h
+++ b/src/workspace_interface.h
@@ -74,8 +74,6 @@ public:
 
     virtual void advise_focus_gained(std::shared_ptr<Container> const& container) = 0;
 
-    virtual void select_first_window() = 0;
-
     [[nodiscard]] virtual OutputInterface* get_output() const = 0;
 
     virtual void set_output(OutputInterface*) = 0;

--- a/src/workspace_manager.cpp
+++ b/src/workspace_manager.cpp
@@ -249,7 +249,6 @@ bool WorkspaceManager::request_focus(uint32_t id)
         registry->advise_focused(std::nullopt, id);
 
     existing->get_output()->advise_workspace_active(*this, id);
-    existing->select_first_window();
     return true;
 }
 

--- a/tests/mock_workspace.h
+++ b/tests/mock_workspace.h
@@ -58,8 +58,6 @@ namespace test
 
         MOCK_METHOD(void, advise_focus_gained, (std::shared_ptr<Container> const& container), (override));
 
-        MOCK_METHOD(void, select_first_window, (), (override));
-
         MOCK_METHOD(OutputInterface*, get_output, (), (const, override));
 
         MOCK_METHOD(void, set_output, (OutputInterface*), (override));


### PR DESCRIPTION
fixes #394 