### PR TITLE
(#400) when hidden, a leaf should be sent to the back to avoid focus issues with X11 windows

### DIFF
--- a/src/leaf_container.cpp
+++ b/src/leaf_container.cpp
@@ -453,6 +453,7 @@ void LeafContainer::show()
     next_state = before_shown_state;
     before_shown_state.reset();
     commit_changes();
+    window_controller->raise(window_);
 }
 
 void LeafContainer::hide()
@@ -460,6 +461,7 @@ void LeafContainer::hide()
     before_shown_state = window_controller->get_state(window_);
     next_state = mir_window_state_hidden;
     commit_changes();
+    window_controller->send_to_back(window_);
 }
 
 bool LeafContainer::toggle_fullscreen()

--- a/tests/test_leaf_container.cpp
+++ b/tests/test_leaf_container.cpp
@@ -240,3 +240,15 @@ INSTANTIATE_TEST_SUITE_P(
     LeafContainerMaximizedTest,
     LeafContainerMaximizedTest,
     ::testing::Values(mir_window_state_maximized, mir_window_state_vertmaximized, mir_window_state_horizmaximized));
+
+TEST_F(LeafContainerTest, ShowingContainerCausesRaise)
+{
+    EXPECT_CALL(*window_controller, raise(testing::_));
+    leaf_container->show();
+}
+
+TEST_F(LeafContainerTest, HidingContainerCausesSendToBack)
+{
+    EXPECT_CALL(*window_controller, send_to_back(testing::_));
+    leaf_container->hide();
+}


### PR DESCRIPTION
fixes #400 