### PR TITLE
(#451) move and drag and drop container services always use the primary button now instead of a random one

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -824,6 +824,11 @@ uint FilesystemConfiguration::get_primary_modifier() const
     return options.primary_modifier;
 }
 
+uint FilesystemConfiguration::get_primary_button() const
+{
+    return options.primary_button;
+}
+
 std::optional<uint> FilesystemConfiguration::try_parse_modifier(std::string const& stringified_action_key)
 {
     if (stringified_action_key == "alt")

--- a/src/config.h
+++ b/src/config.h
@@ -193,6 +193,7 @@ public:
     virtual void unregister_listener(int handle) = 0;
     virtual void try_process_change() = 0;
     [[nodiscard]] virtual uint get_primary_modifier() const = 0;
+    [[nodiscard]] virtual uint get_primary_button() const = 0;
     uint process_modifier(uint modifier) const;
 };
 
@@ -231,12 +232,14 @@ public:
     void unregister_listener(int handle) override;
     void try_process_change() override;
     [[nodiscard]] uint get_primary_modifier() const override;
+    [[nodiscard]] uint get_primary_button() const override;
 
 private:
     struct ConfigDetails
     {
         ConfigDetails();
         uint primary_modifier = mir_input_event_modifier_meta;
+        uint primary_button = mir_pointer_button_primary;
         std::vector<CustomKeyCommand> custom_key_commands;
         KeyCommandList key_commands[static_cast<int>(DefaultKeyCommand::MAX)];
         int inner_gaps_x = 10;

--- a/src/drag_and_drop_service.cpp
+++ b/src/drag_and_drop_service.cpp
@@ -40,14 +40,14 @@ DragAndDropService::DragAndDropService(
 {
 }
 
-bool DragAndDropService::handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, unsigned int modifiers)
+bool DragAndDropService::handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, unsigned int modifiers, MirPointerButtons buttons)
 {
     if (!MIRACLE_FEATURE_FLAG_DRAG_AND_DROP || !config->drag_and_drop().enabled)
         return false;
 
     if (state.mode() == WindowManagerMode::dragging)
     {
-        if (action == mir_pointer_action_button_up)
+        if (action == mir_pointer_action_button_up && (config->get_primary_button() & buttons) == 0)
         {
             command_controller->set_mode(WindowManagerMode::normal);
             if (state.focused_container())
@@ -100,6 +100,9 @@ bool DragAndDropService::handle_pointer_event(CompositorState& state, float x, f
     }
     else if (action == mir_pointer_action_button_down)
     {
+        if ((config->get_primary_button() & buttons) == 0)
+            return false;
+
         uint command_modifiers = config->process_modifier(config->drag_and_drop().modifiers);
         if (command_modifiers != modifiers)
             return false;

--- a/src/drag_and_drop_service.h
+++ b/src/drag_and_drop_service.h
@@ -38,7 +38,7 @@ public:
         std::shared_ptr<CommandController> const& command_controller,
         std::shared_ptr<Config> const& config,
         std::shared_ptr<OutputManager> const& output_manager);
-    bool handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, unsigned int modifiers);
+    bool handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, unsigned int modifiers, MirPointerButtons buttons);
 
 private:
     std::shared_ptr<CommandController> command_controller;

--- a/src/move_service.cpp
+++ b/src/move_service.cpp
@@ -40,11 +40,12 @@ bool MoveService::handle_pointer_event(
     float x,
     float y,
     MirPointerAction action,
-    unsigned int modifiers)
+    unsigned int modifiers,
+    MirPointerButtons buttons)
 {
     if (state.mode() == WindowManagerMode::moving)
     {
-        if (action == mir_pointer_action_button_up)
+        if (action == mir_pointer_action_button_up && (config->get_primary_button() & buttons) == 0)
         {
             command_controller->set_mode(WindowManagerMode::normal);
             return false;
@@ -69,6 +70,9 @@ bool MoveService::handle_pointer_event(
     }
     else if (action == mir_pointer_action_button_down)
     {
+        if ((config->get_primary_button() & buttons) == 0)
+            return false;
+
         uint const move_modifier = config->process_modifier(config->move_modifier());
         if (move_modifier != modifiers)
             return false;

--- a/src/move_service.h
+++ b/src/move_service.h
@@ -32,7 +32,7 @@ class MoveService
 {
 public:
     MoveService(std::shared_ptr<CommandController> const&, std::shared_ptr<Config> const&, std::shared_ptr<OutputManager> const& output_manager);
-    bool handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, unsigned int modifiers);
+    bool handle_pointer_event(CompositorState& state, float x, float y, MirPointerAction action, unsigned int modifiers, MirPointerButtons buttons);
 
 private:
     std::shared_ptr<CommandController> command_controller;

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -297,8 +297,9 @@ bool Policy::handle_pointer_event(MirPointerEvent const* event)
     std::lock_guard lock(self->mutex);
     auto x = miral::toolkit::mir_pointer_event_axis_value(event, MirPointerAxis::mir_pointer_axis_x);
     auto y = miral::toolkit::mir_pointer_event_axis_value(event, MirPointerAxis::mir_pointer_axis_y);
-    auto action = miral::toolkit::mir_pointer_event_action(event);
+    auto const action = miral::toolkit::mir_pointer_event_action(event);
     auto const modifiers = miral::toolkit::mir_pointer_event_modifiers(event) & MODIFIER_MASK;
+    auto const buttons = mir_pointer_event_buttons(event);
     state->cursor_position = { x, y };
 
     // Select the output first
@@ -311,20 +312,20 @@ bool Policy::handle_pointer_event(MirPointerEvent const* event)
                 if (output_manager->focused())
                     output_manager->unfocus(output_manager->focused()->id());
                 output_manager->focus(output->id());
-                if (auto active = output->active())
+                if (auto const active = output->active())
                     workspace_manager->request_focus(active->id());
             }
             break;
         }
     }
 
-    if (resize_service->handle_pointer_event(x, y, action, modifiers))
+    if (resize_service->handle_pointer_event(x, y, action))
         return true;
 
-    if (move_service->handle_pointer_event(*state, x, y, action, modifiers))
+    if (move_service->handle_pointer_event(*state, x, y, action, modifiers, buttons))
         return true;
 
-    if (drag_and_drop_service->handle_pointer_event(*state, x, y, action, modifiers))
+    if (drag_and_drop_service->handle_pointer_event(*state, x, y, action, modifiers, buttons))
         return true;
 
     if (output_manager->focused() && state->mode() != WindowManagerMode::resizing)
@@ -635,8 +636,9 @@ void Policy::handle_request_move(miral::WindowInfo& window_info, const MirInputE
     auto const x = miral::toolkit::mir_pointer_event_axis_value(pointer_event, MirPointerAxis::mir_pointer_axis_x);
     auto const y = miral::toolkit::mir_pointer_event_axis_value(pointer_event, MirPointerAxis::mir_pointer_axis_y);
     auto const action = miral::toolkit::mir_pointer_event_action(pointer_event);
+    auto const buttons = miral::toolkit::mir_pointer_event_buttons(pointer_event);
     move_service->handle_pointer_event(
-        *state, x, y, action, config->process_modifier(config->move_modifier()));
+        *state, x, y, action, config->process_modifier(config->move_modifier()), buttons);
 }
 
 void Policy::handle_request_resize(

--- a/src/resize_service.cpp
+++ b/src/resize_service.cpp
@@ -40,7 +40,7 @@ void ResizeService::stop()
     command_controller->set_mode(WindowManagerMode::normal);
 }
 
-bool ResizeService::handle_pointer_event(float x, float y, MirPointerAction action, MirPointerButtons buttons)
+bool ResizeService::handle_pointer_event(float x, float y, MirPointerAction action)
 {
     if (!is_resizing)
         return false;

--- a/src/resize_service.h
+++ b/src/resize_service.h
@@ -35,7 +35,7 @@ public:
         std::shared_ptr<CompositorState> const& state,
         std::shared_ptr<OutputManager> const& output_manager);
 
-    bool handle_pointer_event(float x, float y, MirPointerAction action, MirPointerButtons buttons);
+    bool handle_pointer_event(float x, float y, MirPointerAction action);
     void handle_request_resize(std::shared_ptr<Container> const& container, MirPointerAction action, MirResizeEdge edge);
 
 private:

--- a/tests/mock_configuration.h
+++ b/tests/mock_configuration.h
@@ -54,6 +54,7 @@ namespace test
         MOCK_METHOD(void, try_process_change, (), (override));
         MOCK_METHOD(uint, get_primary_modifier, (), (const, override));
         MOCK_METHOD(uint, move_modifier, (), (const, override));
+        MOCK_METHOD(uint, get_primary_button, (), (const, override));
     };
 }
 }

--- a/tests/stub_configuration.h
+++ b/tests/stub_configuration.h
@@ -139,6 +139,11 @@ namespace test
             return 0;
         }
 
+        [[nodiscard]] uint get_primary_button() const override
+        {
+            return mir_pointer_button_primary;
+        }
+
     private:
         miracle::BorderConfig border_config;
         std::array<AnimationDefinition, static_cast<int>(AnimateableEvent::max)> animations;

--- a/tests/test_drag_and_drop_service.cpp
+++ b/tests/test_drag_and_drop_service.cpp
@@ -67,6 +67,8 @@ public:
             .WillByDefault(::testing::Return(DragAndDropConfiguration {
                 .enabled = true,
                 .modifiers = mir_input_event_modifier_meta }));
+        ON_CALL(*config, get_primary_button())
+            .WillByDefault(::testing::Return(mir_pointer_button_primary));
     }
 
     std::recursive_mutex mutex;
@@ -113,7 +115,8 @@ TEST_F(DragAndDropServiceTest, CanStartDragging)
         100,
         100,
         mir_pointer_action_button_down,
-        mir_input_event_modifier_meta));
+        mir_input_event_modifier_meta,
+        mir_pointer_button_primary));
 
     ASSERT_EQ(state->mode(), WindowManagerMode::dragging);
 }
@@ -146,7 +149,8 @@ TEST_F(DragAndDropServiceTest, CanStopDragging)
         100,
         100,
         mir_pointer_action_button_down,
-        mir_input_event_modifier_meta);
+        mir_input_event_modifier_meta,
+        mir_pointer_button_primary);
 
     ASSERT_EQ(state->mode(), WindowManagerMode::dragging);
 
@@ -155,7 +159,8 @@ TEST_F(DragAndDropServiceTest, CanStopDragging)
         100,
         100,
         mir_pointer_action_button_up,
-        mir_input_event_modifier_meta);
+        mir_input_event_modifier_meta,
+        0);
 
     ASSERT_EQ(state->mode(), WindowManagerMode::normal);
 }
@@ -188,7 +193,8 @@ TEST_F(DragAndDropServiceTest, CanDragToOtherContainer)
         100,
         100,
         mir_pointer_action_button_down,
-        mir_input_event_modifier_meta);
+        mir_input_event_modifier_meta,
+        mir_pointer_button_primary);
 
     auto other_container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
     state->add(other_container);
@@ -217,5 +223,6 @@ TEST_F(DragAndDropServiceTest, CanDragToOtherContainer)
         500,
         500,
         mir_pointer_action_button_down,
-        mir_input_event_modifier_none);
+        mir_input_event_modifier_none,
+        0);
 }

--- a/tests/test_resize_service.cpp
+++ b/tests/test_resize_service.cpp
@@ -101,7 +101,7 @@ TEST_F(ResizeServiceTest, CanStartResizing)
     service.handle_request_resize(container, mir_pointer_action_button_down, mir_resize_edge_east);
 
     ASSERT_EQ(state->mode(), WindowManagerMode::resizing);
-    ASSERT_TRUE(service.handle_pointer_event(100, 100, mir_pointer_action_button_down, 0));
+    ASSERT_TRUE(service.handle_pointer_event(100, 100, mir_pointer_action_button_down));
 }
 
 TEST_F(ResizeServiceTest, CannotResizeWhenParentHasMoreThanOneChild)
@@ -181,7 +181,7 @@ TEST_F(ResizeServiceTest, ResizeNorthEdge)
 
     service.handle_request_resize(container, mir_pointer_action_button_down, mir_resize_edge_north);
     EXPECT_CALL(*parent, set_logical_area(geom::Rectangle(geom::Point(100, 80), geom::Size(200, 220)), false));
-    ASSERT_TRUE(service.handle_pointer_event(150, 80, mir_pointer_action_motion, 0));
+    ASSERT_TRUE(service.handle_pointer_event(150, 80, mir_pointer_action_motion));
 }
 
 TEST_F(ResizeServiceTest, ResizeSouthEdge)
@@ -208,7 +208,7 @@ TEST_F(ResizeServiceTest, ResizeSouthEdge)
 
     service.handle_request_resize(container, mir_pointer_action_button_down, mir_resize_edge_south);
     EXPECT_CALL(*parent, set_logical_area(geom::Rectangle(geom::Point(100, 100), geom::Size(200, 250)), false));
-    ASSERT_TRUE(service.handle_pointer_event(150, 350, mir_pointer_action_motion, 0));
+    ASSERT_TRUE(service.handle_pointer_event(150, 350, mir_pointer_action_motion));
 }
 
 TEST_F(ResizeServiceTest, ResizeEastEdge)
@@ -235,7 +235,7 @@ TEST_F(ResizeServiceTest, ResizeEastEdge)
 
     service.handle_request_resize(container, mir_pointer_action_button_down, mir_resize_edge_east);
     EXPECT_CALL(*parent, set_logical_area(geom::Rectangle(geom::Point(100, 100), geom::Size(250, 200)), false));
-    ASSERT_TRUE(service.handle_pointer_event(350, 150, mir_pointer_action_motion, 0));
+    ASSERT_TRUE(service.handle_pointer_event(350, 150, mir_pointer_action_motion));
 }
 
 TEST_F(ResizeServiceTest, ResizeWestEdge)
@@ -262,7 +262,7 @@ TEST_F(ResizeServiceTest, ResizeWestEdge)
 
     service.handle_request_resize(container, mir_pointer_action_button_down, mir_resize_edge_west);
     EXPECT_CALL(*parent, set_logical_area(geom::Rectangle(geom::Point(80, 100), geom::Size(220, 200)), false));
-    ASSERT_TRUE(service.handle_pointer_event(80, 150, mir_pointer_action_motion, 0));
+    ASSERT_TRUE(service.handle_pointer_event(80, 150, mir_pointer_action_motion));
 }
 
 TEST_F(ResizeServiceTest, ResizeNorthEastEdge)
@@ -289,7 +289,7 @@ TEST_F(ResizeServiceTest, ResizeNorthEastEdge)
 
     service.handle_request_resize(container, mir_pointer_action_button_down, mir_resize_edge_northeast);
     EXPECT_CALL(*parent, set_logical_area(geom::Rectangle(geom::Point(100, 80), geom::Size(150, 220)), false));
-    ASSERT_TRUE(service.handle_pointer_event(250, 80, mir_pointer_action_motion, 0));
+    ASSERT_TRUE(service.handle_pointer_event(250, 80, mir_pointer_action_motion));
 }
 
 TEST_F(ResizeServiceTest, ResizeNorthWestEdge)
@@ -316,7 +316,7 @@ TEST_F(ResizeServiceTest, ResizeNorthWestEdge)
 
     service.handle_request_resize(container, mir_pointer_action_button_down, mir_resize_edge_northwest);
     EXPECT_CALL(*parent, set_logical_area(geom::Rectangle(geom::Point(80, 80), geom::Size(220, 220)), false));
-    ASSERT_TRUE(service.handle_pointer_event(80, 80, mir_pointer_action_motion, 0));
+    ASSERT_TRUE(service.handle_pointer_event(80, 80, mir_pointer_action_motion));
 }
 
 TEST_F(ResizeServiceTest, ResizeSouthEastEdge)
@@ -343,7 +343,7 @@ TEST_F(ResizeServiceTest, ResizeSouthEastEdge)
 
     service.handle_request_resize(container, mir_pointer_action_button_down, mir_resize_edge_southeast);
     EXPECT_CALL(*parent, set_logical_area(geom::Rectangle(geom::Point(100, 100), geom::Size(150, 150)), false));
-    ASSERT_TRUE(service.handle_pointer_event(250, 250, mir_pointer_action_motion, 0));
+    ASSERT_TRUE(service.handle_pointer_event(250, 250, mir_pointer_action_motion));
 }
 
 TEST_F(ResizeServiceTest, ResizeSouthWestEdge)
@@ -370,7 +370,7 @@ TEST_F(ResizeServiceTest, ResizeSouthWestEdge)
 
     service.handle_request_resize(container, mir_pointer_action_button_down, mir_resize_edge_southwest);
     EXPECT_CALL(*parent, set_logical_area(geom::Rectangle(geom::Point(80, 100), geom::Size(220, 150)), false));
-    ASSERT_TRUE(service.handle_pointer_event(80, 250, mir_pointer_action_motion, 0));
+    ASSERT_TRUE(service.handle_pointer_event(80, 250, mir_pointer_action_motion));
 }
 
 TEST_F(ResizeServiceTest, StopsResizingWhenButtonReleased)
@@ -395,7 +395,7 @@ TEST_F(ResizeServiceTest, StopsResizingWhenButtonReleased)
 
     service.handle_request_resize(container, mir_pointer_action_button_down, mir_resize_edge_east);
 
-    ASSERT_TRUE(service.handle_pointer_event(100, 100, mir_pointer_action_button_down, 0));
-    ASSERT_FALSE(service.handle_pointer_event(100, 100, mir_pointer_action_button_up, 0));
+    ASSERT_TRUE(service.handle_pointer_event(100, 100, mir_pointer_action_button_down));
+    ASSERT_FALSE(service.handle_pointer_event(100, 100, mir_pointer_action_button_up));
     ASSERT_EQ(state->mode(), WindowManagerMode::normal);
 }


### PR DESCRIPTION
fixes #451 