### PR TITLE
Fix missing build deps for debian and use shlibdeps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,9 +24,7 @@ Homepage: https://github.com/mattkae/miracle-wm
 
 Package: miracle-wm
 Architecture: any
-Depends: libmiral7,
-         mir-graphics-drivers-desktop,
-         libmiroil5
+Depends: mir-graphics-drivers-desktop, ${shlibs:Depends}
 Description: miracle-wm is a Wayland compositor based on Mir.
  It features a tiling window manager at its core, very much
  in the style of i3 and sway. The intention is to build a

--- a/debian/control
+++ b/debian/control
@@ -2,22 +2,24 @@ Source: miracle-wm
 Section: devel
 Priority: optional
 Maintainer: Matthew Kosarek <matthew@matthewkosarek.xyz>
-Build-Depends: cmake,
-               pkg-config,
-               build-essential,
-               libmiral-dev,
-               libgtest-dev,
-               libyaml-cpp-dev,
-               libglib2.0-dev,
+Build-Depends: build-essential,
+               cmake,
                libevdev-dev,
-               nlohmann-json3-dev,
-               libmirwayland-dev,
-               libmiroil-dev,
-               libmircommon-internal-dev,
+               libglib2.0-dev,
+               libgmock-dev,
+               libgtest-dev,
+               libjson-c-dev,
+               libmiral-dev,
                libmircommon-dev,
-               libmirserver-internal-dev,
+               libmircommon-internal-dev,
+               libmiroil-dev,
                libmirrenderer-dev,
-               pcre2-utils
+               libmirserver-internal-dev,
+               libmirwayland-dev,
+               libyaml-cpp-dev,
+               nlohmann-json3-dev,
+               pcre2-utils,
+               pkg-config
 Homepage: https://github.com/mattkae/miracle-wm
 
 Package: miracle-wm


### PR DESCRIPTION
Hi. I notice this things: 
1. `debian/control` file had two missing `Build-Depends`: `libjson-c-dev`, `libgmock-dev`.
2. `debian/control` file had not a complete list of dependencies. This can be easily fixed by use `${shlibs:Depends}`

In this PR i suggest fix both of that (and I also sorted deps list, sorry)


Diff of output `dpkg -I <miracle-wm_package>.deb` before and after this commits:

```diff
<  Depends: libmiral7, mir-graphics-drivers-desktop, libmiroil5
---
>  Depends: libc6 (>= 2.38), libegl1, libevdev2 (>= 0.9.1), libgcc-s1 (>= 4.3), libgles2, libglib2.0-0t64 (>= 2.12.0), libmiral7 (>= 5.2.0), libmircommon11 (>= 2.20.0), libmircore2 (>= 2.8.0), libmiroil7 (>= 2.20.0), libmirplatform30 (>= 2.20.0), libmirserver63 (>= 2.20.0), libpcre2-8-0 (>= 10.22), libstdc++6 (>= 13.1), libyaml-cpp0.8 (>= 0.7.0)
```