### PR TITLE
(#447) bugfix: consuming the input event even if we don't move

### DIFF
--- a/src/drag_and_drop_service.cpp
+++ b/src/drag_and_drop_service.cpp
@@ -64,7 +64,7 @@ bool DragAndDropService::handle_pointer_event(CompositorState& state, float x, f
 
         /// If we haven't moved since last time, there's nothing to do
         if (current_x == x && current_y == y)
-            return false;
+            return true;
 
         current_x = x;
         current_y = y;

--- a/src/move_service.cpp
+++ b/src/move_service.cpp
@@ -58,7 +58,7 @@ bool MoveService::handle_pointer_event(
 
         /// If we haven't moved since last time, there's nothing to do
         if (cursor_x == x && cursor_y == y)
-            return false;
+            return true;
 
         auto const dx = x - cursor_x;
         auto const dy = y - cursor_y;


### PR DESCRIPTION
fixes #447 