### PR TITLE
(#419) fixing how LeafContainer resolves is_focused

### DIFF
--- a/src/leaf_container.cpp
+++ b/src/leaf_container.cpp
@@ -643,10 +643,16 @@ void LeafContainer::animation_handle(uint32_t handle)
 
 bool LeafContainer::is_focused() const
 {
-    if ((state->focused_container() && state->focused_container().get() == this) || parent.lock()->is_focused())
+    if (!state->focused_container())
+        return false;
+
+    if (state->focused_container().get() == this)
         return true;
 
-    auto group = Container::as_group(state->focused_container());
+    if (parent.lock()->is_focused())
+        return true;
+
+    auto const group = Container::as_group(state->focused_container());
     if (!group)
         return false;
 

--- a/tests/test_leaf_container.cpp
+++ b/tests/test_leaf_container.cpp
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "compositor_state.h"
 #include "config.h"
+#include "container_group_container.h"
 #include "leaf_container.h"
 #include "mir/geometry/forward.h"
 #include "mir_toolkit/common.h"
@@ -251,4 +252,34 @@ TEST_F(LeafContainerTest, HidingContainerCausesSendToBack)
 {
     EXPECT_CALL(*window_controller, send_to_back(testing::_));
     leaf_container->hide();
+}
+
+TEST_F(LeafContainerTest, LeafContainerIsNotFocusedWhenStateHasNoFocusedContainer)
+{
+    EXPECT_FALSE(leaf_container->is_focused());
+}
+
+TEST_F(LeafContainerTest, LeafContainerIsFocusedWhenStateFocusesThisContainer)
+{
+    state->focus_container(leaf_container);
+    EXPECT_TRUE(leaf_container->is_focused());
+}
+
+TEST_F(LeafContainerTest, LeafContainerIsFocusedWhenParentIsFocused)
+{
+    state->focus_container(parent, true);
+    EXPECT_CALL(*parent, is_focused())
+        .WillOnce(testing::Return(true));
+    EXPECT_TRUE(leaf_container->is_focused());
+}
+
+TEST_F(LeafContainerTest, LeafContainerIsFocusedWhenGroupIsFocused)
+{
+    auto container_group_container = std::make_shared<ContainerGroupContainer>(
+        state);
+    state->focus_container(container_group_container, true);
+    container_group_container->add(leaf_container);
+    EXPECT_CALL(*parent, is_focused())
+        .WillOnce(testing::Return(false));
+    EXPECT_TRUE(leaf_container->is_focused());
 }


### PR DESCRIPTION
fixes #419 