### PR TITLE
(#398) fixing clip area of fullscreen requests coming from the client (e.g. youtube)

### DIFF
--- a/src/leaf_container.cpp
+++ b/src/leaf_container.cpp
@@ -296,6 +296,11 @@ void LeafContainer::handle_modify(miral::WindowSpecification const& modification
     }
 
     window_controller->modify(window_, mods);
+
+    if (state == mir_window_state_fullscreen)
+        window_controller->noclip(window_);
+    else
+        window_controller->clip(window_, visible_area);
 }
 
 void LeafContainer::handle_raise()

--- a/tests/test_leaf_container.cpp
+++ b/tests/test_leaf_container.cpp
@@ -195,6 +195,22 @@ TEST_F(LeafContainerTest, IfParentIsUnanchoredThenParentCanBeResizedDown)
     leaf_container->resize(Direction::down, 20);
 }
 
+TEST_F(LeafContainerTest, IfModifyingWindowToFullScreenThenNoclipIsCalled)
+{
+    miral::WindowSpecification spec;
+    spec.state() = mir_window_state_fullscreen;
+    EXPECT_CALL(*window_controller, noclip(testing::_));
+    leaf_container->handle_modify(spec);
+}
+
+TEST_F(LeafContainerTest, IfModifyingWindowToRestoredThenClipIsCalled)
+{
+    miral::WindowSpecification spec;
+    spec.state() = mir_window_state_restored;
+    EXPECT_CALL(*window_controller, clip(testing::_, testing::_));
+    leaf_container->handle_modify(spec);
+}
+
 namespace
 {
 bool has_restored_state(miral::WindowSpecification const& spec)


### PR DESCRIPTION
fixes #398 