### PR TITLE
bufix: Fix FTBFS with glm 1.0.0+ and musl/libc++ (again)

### DIFF
--- a/src/animator.cpp
+++ b/src/animator.cpp
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define GLM_ENABLE_EXPERIMENTAL
 
 #include "animator.h"
+#include <algorithm>
 #include <chrono>
 #include <glm/gtx/transform.hpp>
 #include <mir/log.h>
@@ -76,11 +77,11 @@ float ease(AnimationDefinition const& defintion, float t)
     case EaseFunction::linear:
         return t;
     case EaseFunction::ease_in_sine:
-        return 1 - cosf((t * M_PIf) / 2.f);
+        return 1 - cosf((t * static_cast<float>(M_PI)) / 2.f);
     case EaseFunction::ease_in_out_sine:
-        return -(cosf(M_PIf * t) - 1) / 2;
+        return -(cosf(static_cast<float>(M_PI) * t) - 1) / 2;
     case EaseFunction::ease_out_sine:
-        return sinf((t * M_PIf) / 2.f);
+        return sinf((t * static_cast<float>(M_PI)) / 2.f);
     case EaseFunction::ease_in_quad:
         return t * t;
     case EaseFunction::ease_out_quad:

--- a/src/drag_and_drop_service.cpp
+++ b/src/drag_and_drop_service.cpp
@@ -40,7 +40,7 @@ DragAndDropService::DragAndDropService(
 {
 }
 
-bool DragAndDropService::handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, uint modifiers)
+bool DragAndDropService::handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, unsigned int modifiers)
 {
     if (!MIRACLE_FEATURE_FLAG_DRAG_AND_DROP || !config->drag_and_drop().enabled)
         return false;

--- a/src/drag_and_drop_service.h
+++ b/src/drag_and_drop_service.h
@@ -38,7 +38,7 @@ public:
         std::shared_ptr<CommandController> const& command_controller,
         std::shared_ptr<Config> const& config,
         std::shared_ptr<OutputManager> const& output_manager);
-    bool handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, uint modifiers);
+    bool handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, unsigned int modifiers);
 
 private:
     std::shared_ptr<CommandController> command_controller;

--- a/src/layout_scheme.cpp
+++ b/src/layout_scheme.cpp
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "layout_scheme.h"
 #include <stdexcept>
+#include <string>
 
 const char* miracle::to_string(miracle::LayoutScheme scheme)
 {

--- a/src/move_service.cpp
+++ b/src/move_service.cpp
@@ -40,7 +40,7 @@ bool MoveService::handle_pointer_event(
     float x,
     float y,
     MirPointerAction action,
-    uint modifiers)
+    unsigned int modifiers)
 {
     if (state.mode() == WindowManagerMode::moving)
     {

--- a/src/move_service.h
+++ b/src/move_service.h
@@ -32,7 +32,7 @@ class MoveService
 {
 public:
     MoveService(std::shared_ptr<CommandController> const&, std::shared_ptr<Config> const&, std::shared_ptr<OutputManager> const& output_manager);
-    bool handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, uint modifiers);
+    bool handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, unsigned int modifiers);
 
 private:
     std::shared_ptr<CommandController> command_controller;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -27,6 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "workspace.h"
 #include "workspace_manager.h"
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/transform.hpp>
 #include <memory>
 #include <mir/log.h>

--- a/src/render_data_manager.h
+++ b/src/render_data_manager.h
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <glm/glm.hpp>
 #include <mir/scene/surface.h>
+#include <mutex>
 #include <vector>
 
 namespace miracle


### PR DESCRIPTION
Fixes the following compile errors I saw under a full LLVM 19.1.7 toolchain on Chimera Linux (some of which already appeared previously in #185):
```
src/layout_scheme.cpp:35:21: error: implicit instantiation of undefined template 'std::basic_string<char>'
   35 |         std::string error = "Encountered unexpected scheme in to_string: " + std::to_string((int)scheme);
      |                     ^
/usr/bin/../include/c++/v1/__fwd/string.h:43:28: note: template is declared here
   43 | class _LIBCPP_TEMPLATE_VIS basic_string;
      |                            ^

src/animator.cpp:79:30: error: use of undeclared identifier 'M_PIf'
   79 |         return 1 - cosf((t * M_PIf) / 2.f);
      |                              ^

In file included from src/output.cpp:30:
/usr/include/glm/gtx/transform.hpp:23:3: error: "GLM: GLM_GTX_transform is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."
   23 | #       error "GLM: GLM_GTX_transform is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."
      |         ^

src/animator.cpp:469:17: error: no member named 'any_of' in namespace 'std'
  469 |     return std::any_of(active.begin(), active.end(), [handle](std::shared_ptr<Animation> const& animation)
      |            ~~~~~^

In file included from src/mode_observer.cpp:18:
In file included from src/mode_observer.h:21:
In file included from src/compositor_state.h:22:
src/render_data_manager.h:51:10: error: no type named 'mutex' in namespace 'std'
   51 |     std::mutex mutex;
      |     ~~~~~^

In file included from src/drag_and_drop_service.cpp:20:
src/drag_and_drop_service.h:41:98: error: unknown type name 'uint'; did you mean 'int'?
   41 |     bool handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, uint modifiers);
      |                                                                                                  ^~~~
      |                                                                                                  int

```
Also includes my proposed fix for https://github.com/miracle-wm-org/miracle-wm/pull/397#pullrequestreview-2661363304

Perhaps also having some "more exotic" CI configurations excersiced here other than just [the usual `ubuntu-24.04`](https://github.com/miracle-wm-org/miracle-wm/blob/develop/.github/workflows/cmake.yml) wouldn't hurt either, then these things may be caught sooner than when I try building myself from time to time :p