### PR TITLE
Update staging libmiroil dependency to version binary is linked to

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -84,7 +84,7 @@ parts:
       - libgmock-dev
     stage-packages:
       - libmiral7
-      - libmiroil5
+      - libmiroil7
       - mir-graphics-drivers-desktop
       - mir-graphics-drivers-nvidia
       - pcre2-utils


### PR DESCRIPTION
Addresses: #465 

Installing the snap via:
```
snap install miracle-wm --classic
```

Runs into error: 
```
/snap/miracle-wm/687/usr/local/bin/miracle-wm: error while loading shared libraries: libmiroil.so.7: cannot open shared object file: No such file or directory
```

The built binary links against `libmiroil.so.7`, however the Snap was staging `libmiroil5`.

```
ldd miracle-wm 
	linux-vdso.so.1 (0x00007ffd579c5000)
....
	libmiroil.so.7 => not found
```

Swapping to `libmiroil7` resolves the issue and ensures the required shared library is present inside the Snap at runtime.

Updating the staging package declaration and building the snap locally shows this issue going away:
```
WAYLAND_DISPLAY=wayland-98 miracle-wm
[2025-03-23 16:52:43.491568] <information> miracle-main: Welcome to miracle-wm v0.5.1
[2025-03-23 16:52:43.524281] <information> mirserver: Starting
```