### PR TITLE
refactor + features: lots of ipc work from the airplane ride yesterday

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,8 @@ add_library(miracle-wm-implementation
     src/config.h
     src/output.cpp
     src/workspace_manager.cpp
-    src/ipc.cpp
+    src/ipc_message_handler.cpp
+    src/ipc_connection_manager.cpp
     src/auto_restarting_launcher.cpp
     src/workspace_interface.h
     src/workspace_observer.cpp

--- a/miraclemsg/ipc_client.cpp
+++ b/miraclemsg/ipc_client.cpp
@@ -35,6 +35,12 @@ static const char ipc_magic[] = { 'i', '3', '-', 'i', 'p', 'c' };
 
 char* get_socketpath(void)
 {
+    const char* miraclesock = getenv("MIRACLESOCK");
+    if (miraclesock)
+    {
+        return strdup(miraclesock);
+    }
+
     const char* swaysock = getenv("SWAYSOCK");
     if (swaysock)
     {

--- a/src/command_controller.cpp
+++ b/src/command_controller.cpp
@@ -19,11 +19,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "command_controller.h"
 #include "config.h"
+#include "leaf_container.h"
 #include "mode_observer.h"
 #include "output_manager.h"
 #include "parent_container.h"
 #include "scratchpad.h"
-#include "window_helpers.h"
 #include "workspace_manager.h"
 
 #include <mir/log.h>
@@ -194,7 +194,7 @@ bool CommandController::try_request_horizontal(std::vector<ContainerScope> const
     return true;
 }
 
-bool CommandController::try_resize(miracle::Direction direction, int pixels, std::vector<ContainerScope> const& scope)
+bool CommandController::try_resize(Direction direction, int pixels, std::vector<ContainerScope> const& scope)
 {
     std::lock_guard lock(mutex);
     auto containers = resolve_scope(scope);
@@ -210,16 +210,64 @@ bool CommandController::try_resize(miracle::Direction direction, int pixels, std
     return result;
 }
 
-bool CommandController::try_set_size(std::optional<int> const& width, std::optional<int> const& height, std::vector<ContainerScope> const& scope)
+bool CommandController::try_resize_ppt(Direction direction, float ppt, std::vector<ContainerScope> const& scope)
 {
     std::lock_guard lock(mutex);
-    auto containers = resolve_scope(scope);
+    auto const containers = resolve_scope(scope);
     if (containers.empty())
         return false;
 
     bool result = true;
     for (auto const& container : containers)
     {
+        auto const output = container->get_output();
+        if (!output)
+        {
+            result = false;
+            continue;
+        }
+
+        float total_size = 0;
+        switch (direction)
+        {
+        case Direction::down:
+        case Direction::up:
+            total_size = output->get_area().size.height.as_value();
+            break;
+        default:
+            total_size = output->get_area().size.width.as_value();
+            break;
+        }
+
+        if (!container->resize(direction, ppt * total_size))
+            result = false;
+    }
+    return result;
+}
+
+bool CommandController::try_set_size(
+    std::optional<int> const& width,
+    bool is_width_ppt,
+    std::optional<int> const& height,
+    bool is_height_ppt,
+    std::vector<ContainerScope> const& scope)
+{
+    // TODO: Account for ppt here
+    std::lock_guard lock(mutex);
+    auto const containers = resolve_scope(scope);
+    if (containers.empty())
+        return false;
+
+    bool result = true;
+    for (auto const& container : containers)
+    {
+        auto const output = container->get_output();
+        if (!output)
+        {
+            result = false;
+            continue;
+        }
+
         if (!container->set_size(width, height))
             result = false;
     }
@@ -305,7 +353,6 @@ bool CommandController::try_move_by_ppt(Direction direction, float ppt, std::vec
     return result;
 }
 
-
 bool CommandController::try_move_to(float x, bool is_x_ppt, float y, bool is_y_ppt, std::vector<ContainerScope> const& scope)
 {
     std::lock_guard lock(mutex);
@@ -371,7 +418,6 @@ bool CommandController::try_move_to_absolute_center(std::vector<ContainerScope> 
     float const y_pos = y / 2.f - static_cast<float>(active->get_visible_area().size.height.as_int()) / 2.f;
     return try_move_to(static_cast<int>(x_pos), false, static_cast<int>(y_pos), false, scope);
 }
-
 
 bool CommandController::try_move_to_cursor(std::vector<ContainerScope> const& scope)
 {
@@ -538,7 +584,6 @@ bool CommandController::try_select_next(std::vector<ContainerScope> const& scope
         }
     }
 }
-
 
 bool CommandController::try_select_floating(std::vector<ContainerScope> const& scope)
 {

--- a/src/command_controller.cpp
+++ b/src/command_controller.cpp
@@ -1320,7 +1320,7 @@ nlohmann::json CommandController::workspaces_json() const
         if (workspace->get_output()->is_defunct())
             continue;
 
-        j.push_back(workspace->to_json(output_manager->focused() == workspace->get_output()));
+        j.push_back(workspace->get_workspaces_json(output_manager->focused() == workspace->get_output()));
     }
     return j;
 }

--- a/src/command_controller.cpp
+++ b/src/command_controller.cpp
@@ -104,6 +104,82 @@ bool CommandController::try_toggle_layout(bool cycle_thru_all, std::vector<Conta
     return true;
 }
 
+bool CommandController::try_cycle_through_request_types(
+    std::vector<LayoutRequestType> const& request_types,
+    std::vector<ContainerScope> const& scope)
+{
+    std::lock_guard lock(mutex);
+    if (state->mode() != WindowManagerMode::normal)
+        return false;
+
+    if (request_types.empty())
+        return false;
+
+    auto const containers = resolve_scope(scope);
+    if (containers.empty())
+        return false;
+
+    for (auto const& container : containers)
+    {
+        auto const current_type = container->get_layout();
+        size_t i = -1;
+        bool found = false;
+        for (; i < request_types.size(); i++)
+        {
+            switch (request_types[i])
+            {
+            case LayoutRequestType::split:
+                if (current_type == LayoutScheme::horizontal || current_type == LayoutScheme::vertical)
+                    found = true;
+                break;
+            case LayoutRequestType::tabbed:
+                if (current_type == LayoutScheme::tabbing)
+                    found = true;
+                break;
+            case LayoutRequestType::stacking:
+                if (current_type == LayoutScheme::stacking)
+                    found = true;
+                break;
+            case LayoutRequestType::splith:
+                if (current_type == LayoutScheme::horizontal)
+                    found = true;
+                break;
+            case LayoutRequestType::splitv:
+                if (current_type == LayoutScheme::vertical)
+                    found = true;
+                break;
+            }
+
+            if (found)
+                break;
+        }
+
+        i++;
+        if (i == request_types.size())
+            i = 0;
+        switch (request_types[i])
+        {
+        case LayoutRequestType::split:
+            container->toggle_layout(false);
+            break;
+        case LayoutRequestType::splitv:
+            container->set_layout(LayoutScheme::vertical);
+            break;
+        case LayoutRequestType::splith:
+            container->set_layout(LayoutScheme::horizontal);
+            break;
+        case LayoutRequestType::stacking:
+            container->set_layout(LayoutScheme::stacking);
+            break;
+        case LayoutRequestType::tabbed:
+            container->set_layout(LayoutScheme::tabbing);
+            break;
+        }
+    }
+
+    return true;
+}
+
 bool CommandController::try_request_horizontal(std::vector<ContainerScope> const& scope)
 {
     std::lock_guard lock(mutex);
@@ -169,7 +245,7 @@ bool CommandController::try_move(miracle::Direction direction, std::vector<Conta
     return result;
 }
 
-bool CommandController::try_move_by(miracle::Direction direction, int pixels, std::vector<ContainerScope> const& scope)
+bool CommandController::try_move_by_pixels(miracle::Direction direction, int pixels, std::vector<ContainerScope> const& scope)
 {
     std::lock_guard lock(mutex);
     if (state->mode() != WindowManagerMode::normal)
@@ -188,23 +264,120 @@ bool CommandController::try_move_by(miracle::Direction direction, int pixels, st
     return result;
 }
 
-bool CommandController::try_move_to(int x, int y, std::vector<ContainerScope> const& scope)
+bool CommandController::try_move_by_ppt(Direction direction, float ppt, std::vector<ContainerScope> const& scope)
 {
     std::lock_guard lock(mutex);
     if (state->mode() != WindowManagerMode::normal)
         return false;
 
-    auto containers = resolve_scope(scope);
+    auto const containers = resolve_scope(scope);
     if (containers.empty())
         return false;
 
     bool result = true;
     for (auto const& container : containers)
     {
-        if (!container->move_to(x, y))
+        auto const output = container->get_output();
+        if (!output)
+        {
+            mir::log_error("try_move_by_ppt: container does not have an output");
+            result = false;
+            continue;
+        }
+
+        float total_size = 0;
+        switch (direction)
+        {
+        case Direction::up:
+        case Direction::down:
+            total_size = output->get_area().size.height.as_value();
+            break;
+        case Direction::left:
+        case Direction::right:
+        default:
+            total_size = output->get_area().size.width.as_value();
+            break;
+        }
+
+        if (!container->move_by(direction, total_size * ppt))
             result = false;
     }
     return result;
+}
+
+
+bool CommandController::try_move_to(float x, bool is_x_ppt, float y, bool is_y_ppt, std::vector<ContainerScope> const& scope)
+{
+    std::lock_guard lock(mutex);
+    if (state->mode() != WindowManagerMode::normal)
+        return false;
+
+    auto const containers = resolve_scope(scope);
+    if (containers.empty())
+        return false;
+
+    bool result = true;
+    for (auto const& container : containers)
+    {
+        auto const output = container->get_output();
+        if (!output)
+        {
+            mir::log_error("try_move_to: container does not have an output");
+            result = false;
+            continue;
+        }
+
+        float resolved_x = x;
+        float resolved_y = y;
+        if (is_x_ppt)
+            resolved_x = output->get_area().size.width.as_value() * x;
+        if (is_y_ppt)
+            resolved_y = output->get_area().size.height.as_value() * y;
+
+        if (!container->move_to(resolved_x, resolved_y))
+            result = false;
+    }
+    return result;
+}
+
+bool CommandController::try_move_to_center_of_active_output(std::vector<ContainerScope> const& scope)
+{
+    std::lock_guard lock(mutex);
+    auto const& active_output = output_manager->focused();
+    auto const active = state->focused_container().get();
+    auto const area = active_output->get_area();
+    float const x = static_cast<float>(area.size.width.as_int()) / 2.f - static_cast<float>(active->get_visible_area().size.width.as_int()) / 2.f;
+    float const y = static_cast<float>(area.size.height.as_int()) / 2.f - static_cast<float>(active->get_visible_area().size.height.as_int()) / 2.f;
+    return try_move_to(static_cast<int>(x), false, static_cast<int>(y), false, scope);
+}
+
+bool CommandController::try_move_to_absolute_center(std::vector<ContainerScope> const& scope)
+{
+    std::lock_guard lock(mutex);
+    float x = 0, y = 0;
+    for (auto const& output : output_manager->outputs())
+    {
+        auto area = output->get_area();
+        float const end_x = static_cast<float>(area.size.width.as_int() + area.top_left.x.as_int());
+        float const end_y = static_cast<float>(area.size.height.as_int() + area.top_left.y.as_int());
+        if (end_x > x)
+            x = end_x;
+        if (end_y > y)
+            y = end_y;
+    }
+
+    auto const active = state->focused_container();
+    float const x_pos = x / 2.f - static_cast<float>(active->get_visible_area().size.width.as_int()) / 2.f;
+    float const y_pos = y / 2.f - static_cast<float>(active->get_visible_area().size.height.as_int()) / 2.f;
+    return try_move_to(static_cast<int>(x_pos), false, static_cast<int>(y_pos), false, scope);
+}
+
+
+bool CommandController::try_move_to_cursor(std::vector<ContainerScope> const& scope)
+{
+    std::lock_guard lock(mutex);
+    auto const& position = state->cursor_position;
+    return try_move_to(position.x.as_int(), false, position.y.as_int(), false, scope);
 }
 
 void CommandController::select_container(std::shared_ptr<Container> const& container)
@@ -323,6 +496,49 @@ bool CommandController::try_select_child(std::vector<ContainerScope> const& scop
     }
     return result;
 }
+
+bool CommandController::try_select_prev(std::vector<ContainerScope> const& scope)
+{
+    std::lock_guard lock(mutex);
+    auto const container = state->focused_container();
+    if (!container)
+        return false;
+
+    if (container->get_type() != ContainerType::leaf)
+        return false;
+
+    if (auto const parent = Container::as_parent(container->get_parent().lock()))
+    {
+        auto const index = parent->get_index_of_node(container).value();
+        if (index != 0)
+        {
+            auto const node_to_select = parent->get_nth_window(index - 1);
+            window_controller->select_active_window(node_to_select->window().value());
+        }
+    }
+}
+
+bool CommandController::try_select_next(std::vector<ContainerScope> const& scope)
+{
+    std::lock_guard lock(mutex);
+    auto const container = state->focused_container();
+    if (!container)
+        return false;
+
+    if (container->get_type() != ContainerType::leaf)
+        return false;
+
+    if (auto const parent = Container::as_parent(container->get_parent().lock()))
+    {
+        auto const index = parent->get_index_of_node(container).value();
+        if (index != parent->num_nodes() - 1)
+        {
+            auto node_to_select = parent->get_nth_window(index + 1);
+            window_controller->select_active_window(node_to_select->window().value());
+        }
+    }
+}
+
 
 bool CommandController::try_select_floating(std::vector<ContainerScope> const& scope)
 {
@@ -520,22 +736,28 @@ bool CommandController::back_and_forth_workspace()
     return true;
 }
 
-bool CommandController::next_workspace_on_output(miracle::OutputInterface const& output)
+bool CommandController::next_workspace_on_output()
 {
     std::lock_guard lock(mutex);
     if (state->mode() != WindowManagerMode::normal)
         return false;
 
-    return workspace_manager->request_next_on_output(output);
+    if (auto const focused = output_manager->focused())
+        return workspace_manager->request_next_on_output(*focused);
+
+    return false;
 }
 
-bool CommandController::prev_workspace_on_output(miracle::OutputInterface const& output)
+bool CommandController::prev_workspace_on_output()
 {
     std::lock_guard lock(mutex);
     if (state->mode() != WindowManagerMode::normal)
         return false;
 
-    return workspace_manager->request_prev_on_output(output);
+    if (auto const focused = output_manager->focused())
+        return workspace_manager->request_prev_on_output(*focused);
+
+    return false;
 }
 
 bool CommandController::move_active_to_workspace(int number, bool back_and_forth)

--- a/src/command_controller.cpp
+++ b/src/command_controller.cpp
@@ -1306,7 +1306,7 @@ nlohmann::json CommandController::outputs_json() const
         if (output->is_defunct())
             continue;
 
-        j.push_back(output->to_json_for_output_list(output_manager->focused() == output.get()));
+        j.push_back(output->get_outputs_json(output_manager->focused() == output.get()));
     }
     return j;
 }

--- a/src/command_controller.h
+++ b/src/command_controller.h
@@ -37,6 +37,15 @@ class Scratchpad;
 class ModeObserverRegistrar;
 class OutputManager;
 
+enum class LayoutRequestType
+{
+    split,
+    tabbed,
+    stacking,
+    splitv,
+    splith
+};
+
 /// Responsible for fielding requests from the system and forwarding
 /// them to an appropriate handler. Requests can come from any thread
 /// (e.g. the keyboard input thread, the ipc thread, etc.).
@@ -51,16 +60,23 @@ public:
     virtual bool try_request_horizontal(std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_request_vertical(std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_toggle_layout(bool cycle_through_all, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_cycle_through_request_types(std::vector<LayoutRequestType> const& request_types, std::vector<ContainerScope> const& scope) = 0;
     virtual void try_toggle_resize_mode() = 0;
     virtual bool try_resize(Direction direction, int pixels, std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_set_size(std::optional<int> const& width, std::optional<int> const& height, std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_move(Direction direction, std::vector<ContainerScope> const& scope) = 0;
-    virtual bool try_move_by(Direction direction, int pixels, std::vector<ContainerScope> const& scope) = 0;
-    virtual bool try_move_to(int x, int y, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_move_by_pixels(Direction direction, int pixels, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_move_by_ppt(Direction direction, float ppt, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_move_to(float x, bool is_x_ppt, float y, bool is_y_ppt, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_move_to_center_of_active_output(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_move_to_absolute_center(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_move_to_cursor(std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_select(std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_select(Direction direction, std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_select_parent(std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_select_child(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_select_prev(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_select_next(std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_select_floating(std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_select_tiling(std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_select_toggle(std::vector<ContainerScope> const& scope) = 0;
@@ -73,8 +89,8 @@ public:
     virtual bool next_workspace() = 0;
     virtual bool prev_workspace() = 0;
     virtual bool back_and_forth_workspace() = 0;
-    virtual bool next_workspace_on_output(OutputInterface const&) = 0;
-    virtual bool prev_workspace_on_output(OutputInterface const&) = 0;
+    virtual bool next_workspace_on_output() = 0;
+    virtual bool prev_workspace_on_output() = 0;
     virtual bool move_active_to_workspace(int number, bool back_and_forth) = 0;
     virtual bool move_active_to_workspace_named(std::string const&, bool back_and_forth) = 0;
     virtual bool move_active_to_next_workspace() = 0;
@@ -134,16 +150,23 @@ public:
     bool try_request_horizontal(std::vector<ContainerScope> const& scope) override;
     bool try_request_vertical(std::vector<ContainerScope> const& scope) override;
     bool try_toggle_layout(bool cycle_through_all, std::vector<ContainerScope> const& scope) override;
+    bool try_cycle_through_request_types(std::vector<LayoutRequestType> const& request_types, std::vector<ContainerScope> const& scope) override;
     void try_toggle_resize_mode() override;
     bool try_resize(Direction direction, int pixels, std::vector<ContainerScope> const& scope) override;
     bool try_set_size(std::optional<int> const& width, std::optional<int> const& height, std::vector<ContainerScope> const& scope) override;
     bool try_move(Direction direction, std::vector<ContainerScope> const& scope) override;
-    bool try_move_by(Direction direction, int pixels, std::vector<ContainerScope> const& scope) override;
-    bool try_move_to(int x, int y, std::vector<ContainerScope> const& scope) override;
+    bool try_move_by_pixels(Direction direction, int pixels, std::vector<ContainerScope> const& scope) override;
+    bool try_move_by_ppt(Direction direction, float ppt, std::vector<ContainerScope> const& scope) override;
+    bool try_move_to(float x, bool is_x_ppt, float y, bool is_y_ppt, std::vector<ContainerScope> const& scope) override;
+    bool try_move_to_center_of_active_output(std::vector<ContainerScope> const& scope) override;
+    bool try_move_to_absolute_center(std::vector<ContainerScope> const& scope) override;
+    bool try_move_to_cursor(std::vector<ContainerScope> const& scope) override;
     bool try_select(std::vector<ContainerScope> const& scope) override;
     bool try_select(Direction direction, std::vector<ContainerScope> const& scope) override;
     bool try_select_parent(std::vector<ContainerScope> const& scope) override;
     bool try_select_child(std::vector<ContainerScope> const& scope) override;
+    bool try_select_prev(std::vector<ContainerScope> const& scope) override;
+    bool try_select_next(std::vector<ContainerScope> const& scope) override;
     bool try_select_floating(std::vector<ContainerScope> const& scope) override;
     bool try_select_tiling(std::vector<ContainerScope> const& scope) override;
     bool try_select_toggle(std::vector<ContainerScope> const& scope) override;
@@ -156,8 +179,8 @@ public:
     bool next_workspace() override;
     bool prev_workspace() override;
     bool back_and_forth_workspace() override;
-    bool next_workspace_on_output(OutputInterface const&) override;
-    bool prev_workspace_on_output(OutputInterface const&) override;
+    bool next_workspace_on_output() override;
+    bool prev_workspace_on_output() override;
     bool move_active_to_workspace(int number, bool back_and_forth) override;
     bool move_active_to_workspace_named(std::string const&, bool back_and_forth) override;
     bool move_active_to_next_workspace() override;

--- a/src/command_controller.h
+++ b/src/command_controller.h
@@ -37,13 +37,6 @@ class Scratchpad;
 class ModeObserverRegistrar;
 class OutputManager;
 
-class CommandControllerInterface
-{
-public:
-    virtual ~CommandControllerInterface() = default;
-    virtual void quit() = 0;
-};
-
 /// Responsible for fielding requests from the system and forwarding
 /// them to an appropriate handler. Requests can come from any thread
 /// (e.g. the keyboard input thread, the ipc thread, etc.).
@@ -51,7 +44,80 @@ public:
 /// whereby requests are made on the controller that are then sent
 /// to the proper subsystem for processing. In this case, the subsystem
 /// may be anything from the tiles in the grid, the scratchpad, etc.
-class CommandController
+class AbstractCommandController
+{
+public:
+    virtual ~AbstractCommandController() = default;
+    virtual bool try_request_horizontal(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_request_vertical(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_toggle_layout(bool cycle_through_all, std::vector<ContainerScope> const& scope) = 0;
+    virtual void try_toggle_resize_mode() = 0;
+    virtual bool try_resize(Direction direction, int pixels, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_set_size(std::optional<int> const& width, std::optional<int> const& height, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_move(Direction direction, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_move_by(Direction direction, int pixels, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_move_to(int x, int y, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_select(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_select(Direction direction, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_select_parent(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_select_child(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_select_floating(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_select_tiling(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_select_toggle(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_close_window(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool quit() = 0;
+    virtual bool try_toggle_fullscreen(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool select_workspace(int number, bool back_and_forth) = 0;
+    virtual bool select_workspace(std::string const& name, bool back_and_forth) = 0;
+    virtual bool select_workspace_with_scope(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool next_workspace() = 0;
+    virtual bool prev_workspace() = 0;
+    virtual bool back_and_forth_workspace() = 0;
+    virtual bool next_workspace_on_output(OutputInterface const&) = 0;
+    virtual bool prev_workspace_on_output(OutputInterface const&) = 0;
+    virtual bool move_active_to_workspace(int number, bool back_and_forth) = 0;
+    virtual bool move_active_to_workspace_named(std::string const&, bool back_and_forth) = 0;
+    virtual bool move_active_to_next_workspace() = 0;
+    virtual bool move_active_to_prev_workspace() = 0;
+    virtual bool move_active_to_back_and_forth() = 0;
+    virtual bool move_to_scratchpad() = 0;
+    virtual bool show_scratchpad() = 0;
+    virtual bool toggle_floating(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool toggle_pinned_to_workspace(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool set_is_pinned(bool, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool toggle_tabbing(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool toggle_stacking(std::vector<ContainerScope> const& scope) = 0;
+    virtual bool set_layout(LayoutScheme scheme, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool set_layout_default(std::vector<ContainerScope> const& scope) = 0;
+    virtual void move_cursor_to_output(OutputInterface const&) = 0;
+    virtual bool try_select_next_output() = 0;
+    virtual bool try_select_prev_output() = 0;
+    virtual bool try_select_output(Direction direction) = 0;
+    virtual bool try_select_output(std::vector<std::string> const& names) = 0;
+    virtual bool try_move_active_to_output(Direction direction) = 0;
+    virtual bool try_move_active_to_current() = 0;
+    virtual bool try_move_active_to_primary() = 0;
+    virtual bool try_move_active_to_nonprimary() = 0;
+    virtual bool try_move_active_to_next() = 0;
+    virtual bool try_move_active(std::vector<std::string> const& names) = 0;
+    virtual bool reload_config() = 0;
+    virtual void set_mode(WindowManagerMode mode) = 0;
+    virtual void select_container(std::shared_ptr<Container> const&) = 0;
+    [[nodiscard]] virtual nlohmann::json to_json() const = 0;
+    [[nodiscard]] virtual nlohmann::json outputs_json() const = 0;
+    [[nodiscard]] virtual nlohmann::json workspaces_json() const = 0;
+    [[nodiscard]] virtual nlohmann::json workspace_to_json(uint32_t) const = 0;
+    [[nodiscard]] virtual nlohmann::json mode_to_json() const = 0;
+};
+
+class CommandControllerInterface
+{
+public:
+    virtual ~CommandControllerInterface() = default;
+    virtual void quit() = 0;
+};
+
+class CommandController : public AbstractCommandController
 {
 public:
     CommandController(
@@ -65,66 +131,66 @@ public:
         std::shared_ptr<Scratchpad> const& scratchpad,
         std::shared_ptr<OutputManager> const& output_manager);
 
-    bool try_request_horizontal(std::vector<ContainerScope> const& scope);
-    bool try_request_vertical(std::vector<ContainerScope> const& scope);
-    bool try_toggle_layout(bool cycle_through_all, std::vector<ContainerScope> const& scope);
-    void try_toggle_resize_mode();
-    bool try_resize(Direction direction, int pixels, std::vector<ContainerScope> const& scope);
-    bool try_set_size(std::optional<int> const& width, std::optional<int> const& height, std::vector<ContainerScope> const& scope);
-    bool try_move(Direction direction, std::vector<ContainerScope> const& scope);
-    bool try_move_by(Direction direction, int pixels, std::vector<ContainerScope> const& scope);
-    bool try_move_to(int x, int y, std::vector<ContainerScope> const& scope);
-    bool try_select(std::vector<ContainerScope> const& scope);
-    bool try_select(Direction direction, std::vector<ContainerScope> const& scope);
-    bool try_select_parent(std::vector<ContainerScope> const& scope);
-    bool try_select_child(std::vector<ContainerScope> const& scope);
-    bool try_select_floating(std::vector<ContainerScope> const& scope);
-    bool try_select_tiling(std::vector<ContainerScope> const& scope);
-    bool try_select_toggle(std::vector<ContainerScope> const& scope);
-    bool try_close_window(std::vector<ContainerScope> const& scope);
-    bool quit();
-    bool try_toggle_fullscreen(std::vector<ContainerScope> const& scope);
-    bool select_workspace(int number, bool back_and_forth = true);
-    bool select_workspace(std::string const& name, bool back_and_forth);
-    bool select_workspace_with_scope(std::vector<ContainerScope> const& scope);
-    bool next_workspace();
-    bool prev_workspace();
-    bool back_and_forth_workspace();
-    bool next_workspace_on_output(OutputInterface const&);
-    bool prev_workspace_on_output(OutputInterface const&);
-    bool move_active_to_workspace(int number, bool back_and_forth = true);
-    bool move_active_to_workspace_named(std::string const&, bool back_and_forth);
-    bool move_active_to_next_workspace();
-    bool move_active_to_prev_workspace();
-    bool move_active_to_back_and_forth();
-    bool move_to_scratchpad();
-    bool show_scratchpad();
-    bool toggle_floating(std::vector<ContainerScope> const& scope = {});
-    bool toggle_pinned_to_workspace(std::vector<ContainerScope> const& scope = {});
-    bool set_is_pinned(bool, std::vector<ContainerScope> const& scope = {});
-    bool toggle_tabbing(std::vector<ContainerScope> const& scope = {});
-    bool toggle_stacking(std::vector<ContainerScope> const& scope = {});
-    bool set_layout(LayoutScheme scheme, std::vector<ContainerScope> const& scope = {});
-    bool set_layout_default(std::vector<ContainerScope> const& scope = {});
-    void move_cursor_to_output(OutputInterface const&);
-    bool try_select_next_output();
-    bool try_select_prev_output();
-    bool try_select_output(Direction direction);
-    bool try_select_output(std::vector<std::string> const& names);
-    bool try_move_active_to_output(Direction direction);
-    bool try_move_active_to_current();
-    bool try_move_active_to_primary();
-    bool try_move_active_to_nonprimary();
-    bool try_move_active_to_next();
-    bool try_move_active(std::vector<std::string> const& names);
-    bool reload_config();
-    void set_mode(WindowManagerMode mode);
-    void select_container(std::shared_ptr<Container> const&);
-    [[nodiscard]] nlohmann::json to_json() const;
-    [[nodiscard]] nlohmann::json outputs_json() const;
-    [[nodiscard]] nlohmann::json workspaces_json() const;
-    [[nodiscard]] nlohmann::json workspace_to_json(uint32_t) const;
-    [[nodiscard]] nlohmann::json mode_to_json() const;
+    bool try_request_horizontal(std::vector<ContainerScope> const& scope) override;
+    bool try_request_vertical(std::vector<ContainerScope> const& scope) override;
+    bool try_toggle_layout(bool cycle_through_all, std::vector<ContainerScope> const& scope) override;
+    void try_toggle_resize_mode() override;
+    bool try_resize(Direction direction, int pixels, std::vector<ContainerScope> const& scope) override;
+    bool try_set_size(std::optional<int> const& width, std::optional<int> const& height, std::vector<ContainerScope> const& scope) override;
+    bool try_move(Direction direction, std::vector<ContainerScope> const& scope) override;
+    bool try_move_by(Direction direction, int pixels, std::vector<ContainerScope> const& scope) override;
+    bool try_move_to(int x, int y, std::vector<ContainerScope> const& scope) override;
+    bool try_select(std::vector<ContainerScope> const& scope) override;
+    bool try_select(Direction direction, std::vector<ContainerScope> const& scope) override;
+    bool try_select_parent(std::vector<ContainerScope> const& scope) override;
+    bool try_select_child(std::vector<ContainerScope> const& scope) override;
+    bool try_select_floating(std::vector<ContainerScope> const& scope) override;
+    bool try_select_tiling(std::vector<ContainerScope> const& scope) override;
+    bool try_select_toggle(std::vector<ContainerScope> const& scope) override;
+    bool try_close_window(std::vector<ContainerScope> const& scope) override;
+    bool quit() override;
+    bool try_toggle_fullscreen(std::vector<ContainerScope> const& scope) override;
+    bool select_workspace(int number, bool back_and_forth) override;
+    bool select_workspace(std::string const& name, bool back_and_forth) override;
+    bool select_workspace_with_scope(std::vector<ContainerScope> const& scope) override;
+    bool next_workspace() override;
+    bool prev_workspace() override;
+    bool back_and_forth_workspace() override;
+    bool next_workspace_on_output(OutputInterface const&) override;
+    bool prev_workspace_on_output(OutputInterface const&) override;
+    bool move_active_to_workspace(int number, bool back_and_forth) override;
+    bool move_active_to_workspace_named(std::string const&, bool back_and_forth) override;
+    bool move_active_to_next_workspace() override;
+    bool move_active_to_prev_workspace() override;
+    bool move_active_to_back_and_forth() override;
+    bool move_to_scratchpad() override;
+    bool show_scratchpad() override;
+    bool toggle_floating(std::vector<ContainerScope> const& scope) override;
+    bool toggle_pinned_to_workspace(std::vector<ContainerScope> const& scope) override;
+    bool set_is_pinned(bool, std::vector<ContainerScope> const& scope) override;
+    bool toggle_tabbing(std::vector<ContainerScope> const& scope) override;
+    bool toggle_stacking(std::vector<ContainerScope> const& scope) override;
+    bool set_layout(LayoutScheme scheme, std::vector<ContainerScope> const& scope) override;
+    bool set_layout_default(std::vector<ContainerScope> const& scope) override;
+    void move_cursor_to_output(OutputInterface const&) override;
+    bool try_select_next_output() override;
+    bool try_select_prev_output() override;
+    bool try_select_output(Direction direction) override;
+    bool try_select_output(std::vector<std::string> const& names) override;
+    bool try_move_active_to_output(Direction direction) override;
+    bool try_move_active_to_current() override;
+    bool try_move_active_to_primary() override;
+    bool try_move_active_to_nonprimary() override;
+    bool try_move_active_to_next() override;
+    bool try_move_active(std::vector<std::string> const& names) override;
+    bool reload_config() override;
+    void set_mode(WindowManagerMode mode) override;
+    void select_container(std::shared_ptr<Container> const&) override;
+    [[nodiscard]] nlohmann::json to_json() const override;
+    [[nodiscard]] nlohmann::json outputs_json() const override;
+    [[nodiscard]] nlohmann::json workspaces_json() const override;
+    [[nodiscard]] nlohmann::json workspace_to_json(uint32_t) const override;
+    [[nodiscard]] nlohmann::json mode_to_json() const override;
 
 private:
     std::shared_ptr<Config> config;

--- a/src/command_controller.h
+++ b/src/command_controller.h
@@ -63,7 +63,8 @@ public:
     virtual bool try_cycle_through_request_types(std::vector<LayoutRequestType> const& request_types, std::vector<ContainerScope> const& scope) = 0;
     virtual void try_toggle_resize_mode() = 0;
     virtual bool try_resize(Direction direction, int pixels, std::vector<ContainerScope> const& scope) = 0;
-    virtual bool try_set_size(std::optional<int> const& width, std::optional<int> const& height, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_resize_ppt(Direction direction, float ppt, std::vector<ContainerScope> const& scope) = 0;
+    virtual bool try_set_size(std::optional<int> const& width, bool is_width_ppt, std::optional<int> const& height, bool is_height_ppt, std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_move(Direction direction, std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_move_by_pixels(Direction direction, int pixels, std::vector<ContainerScope> const& scope) = 0;
     virtual bool try_move_by_ppt(Direction direction, float ppt, std::vector<ContainerScope> const& scope) = 0;
@@ -153,7 +154,8 @@ public:
     bool try_cycle_through_request_types(std::vector<LayoutRequestType> const& request_types, std::vector<ContainerScope> const& scope) override;
     void try_toggle_resize_mode() override;
     bool try_resize(Direction direction, int pixels, std::vector<ContainerScope> const& scope) override;
-    bool try_set_size(std::optional<int> const& width, std::optional<int> const& height, std::vector<ContainerScope> const& scope) override;
+    bool try_resize_ppt(Direction direction, float ppt, std::vector<ContainerScope> const& scope) override;
+    bool try_set_size(std::optional<int> const& width, bool is_width_ppt, std::optional<int> const& height, bool is_height_ppt, std::vector<ContainerScope> const& scope) override;
     bool try_move(Direction direction, std::vector<ContainerScope> const& scope) override;
     bool try_move_by_pixels(Direction direction, int pixels, std::vector<ContainerScope> const& scope) override;
     bool try_move_by_ppt(Direction direction, float ppt, std::vector<ContainerScope> const& scope) override;

--- a/src/compositor_state.h
+++ b/src/compositor_state.h
@@ -43,7 +43,13 @@ enum class WindowManagerMode
 
     dragging,
 
-    moving
+    moving,
+
+    max
+};
+
+constexpr std::array<std::string, static_cast<int>(WindowManagerMode::max)> BINDING_MODE_STRINGS = {
+    "default", "resize", "selecting", "dragging", "moving"
 };
 
 class CompositorState

--- a/src/display_config.cpp
+++ b/src/display_config.cpp
@@ -101,6 +101,8 @@ struct convert<miracle::DisplayConfig::OutputConfig>
         Node node;
         node["enabled"] = card.enabled;
         node["name"] = card.name;
+        if (card.primary)
+            node["primary"] = card.primary;
         if (card.position)
             node["position"] = *card.position;
         if (card.size)
@@ -132,6 +134,8 @@ struct convert<miracle::DisplayConfig::OutputConfig>
         card.name = node["name"].as<std::string>();
         card.enabled = node["enabled"].as<bool>(false);
 
+        if (node["primary"])
+            card.primary = node["primary"].as<bool>();
         if (node["position"])
             card.position = node["position"].as<mir::geometry::Point>();
         if (node["size"])
@@ -377,6 +381,7 @@ private:
     {
         std::vector<OutputConfig> result;
         geom::Point position(0, 0);
+        bool enconutered_first = false;
         configuration.for_each_output([&](mg::UserDisplayConfigurationOutput& output)
         {
             if (!output.connected || output.modes.empty())
@@ -384,6 +389,7 @@ private:
 
             OutputConfig config;
             config.enabled = output.connected && !output.modes.empty();
+            config.primary = !enconutered_first;
             config.name = output.name;
             config.position = position;
             position.x = geom::X { position.x.as_int() + output.extents().size.width.as_int() };
@@ -396,6 +402,7 @@ private:
             config.orientation = output.orientation;
             config.scale = output.scale;
             config.group_id = mg::DisplayConfigurationLogicalGroupId(0);
+            enconutered_first = true;
             result.push_back(config);
         });
 
@@ -404,6 +411,7 @@ private:
 
     static void apply_internal(mg::DisplayConfiguration& conf, std::vector<OutputConfig> const& configs)
     {
+        bool has_had_primary = false;
         conf.for_each_output([&](mg::UserDisplayConfigurationOutput const& output)
         {
             if (!output.connected || output.modes.empty())
@@ -430,6 +438,15 @@ private:
             output.used = true;
             output.power_mode = mir_power_mode_on;
             output.orientation = mir_orientation_normal;
+
+            bool primary = false;
+            if (card.primary && !has_had_primary)
+            {
+                has_had_primary = true;
+                primary = true;
+            }
+
+            output.custom_attribute["primary"] = primary ? "true" : "false";
 
             if (card.position)
                 output.top_left = card.position.value();

--- a/src/display_config.h
+++ b/src/display_config.h
@@ -35,6 +35,7 @@ public:
     struct OutputConfig
     {
         bool enabled = false;
+        bool primary = false;
         std::string name;
         std::optional<mir::geometry::Point> position;
         std::optional<mir::geometry::Size> size;

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -162,6 +162,7 @@ Ipc::Ipc(miral::MirRunner& runner,
     // Set i3 IPC socket path so that i3-msg works out of the box
     setenv("I3SOCK", ipc_sockaddr->sun_path, 1);
     setenv("SWAYSOCK", ipc_sockaddr->sun_path, 1);
+    setenv("MIRACLESOCK", ipc_sockaddr->sun_path, 1);
 
     mir::log_info("Listening to IPC socket on path: %s", ipc_sockaddr->sun_path);
 

--- a/src/ipc_command.cpp
+++ b/src/ipc_command.cpp
@@ -18,8 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "container_scope.h"
 #define MIR_LOG_COMPONENT "ipc_command"
 
-#include "ipc.h"
 #include "ipc_command.h"
+#include "ipc_message_handler.h"
 
 #include <cctype>
 #include <mir/log.h>

--- a/src/ipc_command.cpp
+++ b/src/ipc_command.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ipc_command.h"
 #include "ipc_message_handler.h"
 
+#include <cassert>
 #include <cctype>
 #include <mir/log.h>
 #include <sstream>

--- a/src/ipc_command.cpp
+++ b/src/ipc_command.cpp
@@ -276,7 +276,9 @@ IpcParseResult IpcCommandParser::parse()
                 if (ss.str().empty())
                     break;
 
-                retval.commands.push_back({ command_from_string(ss.str()) });
+                retval.commands.push_back({ command_from_string(ss.str()),
+                    ss.str(),
+                    {}, {} });
                 ss = std::stringstream();
                 stack.pop_back();
                 can_parse_options = true;
@@ -339,7 +341,9 @@ IpcParseResult IpcCommandParser::parse()
             retval.commands.back().arguments.push_back(ss.str());
             break;
         case ParseState::command:
-            retval.commands.push_back({ command_from_string(ss.str()) });
+            retval.commands.push_back({ command_from_string(ss.str()),
+                ss.str(),
+                {}, {} });
             break;
         case ParseState::scope_key:
             retval.scope.push_back({ scope_from_string(ss.str()) });

--- a/src/ipc_command.h
+++ b/src/ipc_command.h
@@ -59,7 +59,8 @@ enum class IpcCommandType
 
 struct IpcCommand
 {
-    IpcCommandType type;
+    IpcCommandType const type;
+    std::string const raw_command;
     std::vector<std::string> options;
     std::vector<std::string> arguments;
 };

--- a/src/ipc_command_executor.cpp
+++ b/src/ipc_command_executor.cpp
@@ -115,60 +115,57 @@ IpcCommandExecutor::IpcCommandExecutor(
 {
 }
 
-IpcValidationResult IpcCommandExecutor::process(miracle::IpcParseResult const& command_list)
+std::vector<IpcValidationResult> IpcCommandExecutor::process(miracle::IpcParseResult const& command_list)
 {
-    IpcValidationResult result;
+    std::vector<IpcValidationResult> result;
     for (auto const& command : command_list.commands)
     {
         switch (command.type)
         {
         case IpcCommandType::exec:
-            result = process_exec(command, command_list);
+            result.push_back(process_exec(command, command_list));
             break;
         case IpcCommandType::split:
-            result = process_split(command, command_list);
+            result.push_back(process_split(command, command_list));
             break;
         case IpcCommandType::focus:
-            result = process_focus(command, command_list);
+            result.push_back(process_focus(command, command_list));
             break;
         case IpcCommandType::move:
-            result = process_move(command, command_list);
+            result.push_back(process_move(command, command_list));
             break;
         case IpcCommandType::sticky:
-            result = process_sticky(command, command_list);
+            result.push_back(process_sticky(command, command_list));
             break;
         case IpcCommandType::exit:
             policy->quit();
-            result = {};
+            result.push_back({ .success = true });
             break;
         case IpcCommandType::input:
-            result = process_input(command, command_list);
+            result.push_back(process_input(command, command_list));
             break;
         case IpcCommandType::workspace:
-            result = process_workspace(command, command_list);
+            result.push_back(process_workspace(command, command_list));
             break;
         case IpcCommandType::layout:
-            result = process_layout(command, command_list);
+            result.push_back(process_layout(command, command_list));
             break;
         case IpcCommandType::scratchpad:
-            result = process_scratchpad(command, command_list);
+            result.push_back(process_scratchpad(command, command_list));
             break;
         case IpcCommandType::resize:
-            result = process_resize(command, command_list);
+            result.push_back(process_resize(command, command_list));
             break;
         case IpcCommandType::reload:
-            result = process_reload(command, command_list);
+            result.push_back(process_reload(command, command_list));
             break;
         default:
-            result = parse_error(std::format("Unsupported command type: {}", (int)command.type));
+            result.push_back(parse_error(std::format("Unsupported command type: {}", command.raw_command)));
             break;
         }
-
-        if (!result.success)
-            return result;
     }
 
-    return {};
+    return result;
 }
 
 IpcValidationResult IpcCommandExecutor::parse_error(std::string error)

--- a/src/ipc_command_executor.cpp
+++ b/src/ipc_command_executor.cpp
@@ -101,7 +101,8 @@ public:
             // The 'next' item wasn't ppt or px, so let's pop out of it.
             if (!has_type_label)
                 prev();
-            return ParseMoveResult(true, move_type, amount);;
+            return ParseMoveResult(true, move_type, amount);
+            ;
         }
         catch (std::invalid_argument const& e)
         {
@@ -280,8 +281,8 @@ IpcValidationResult IpcCommandExecutor::process_focus(IpcCommand const& command,
     }
     else if (arg == "prev")
     {
-       if (!policy->try_select_prev(command_list.scope))
-           return IpcValidationResult::create_failure("Failed to select prev", false);
+        if (!policy->try_select_prev(command_list.scope))
+            return IpcValidationResult::create_failure("Failed to select prev", false);
 
         return IpcValidationResult::create_success();
     }
@@ -350,12 +351,11 @@ IpcValidationResult IpcCommandExecutor::process_focus(IpcCommand const& command,
 namespace
 {
 
-
 ParseMoveResult parse_move_distance(std::vector<std::string> const& arguments, int& index)
 {
     auto const size = arguments.size() - index;
     if (size <= 1)
-        return ParseMoveResult{false, ParseMoveResult::MoveType::invalid, 0};
+        return ParseMoveResult { false, ParseMoveResult::MoveType::invalid, 0 };
 
     try
     {
@@ -377,12 +377,12 @@ ParseMoveResult parse_move_distance(std::vector<std::string> const& arguments, i
             }
         }
 
-        return ParseMoveResult{true, move_type, amount};
+        return ParseMoveResult { true, move_type, amount };
     }
     catch (std::invalid_argument const& e)
     {
         mir::log_error("Invalid argument: %s", arguments[index].c_str());
-        return ParseMoveResult{false, ParseMoveResult::MoveType::invalid, 0};
+        return ParseMoveResult { false, ParseMoveResult::MoveType::invalid, 0 };
     }
 }
 }
@@ -793,35 +793,22 @@ ResizeAdjust parse_resize(ArgumentsIndexer& indexer, int multiplier)
     if (!indexer.next())
         return { .success = false, .error = "process_resize: expected argument after 'resize grow'" };
 
-    Direction direction;;
+    Direction direction;
+    ;
     if (indexer.current() == "width" || indexer.current() == "horizontal")
-    {
         direction = Direction::right;
-    }
     else if (indexer.current() == "height" || indexer.current() == "vertical")
-    {
         direction = Direction::down;
-    }
     else if (indexer.current() == "up")
-    {
         direction = Direction::up;
-    }
     else if (indexer.current() == "down")
-    {
         direction = Direction::down;
-    }
     else if (indexer.current() == "left")
-    {
         direction = Direction::left;
-    }
     else if (indexer.current() == "right")
-    {
         direction = Direction::right;
-    }
     else
-    {
         return { .success = false, .error = std::format("Unknown direction value: {}", indexer.current().c_str()) };
-    }
 
     auto const first_move_distance = indexer.parse_move_distance();
     if (!first_move_distance.success)
@@ -872,7 +859,13 @@ IpcValidationResult IpcCommandExecutor::process_resize(IpcCommand const& command
         if (!adjust.success)
             return IpcValidationResult::create_failure(adjust.error, true);
 
-        policy->try_resize(adjust.direction, adjust.first, command_list.scope);
+        if (!adjust.first.has_value())
+            return IpcValidationResult::create_failure("Expected a value after 'grow'", true);
+
+        if (adjust.first->move_type == ParseMoveResult::MoveType::ppt)
+            policy->try_resize_ppt(adjust.direction, adjust.first->amount, command_list.scope);
+        else
+            policy->try_resize(adjust.direction, adjust.first->amount, command_list.scope);
         return IpcValidationResult::create_success();
     }
     else if (arg0 == "shrink")
@@ -881,7 +874,13 @@ IpcValidationResult IpcCommandExecutor::process_resize(IpcCommand const& command
         if (!adjust.success)
             return IpcValidationResult::create_failure(adjust.error, true);
 
-        policy->try_resize(adjust.direction, adjust.first, command_list.scope);
+        if (!adjust.first.has_value())
+            return IpcValidationResult::create_failure("Expected a value after 'shrink'", true);
+
+        if (adjust.first->move_type == ParseMoveResult::MoveType::ppt)
+            policy->try_resize_ppt(adjust.direction, adjust.first->amount, command_list.scope);
+        else
+            policy->try_resize(adjust.direction, adjust.first->amount, command_list.scope);
         return IpcValidationResult::create_success();
     }
     else if (arg0 == "set")
@@ -890,7 +889,12 @@ IpcValidationResult IpcCommandExecutor::process_resize(IpcCommand const& command
         if (!result.success)
             return IpcValidationResult::create_failure(result.error, true);
 
-        policy->try_set_size(result.width, result.height, command_list.scope);
+        policy->try_set_size(
+            result.width.amount,
+            result.width.move_type == ParseMoveResult::MoveType::ppt,
+            result.height.amount,
+            result.height.move_type == ParseMoveResult::MoveType::ppt,
+            command_list.scope);
         return IpcValidationResult::create_success();
     }
     else

--- a/src/ipc_command_executor.cpp
+++ b/src/ipc_command_executor.cpp
@@ -15,6 +15,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
+#define MIR_LOG_COMPONENT "miracle"
+
 #include "ipc_command_executor.h"
 #include "auto_restarting_launcher.h"
 #include "command_controller.h"
@@ -25,9 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "parent_container.h"
 #include "utility_general.h"
 #include "window_controller.h"
-#include "window_helpers.h"
 
-#define MIR_LOG_COMPONENT "miracle"
 #include <format>
 #include <mir/log.h>
 #include <miral/application_info.h>
@@ -115,7 +115,7 @@ IpcCommandExecutor::IpcCommandExecutor(
 {
 }
 
-std::vector<IpcValidationResult> IpcCommandExecutor::process(miracle::IpcParseResult const& command_list)
+std::vector<IpcValidationResult> IpcCommandExecutor::process(IpcParseResult const& command_list)
 {
     std::vector<IpcValidationResult> result;
     for (auto const& command : command_list.commands)
@@ -139,7 +139,7 @@ std::vector<IpcValidationResult> IpcCommandExecutor::process(miracle::IpcParseRe
             break;
         case IpcCommandType::exit:
             policy->quit();
-            result.push_back({ .success = true });
+            result.push_back(IpcValidationResult::create_success());
             break;
         case IpcCommandType::input:
             result.push_back(process_input(command, command_list));
@@ -160,7 +160,7 @@ std::vector<IpcValidationResult> IpcCommandExecutor::process(miracle::IpcParseRe
             result.push_back(process_reload(command, command_list));
             break;
         default:
-            result.push_back(parse_error(std::format("Unsupported command type: {}", command.raw_command)));
+            result.push_back(IpcValidationResult::create_failure(std::format("Unsupported command type: {}", command.raw_command), true));
             break;
         }
     }
@@ -168,27 +168,17 @@ std::vector<IpcValidationResult> IpcCommandExecutor::process(miracle::IpcParseRe
     return result;
 }
 
-IpcValidationResult IpcCommandExecutor::parse_error(std::string error)
-{
-    mir::log_error("Parse Error: %s", error.c_str());
-    return {
-        .success = false,
-        .parse_error = true,
-        .error = std::move(error)
-    };
-}
-
-IpcValidationResult IpcCommandExecutor::process_exec(miracle::IpcCommand const& command, miracle::IpcParseResult const& command_list)
+IpcValidationResult IpcCommandExecutor::process_exec(IpcCommand const& command, IpcParseResult const&)
 {
     if (command.arguments.empty())
-        return parse_error("process_exec: no arguments were supplied");
+        return IpcValidationResult::create_failure("No arguments were supplied", false);
 
     bool no_startup_id = false;
     if (!command.options.empty() && command.options[0] == "--no-startup-id")
         no_startup_id = true;
 
     if (command.arguments.empty())
-        return parse_error("process_exec: argument does not have a command to run");
+        return IpcValidationResult::create_failure("Argument does not have a command to run", false);
 
     std::string exec_cmd;
     for (auto const& arg : command.arguments)
@@ -196,15 +186,15 @@ IpcValidationResult IpcCommandExecutor::process_exec(miracle::IpcCommand const& 
         exec_cmd += arg + " ";
     }
 
-    StartupApp app { exec_cmd, false, no_startup_id };
+    StartupApp const app { exec_cmd, false, no_startup_id };
     launcher.launch(app);
-    return {};
+    return IpcValidationResult::create_success();
 }
 
 IpcValidationResult IpcCommandExecutor::process_split(IpcCommand const& command, IpcParseResult const& command_list)
 {
     if (command.arguments.empty())
-        return parse_error("process_split: no arguments were supplied");
+        return IpcValidationResult::create_failure("No arguments were supplied", false);
 
     if (command.arguments.front() == "vertical")
     {
@@ -220,10 +210,10 @@ IpcValidationResult IpcCommandExecutor::process_split(IpcCommand const& command,
     }
     else
     {
-        return parse_error(std::format("process_split: unknown argument {}", command.arguments.front().c_str()));
+        return IpcValidationResult::create_failure(std::format("Unknown argument {}", command.arguments.front().c_str()), false);
     }
 
-    return {};
+    return IpcValidationResult::create_success();
 }
 
 IpcValidationResult IpcCommandExecutor::process_focus(IpcCommand const& command, IpcParseResult const& command_list)
@@ -232,17 +222,17 @@ IpcValidationResult IpcCommandExecutor::process_focus(IpcCommand const& command,
     if (command.arguments.empty())
     {
         if (command_list.scope.empty())
-            return parse_error("Focus command expected scope but none was provided");
+            return IpcValidationResult::create_failure("Focus command expected scope but none was provided", false);
 
         policy->try_select(command_list.scope);
-        return {};
+        return IpcValidationResult::create_success();
     }
 
     auto const& arg = command.arguments.front();
     if (arg == "workspace")
     {
         if (command_list.scope.empty())
-            return parse_error("Focus 'workspace' command expected scope but none was provided");
+            return IpcValidationResult::create_failure("Focus 'workspace' command expected scope but none was provided", false);
 
         policy->select_workspace_with_scope(command_list.scope);
     }
@@ -263,10 +253,10 @@ IpcValidationResult IpcCommandExecutor::process_focus(IpcCommand const& command,
         // TODO: Move this to the policy because this is racy
         auto const container = state->focused_container();
         if (!container)
-            return parse_error("Active container does not exist");
+            return IpcValidationResult::create_failure("Active container does not exist", false);
 
         if (container->get_type() != ContainerType::leaf)
-            return parse_error("Cannot focus prev when a tiling window is not selected");
+            return IpcValidationResult::create_failure("Cannot focus prev when a tiling window is not selected", false);
 
         if (auto const parent = Container::as_parent(container->get_parent().lock()))
         {
@@ -283,10 +273,10 @@ IpcValidationResult IpcCommandExecutor::process_focus(IpcCommand const& command,
         // TODO: Move this to the policy because this is racy
         auto const container = state->focused_container();
         if (!container)
-            return parse_error("No container is selected");
+            return IpcValidationResult::create_failure("No container is selected", false);
 
         if (container->get_type() != ContainerType::leaf)
-            return parse_error("Cannot focus prev when a tiling window is not selected");
+            return IpcValidationResult::create_failure("Cannot focus prev when a tiling window is not selected", false);
 
         if (auto const parent = Container::as_parent(container->get_parent().lock()))
         {
@@ -307,7 +297,7 @@ IpcValidationResult IpcCommandExecutor::process_focus(IpcCommand const& command,
     else if (arg == "output")
     {
         if (command.arguments.size() < 2)
-            return parse_error("process_focus: 'focus output' must have more than two arguments");
+            return IpcValidationResult::create_failure("'focus output' must have more than two arguments", true);
 
         auto const& arg1 = command.arguments[1];
         if (arg1 == "next")
@@ -329,14 +319,14 @@ IpcValidationResult IpcCommandExecutor::process_focus(IpcCommand const& command,
         }
     }
 
-    return {};
+    return IpcValidationResult::create_success();
 }
 
 namespace
 {
 bool parse_move_distance(std::vector<std::string> const& arguments, int& index, int total_size, int& out)
 {
-    auto size = arguments.size() - index;
+    auto const size = arguments.size() - index;
     if (size <= 1)
         return false;
 
@@ -348,8 +338,8 @@ bool parse_move_distance(std::vector<std::string> const& arguments, int& index, 
             // We default to assuming the value is in pixels
             if (arguments[index + 1] == "ppt")
             {
-                float ppt = static_cast<float>(out) / 100.f;
-                out = (float)total_size * ppt;
+                float const ppt = static_cast<float>(out) / 100.f;
+                out = static_cast<float>(total_size) * ppt;
             }
         }
 
@@ -367,11 +357,11 @@ IpcValidationResult IpcCommandExecutor::process_move(IpcCommand const& command, 
 {
     auto const& active_output = output_manager->focused();
     if (!active_output)
-        return parse_error("process_move: output is not set");
+        return IpcValidationResult::create_failure("process_move: output is not set", false);
 
     // https://i3wm.org/docs/userguide.html#_focusing_moving_containers
     if (command.arguments.empty())
-        return parse_error("process_move: move command expects arguments");
+        return IpcValidationResult::create_failure("process_move: move command expects arguments", false);
 
     int index = 0;
     auto const& arg0 = command.arguments[index++];
@@ -397,19 +387,30 @@ IpcValidationResult IpcCommandExecutor::process_move(IpcCommand const& command, 
         direction = Direction::down;
         total_size = active_output->get_area().size.height.as_int();
     }
-    else if (arg0 == "position")
+
+    if (direction < Direction::MAX)
+    {
+        int move_distance;
+        if (parse_move_distance(command.arguments, index, total_size, move_distance))
+            policy->try_move_by(direction, move_distance, command_list.scope);
+        else
+            policy->try_move(direction, command_list.scope);
+        return IpcValidationResult::create_success();
+    }
+
+    if (arg0 == "position")
     {
         if (command.arguments.size() < 2)
-            return parse_error("process_move: move position expected a third argument");
+            return IpcValidationResult::create_failure("move position expected a third argument", true);
 
         auto const& arg1 = command.arguments[index++];
         if (arg1 == "center")
         {
-            auto active = state->focused_container().get();
-            auto area = active_output->get_area();
-            float x = (float)area.size.width.as_int() / 2.f - (float)active->get_visible_area().size.width.as_int() / 2.f;
-            float y = (float)area.size.height.as_int() / 2.f - (float)active->get_visible_area().size.height.as_int() / 2.f;
-            policy->try_move_to((int)x, (int)y, command_list.scope);
+            auto const active = state->focused_container().get();
+            auto const area = active_output->get_area();
+            float const x = static_cast<float>(area.size.width.as_int()) / 2.f - static_cast<float>(active->get_visible_area().size.width.as_int()) / 2.f;
+            float const y = static_cast<float>(area.size.height.as_int()) / 2.f - static_cast<float>(active->get_visible_area().size.height.as_int()) / 2.f;
+            policy->try_move_to(static_cast<int>(x), static_cast<int>(y), command_list.scope);
         }
         else if (arg1 == "mouse")
         {
@@ -422,56 +423,56 @@ IpcValidationResult IpcCommandExecutor::process_move(IpcCommand const& command, 
             int move_distance_y;
 
             if (!parse_move_distance(command.arguments, index, total_size, move_distance_x))
-                return parse_error("process_move: move position <x> <y>: unable to parse x");
+                return IpcValidationResult::create_failure("move position <x> <y>: unable to parse x", true);
 
             if (!parse_move_distance(command.arguments, index, total_size, move_distance_y))
-                return parse_error("process_move: move position <x> <y>: unable to parse y");
+                return IpcValidationResult::create_failure("move position <x> <y>: unable to parse y", true);
 
             policy->try_move_to(move_distance_x, move_distance_y, command_list.scope);
         }
 
-        return {};
+        return IpcValidationResult::create_success();
     }
     else if (arg0 == "absolute")
     {
         auto const& arg1 = command.arguments[index++];
         auto const& arg2 = command.arguments[index++];
         if (arg1 != "position")
-            return parse_error("process_move: move [absolute] ... expected 'position' as the third argument");
+            return IpcValidationResult::create_failure("move [absolute] ... expected 'position' as the third argument", true);
 
         if (arg2 != "center")
-            return parse_error("process_move: move absolute position ... expected 'center' as the third argument");
+            return IpcValidationResult::create_failure("move absolute position ... expected 'center' as the third argument", true);
 
         float x = 0, y = 0;
         for (auto const& output : output_manager->outputs())
         {
             auto area = output->get_area();
-            float end_x = (float)area.size.width.as_int() + (float)area.top_left.x.as_int();
-            float end_y = (float)area.size.height.as_int() + (float)area.top_left.y.as_int();
+            float const end_x = static_cast<float>(area.size.width.as_int() + area.top_left.x.as_int());
+            float const end_y = static_cast<float>(area.size.height.as_int() + area.top_left.y.as_int());
             if (end_x > x)
                 x = end_x;
             if (end_y > y)
                 y = end_y;
         }
 
-        auto active = state->focused_container();
-        float x_pos = x / 2.f - (float)active->get_visible_area().size.width.as_int() / 2.f;
-        float y_pos = y / 2.f - (float)active->get_visible_area().size.height.as_int() / 2.f;
-        policy->try_move_to((int)x_pos, (int)y_pos, command_list.scope);
-        return {};
+        auto const active = state->focused_container();
+        float const x_pos = x / 2.f - static_cast<float>(active->get_visible_area().size.width.as_int()) / 2.f;
+        float const y_pos = y / 2.f - static_cast<float>(active->get_visible_area().size.height.as_int()) / 2.f;
+        policy->try_move_to(static_cast<int>(x_pos), static_cast<int>(y_pos), command_list.scope);
+        return IpcValidationResult::create_success();
     }
     else if (arg0 == "window" || arg0 == "container")
     {
         auto const back_and_forth = std::find(command.options.begin(), command.options.end(), "--no-auto-back-and-forth") == command.options.end();
         auto const& arg1 = command.arguments[index++];
         if (arg1 != "to")
-            return parse_error("process_move: expected 'to' after 'move window/container ...'");
+            return IpcValidationResult::create_failure("Expected 'to' after 'move window/container ...'", true);
 
         auto const& arg2 = command.arguments[index++];
         if (arg2 == "workspace")
         {
             if (command.arguments.size() <= 3)
-                return parse_error("process_move: expected another argument after 'move container/window to output...'");
+                return IpcValidationResult::create_failure("Expected another argument after 'move container/window to output...'", true);
 
             auto const& arg3 = command.arguments[index++];
             int number = -1;
@@ -479,17 +480,17 @@ IpcValidationResult IpcCommandExecutor::process_move(IpcCommand const& command, 
             {
                 // TODO: Do we need to care about the name here?
                 policy->move_active_to_workspace(number, back_and_forth);
-                return {};
+                return IpcValidationResult::create_success();
             }
             else if (arg3 == "next")
             {
                 policy->move_active_to_next_workspace();
-                return {};
+                return IpcValidationResult::create_success();
             }
             else if (arg3 == "prev")
             {
                 policy->move_active_to_prev_workspace();
-                return {};
+                return IpcValidationResult::create_success();
             }
             else if (arg3 == "current")
             {
@@ -498,21 +499,18 @@ IpcValidationResult IpcCommandExecutor::process_move(IpcCommand const& command, 
             else if (arg3 == "back_and_forth")
             {
                 policy->move_active_to_back_and_forth();
-                return {};
+                return IpcValidationResult::create_success();
             }
             else
             {
                 policy->move_active_to_workspace_named(arg3, back_and_forth);
-                return {};
+                return IpcValidationResult::create_success();
             }
         }
         else if (arg2 == "output")
         {
             if (command.arguments.size() <= 3)
-            {
-                mir::log_error("process_move: expected another argument after 'move container/window to output...'");
-                return {};
-            }
+                return IpcValidationResult::create_failure("Expected another argument after 'move container/window to output...'", true);
 
             auto const& arg3 = command.arguments[index++];
             if (arg3 == "left")
@@ -536,30 +534,24 @@ IpcValidationResult IpcCommandExecutor::process_move(IpcCommand const& command, 
                 auto names = std::vector<std::string>(command.arguments.begin() + index - 1, command.arguments.end());
                 policy->try_move_active(names);
             }
+            return IpcValidationResult::create_success();
         }
+
+        return IpcValidationResult::create_failure("Expected workspace/output after 'move container/window to ...'", true);
     }
     else if (arg0 == "scratchpad")
     {
         policy->move_to_scratchpad();
-        return {};
+        return IpcValidationResult::create_success();
     }
 
-    if (direction < Direction::MAX)
-    {
-        int move_distance;
-        if (parse_move_distance(command.arguments, index, total_size, move_distance))
-            policy->try_move_by(direction, move_distance, command_list.scope);
-        else
-            policy->try_move(direction, command_list.scope);
-    }
-
-    return {};
+    return IpcValidationResult::create_failure("Expected left/right/up/down/position/absolute/window/container/scratchpad after 'move ...'", true);
 }
 
 IpcValidationResult IpcCommandExecutor::process_sticky(IpcCommand const& command, IpcParseResult const& command_list)
 {
     if (command.arguments.empty())
-        return parse_error("process_sticky: expects arguments");
+        return IpcValidationResult::create_failure("'sticky' expects arguments", true);
 
     auto const& arg0 = command.arguments[0];
     if (arg0 == "enable")
@@ -569,9 +561,9 @@ IpcValidationResult IpcCommandExecutor::process_sticky(IpcCommand const& command
     else if (arg0 == "toggle")
         policy->toggle_pinned_to_workspace({});
     else
-        mir::log_warning("process_sticky: unknown arguments: %s", arg0.c_str());
+        return IpcValidationResult::create_failure("Expected enable/disable/toggle after 'sticky'", true);
 
-    return {};
+    return IpcValidationResult::create_success();
 }
 
 IpcValidationResult IpcCommandExecutor::process_input(IpcCommand const& command, IpcParseResult const& command_list)
@@ -582,28 +574,31 @@ IpcValidationResult IpcCommandExecutor::process_input(IpcCommand const& command,
     // and Z is the value of that variable. Z may not be included at all, in which
     // case the variable is set to the default.
     if (command.arguments.size() < 2)
-        return parse_error("process_input: expects at least 2 arguments");
+        return IpcValidationResult::create_failure("Expected at least 2 arguments for 'input'", true);
 
-    const char* const TYPE_PREFIX = "type:";
+    constexpr char* const TYPE_PREFIX = "type:";
     const size_t TYPE_PREFIX_LEN = strlen(TYPE_PREFIX);
     std::string_view type_str = command.arguments[0];
     if (!type_str.starts_with("type:"))
-        return parse_error(std::format("process_input: 'type' string is misformatted: {}", command.arguments[0].c_str()));
+        return IpcValidationResult::create_failure(std::format("'type' string is misformatted: {}", command.arguments[0].c_str()), true);
 
-    std::string_view type = type_str.substr(TYPE_PREFIX_LEN);
+    std::string_view const type = type_str.substr(TYPE_PREFIX_LEN);
     assert(type == "keyboard");
 
-    std::string_view xkb_str = command.arguments[1];
-    const char* const XKB_PREFIX = "xkb_";
+    std::string_view const xkb_str = command.arguments[1];
+    constexpr char* const XKB_PREFIX = "xkb_";
     const size_t XKB_PREFIX_LEN = strlen(XKB_PREFIX);
     if (!xkb_str.starts_with(XKB_PREFIX))
-        return parse_error(std::format("process_input: 'xkb' string is misformatted: {}", command.arguments[1].c_str()));
+        return IpcValidationResult::create_failure(std::format("'xkb' string is misformatted: {}", command.arguments[1].c_str()), true);
 
-    std::string_view xkb_variable_name = xkb_str.substr(XKB_PREFIX_LEN);
-    assert(xkb_variable_name == "model"
-        || xkb_variable_name == "layout"
-        || xkb_variable_name == "variant"
-        || xkb_variable_name == "options");
+    std::string_view const xkb_variable_name = xkb_str.substr(XKB_PREFIX_LEN);
+    if (xkb_variable_name != "model"
+        && xkb_variable_name != "layout"
+        && xkb_variable_name != "variant"
+        && xkb_variable_name != "options")
+    {
+        return IpcValidationResult::create_failure("Expected xkb variable name to be xkb_model, xkb_layout, xkb_variant, or xkb_options", true);
+    }
 
     mir::log_info("Processing input from locale1: type=%s, xkb_variable=%s", type.data(), xkb_variable_name.data());
 
@@ -616,68 +611,77 @@ IpcValidationResult IpcCommandExecutor::process_input(IpcCommand const& command,
         // TODO: Set to the default
     }
     else
-    {
-        return parse_error("process_input: > 3 arguments were provided but only <= 3 are expected");
-    }
+        return IpcValidationResult::create_failure("Received > 3 arguments for 'input' command but only <= 3 are expected", true);
 
-    return {};
+    return IpcValidationResult::create_success();
 }
 
-IpcValidationResult IpcCommandExecutor::process_workspace(IpcCommand const& command, IpcParseResult const& command_list)
+IpcValidationResult IpcCommandExecutor::process_workspace(IpcCommand const& command, IpcParseResult const&)
 {
     if (command.arguments.empty())
-        return parse_error("process_workspace: no arguments provided");
+        return IpcValidationResult::create_failure("Expected arguments for 'workspace' command", true);
 
     std::string const& arg0 = command.arguments[0];
     if (arg0 == "next")
+    {
         policy->next_workspace();
+        return IpcValidationResult::create_success();
+    }
     else if (arg0 == "prev")
+    {
         policy->prev_workspace();
+        return IpcValidationResult::create_success();
+    }
     else if (arg0 == "next_on_output")
     {
         if (auto const& output = output_manager->focused())
+        {
             policy->next_workspace_on_output(*output);
+            return IpcValidationResult::create_success();
+        }
         else
-            mir::log_error("process_workspace: next_on_output has no output to go next on");
+            return IpcValidationResult::create_failure("'workspace next_on_output' has no output to go next on", false);
     }
     else if (arg0 == "prev_on_output")
     {
         if (auto const& output = output_manager->focused())
+        {
             policy->prev_workspace_on_output(*output);
+            return IpcValidationResult::create_success();
+        }
         else
-            mir::log_error("process_workspace: prev_on_output has no output to go prev on");
+            return IpcValidationResult::create_failure("'workspace prev_on_output' has no output to go prev on", false);
     }
     else if (arg0 == "back_and_forth")
     {
         policy->back_and_forth_workspace();
+        return IpcValidationResult::create_success();
+    }
+
+    std::string const* arg1 = &arg0;
+    auto const back_and_forth = std::ranges::find(command.options, "--no-auto-back-and-forth") == command.options.end();
+
+    int number = -1;
+    if (try_get_number(*arg1, number))
+    {
+        // Check if we just have "workspace number"
+        if (command.arguments.size() < 3)
+        {
+            policy->select_workspace(number, back_and_forth);
+            return IpcValidationResult::create_success();
+        }
+
+        // We have "workspace number <name>"
+        arg1 = &command.arguments[2];
+        policy->select_workspace(*arg1, back_and_forth);
+        return IpcValidationResult::create_success();
     }
     else
     {
-        std::string const* arg1 = &arg0;
-        auto const back_and_forth = std::find(command.options.begin(), command.options.end(), "--no-auto-back-and-forth") == command.options.end();
-
-        int number = -1;
-        if (try_get_number(*arg1, number))
-        {
-            // Check if we just have "workspace number"
-            if (command.arguments.size() < 3)
-            {
-                policy->select_workspace(number, back_and_forth);
-                return {};
-            }
-
-            // We have "workspace number <name>"
-            arg1 = &command.arguments[2];
-            policy->select_workspace(*arg1, back_and_forth);
-        }
-        else
-        {
-            // We have "workspace <name>"
-            policy->select_workspace(*arg1, back_and_forth);
-        }
+        // We have "workspace <name>"
+        policy->select_workspace(*arg1, back_and_forth);
+        return IpcValidationResult::create_success();
     }
-
-    return {};
 }
 
 IpcValidationResult IpcCommandExecutor::process_layout(IpcCommand const& command, IpcParseResult const& command_list)
@@ -685,117 +689,155 @@ IpcValidationResult IpcCommandExecutor::process_layout(IpcCommand const& command
     // https://i3wm.org/docs/userguide.html#manipulating_layout
     std::string const& arg0 = command.arguments[0];
     if (arg0 == "default")
+    {
         policy->set_layout_default({});
+        return IpcValidationResult::create_success();
+    }
     else if (arg0 == "tabbed")
+    {
         policy->set_layout(LayoutScheme::tabbing, {});
+        return IpcValidationResult::create_success();
+    }
     else if (arg0 == "stacking")
+    {
         policy->set_layout(LayoutScheme::stacking, {});
+        return IpcValidationResult::create_success();
+    }
     else if (arg0 == "splitv")
+    {
         policy->set_layout(LayoutScheme::vertical, {});
+        return IpcValidationResult::create_success();
+    }
     else if (arg0 == "splith")
+    {
         policy->set_layout(LayoutScheme::horizontal, {});
+        return IpcValidationResult::create_success();
+    }
     else if (arg0 == "toggle")
     {
         if (command.arguments.size() == 1)
-            return parse_error("process_layout: expected argument after 'layout toggle ...'");
+            return IpcValidationResult::create_failure("Expected argument after 'layout toggle ...'", true);
 
         if (command.arguments.size() == 2)
         {
             auto const& arg1 = command.arguments[1];
             if (arg1 == "split")
+            {
                 policy->try_toggle_layout(false, command_list.scope);
+                return IpcValidationResult::create_success();
+            }
             else if (arg1 == "all")
+            {
                 policy->try_toggle_layout(true, command_list.scope);
-            else
-                return parse_error("process_layout: expected split/all after 'layout toggle X'");
+                return IpcValidationResult::create_success();
+            }
 
-            return {};
+            return IpcValidationResult::create_failure("Expected split/all after 'layout toggle X'", true);
+        }
+
+        auto const container = state->focused_container();
+        if (!container)
+            return IpcValidationResult::create_failure("Container unavailable during 'layout'", false);
+
+        auto const current_type = container->get_layout();
+        size_t index = 0;
+        for (size_t i = 1; i < command.arguments.size(); i++)
+        {
+            auto const& argn = command.arguments[i];
+            if (argn == "split")
+            {
+                if (current_type == LayoutScheme::horizontal || current_type == LayoutScheme::vertical)
+                {
+                    index = i;
+                    break;
+                }
+            }
+            else if (argn == "tabbed")
+            {
+                if (current_type == LayoutScheme::tabbing)
+                {
+                    index = i;
+                    break;
+                }
+            }
+            else if (argn == "stacking")
+            {
+                if (current_type == LayoutScheme::stacking)
+                {
+                    index = i;
+                    break;
+                }
+            }
+            else if (argn == "splitv")
+            {
+                if (current_type == LayoutScheme::vertical)
+                {
+                    index = i;
+                    break;
+                }
+            }
+            else if (argn == "splith")
+            {
+                if (current_type == LayoutScheme::horizontal)
+                {
+                    index = i;
+                    break;
+                }
+            }
+        }
+
+        index++;
+        if (index == command.arguments.size())
+            index = 1;
+
+        auto const& target = command.arguments[index];
+        if (target == "split")
+        {
+            policy->try_toggle_layout(false, command_list.scope);
+            return IpcValidationResult::create_success();
+        }
+        else if (target == "tabbed")
+        {
+            policy->set_layout(LayoutScheme::tabbing, {});
+            return IpcValidationResult::create_success();
+        }
+        else if (target == "stacking")
+        {
+            policy->set_layout(LayoutScheme::stacking, {});
+            return IpcValidationResult::create_success();
+        }
+        else if (target == "splitv")
+        {
+            policy->set_layout(LayoutScheme::vertical, {});
+            return IpcValidationResult::create_success();
+        }
+        else if (target == "splith")
+        {
+            policy->set_layout(LayoutScheme::horizontal, {});
+            return IpcValidationResult::create_success();
         }
         else
         {
-            auto container = state->focused_container();
-            if (!container)
-                return parse_error("process_layout: container unavailable");
-
-            auto current_type = container->get_layout();
-            size_t index = 0;
-            for (size_t i = 1; i < command.arguments.size(); i++)
-            {
-                auto const& argn = command.arguments[i];
-                if (argn == "split")
-                {
-                    if (current_type == LayoutScheme::horizontal || current_type == LayoutScheme::vertical)
-                    {
-                        index = i;
-                        break;
-                    }
-                }
-                else if (argn == "tabbed")
-                {
-                    if (current_type == LayoutScheme::tabbing)
-                    {
-                        index = i;
-                        break;
-                    }
-                }
-                else if (argn == "stacking")
-                {
-                    if (current_type == LayoutScheme::stacking)
-                    {
-                        index = i;
-                        break;
-                    }
-                }
-                else if (argn == "splitv")
-                {
-                    if (current_type == LayoutScheme::vertical)
-                    {
-                        index = i;
-                        break;
-                    }
-                }
-                else if (argn == "splith")
-                {
-                    if (current_type == LayoutScheme::horizontal)
-                    {
-                        index = i;
-                        break;
-                    }
-                }
-            }
-
-            index++;
-            if (index == command.arguments.size())
-                index = 1;
-
-            auto const& target = command.arguments[index];
-            if (target == "split")
-                policy->try_toggle_layout(false, command_list.scope);
-            else if (target == "tabbed")
-                policy->set_layout(LayoutScheme::tabbing, {});
-            else if (target == "stacking")
-                policy->set_layout(LayoutScheme::stacking, {});
-            else if (target == "splitv")
-                policy->set_layout(LayoutScheme::vertical, {});
-            else if (target == "splith")
-                policy->set_layout(LayoutScheme::horizontal, {});
+            return IpcValidationResult::create_failure(std::format("Unknown argument to 'layout' command, {}", target), true);
         }
     }
-
-    return {};
+    else
+    {
+        return IpcValidationResult::create_failure("Expected default/tabbed/stacking/splitv/splith/toggle after 'layout'", true);
+    }
 }
 
-IpcValidationResult IpcCommandExecutor::process_scratchpad(IpcCommand const& command, IpcParseResult const& command_list)
+IpcValidationResult IpcCommandExecutor::process_scratchpad(IpcCommand const& command, IpcParseResult const&)
 {
     if (command.arguments.empty())
-        return parse_error("process_scratchpad: no arguments provided");
+        return IpcValidationResult::create_failure("No arguments provided to 'scratchpad' command", true);
 
     std::string const& arg0 = command.arguments[0];
     if (arg0 != "show")
-        return parse_error("process_scratchpad: all scratchpad commands must be 'scratchpad show'");
+        return IpcValidationResult::create_failure("Expected 'show' after 'scratchpad'", true);
 
     policy->show_scratchpad();
-    return {};
+    return IpcValidationResult::create_success();
 }
 
 namespace
@@ -911,45 +953,46 @@ SetResizeResult parse_set_resize(std::shared_ptr<CompositorState> const& state, 
 IpcValidationResult IpcCommandExecutor::process_resize(IpcCommand const& command, IpcParseResult const& command_list)
 {
     if (command.arguments.empty())
-        return parse_error("process_resize: no arguments provided");
+        return IpcValidationResult::create_failure("Expected arguments to be provided to 'resize'", true);
 
     ArgumentsIndexer indexer(command);
     auto const& arg0 = indexer.current();
     if (arg0 == "grow")
     {
-        auto adjust = parse_resize(state, indexer, 1);
+        auto const adjust = parse_resize(state, indexer, 1);
         if (!adjust.success)
-            return parse_error(adjust.error);
+            return IpcValidationResult::create_failure(adjust.error, true);
 
         policy->try_resize(adjust.direction, adjust.first, command_list.scope);
+        return IpcValidationResult::create_success();
     }
     else if (arg0 == "shrink")
     {
-        auto adjust = parse_resize(state, indexer, -1);
+        auto const adjust = parse_resize(state, indexer, -1);
         if (!adjust.success)
-            return parse_error(adjust.error);
+            return IpcValidationResult::create_failure(adjust.error, true);
 
         policy->try_resize(adjust.direction, adjust.first, command_list.scope);
+        return IpcValidationResult::create_success();
     }
     else if (arg0 == "set")
     {
-        auto result = parse_set_resize(state, indexer);
+        auto const result = parse_set_resize(state, indexer);
         if (!result.success)
-            return parse_error(result.error);
+            return IpcValidationResult::create_failure(result.error, true);
 
         policy->try_set_size(result.width, result.height, command_list.scope);
+        return IpcValidationResult::create_success();
     }
     else
-        return parse_error(std::format("process_resize: unexpected argument: {}", arg0.c_str()));
-
-    return {};
+        return IpcValidationResult::create_failure(std::format("Encountered unexpected argument during 'resize': {}", arg0.c_str()), true);
 }
 
 IpcValidationResult IpcCommandExecutor::process_reload(IpcCommand const& command, IpcParseResult const&)
 {
     if (!command.arguments.empty())
-        return parse_error("'reload' command expects no arguments");
+        return IpcValidationResult::create_failure("'reload' command expects no arguments", true);
 
     policy->reload_config();
-    return {};
+    return IpcValidationResult::create_success();
 }

--- a/src/ipc_command_executor.cpp
+++ b/src/ipc_command_executor.cpp
@@ -36,6 +36,18 @@ using namespace miracle;
 
 namespace
 {
+struct ParseMoveResult
+{
+    bool const success;
+    enum class MoveType
+    {
+        pixel,
+        ppt,
+        invalid
+    } const move_type;
+    float const amount;
+};
+
 class ArgumentsIndexer
 {
 public:
@@ -61,37 +73,40 @@ public:
         return command.arguments[index];
     }
 
-    bool parse_move_distance(int available_area, int& out)
+    ParseMoveResult parse_move_distance()
     {
         if (!next())
-            return false;
+            return ParseMoveResult(false, ParseMoveResult::MoveType::invalid, 0);
 
         try
         {
-            out = std::stoi(current());
+            auto move_type = ParseMoveResult::MoveType::pixel;
+            float amount = std::stoi(current());
+            bool has_type_label = false;
             if (next())
             {
                 // We default to assuming the value is in pixels
                 if (current() == "ppt")
                 {
-                    float ppt = static_cast<float>(out) / 100.f;
-                    out = static_cast<float>(available_area) * ppt;
-                    return true;
+                    amount = amount / 100.f;
+                    move_type = ParseMoveResult::MoveType::pixel;
+                    has_type_label = true;
                 }
                 else if (current() == "px")
                 {
-                    return true;
+                    has_type_label = true;
                 }
             }
 
             // The 'next' item wasn't ppt or px, so let's pop out of it.
-            prev();
-            return true;
+            if (!has_type_label)
+                prev();
+            return ParseMoveResult(true, move_type, amount);;
         }
         catch (std::invalid_argument const& e)
         {
             mir::log_error("Invalid argument: %s", command.arguments[index].c_str());
-            return false;
+            return ParseMoveResult(false, ParseMoveResult::MoveType::invalid, 0);
         }
     }
 
@@ -103,13 +118,9 @@ protected:
 
 IpcCommandExecutor::IpcCommandExecutor(
     std::shared_ptr<CommandController> const& policy,
-    std::shared_ptr<OutputManager> const& output_manager,
-    std::shared_ptr<CompositorState> const& state,
     AutoRestartingLauncher& launcher,
     std::shared_ptr<WindowController> const& window_controller) :
     policy { policy },
-    output_manager { output_manager },
-    state { state },
     launcher { launcher },
     window_controller { window_controller }
 {
@@ -235,58 +246,51 @@ IpcValidationResult IpcCommandExecutor::process_focus(IpcCommand const& command,
             return IpcValidationResult::create_failure("Focus 'workspace' command expected scope but none was provided", false);
 
         policy->select_workspace_with_scope(command_list.scope);
+        return IpcValidationResult::create_success();
     }
     else if (arg == "left")
+    {
         policy->try_select(Direction::left, command_list.scope);
+        return IpcValidationResult::create_success();
+    }
     else if (arg == "right")
+    {
         policy->try_select(Direction::right, command_list.scope);
+        return IpcValidationResult::create_success();
+    }
     else if (arg == "up")
+    {
         policy->try_select(Direction::up, command_list.scope);
+        return IpcValidationResult::create_success();
+    }
     else if (arg == "down")
+    {
         policy->try_select(Direction::down, command_list.scope);
+        return IpcValidationResult::create_success();
+    }
     else if (arg == "parent")
+    {
         policy->try_select_parent(command_list.scope);
+        return IpcValidationResult::create_success();
+    }
     else if (arg == "child")
+    {
         policy->try_select_child(command_list.scope);
+        return IpcValidationResult::create_success();
+    }
     else if (arg == "prev")
     {
-        // TODO: Move this to the policy because this is racy
-        auto const container = state->focused_container();
-        if (!container)
-            return IpcValidationResult::create_failure("Active container does not exist", false);
+       if (!policy->try_select_prev(command_list.scope))
+           return IpcValidationResult::create_failure("Failed to select prev", false);
 
-        if (container->get_type() != ContainerType::leaf)
-            return IpcValidationResult::create_failure("Cannot focus prev when a tiling window is not selected", false);
-
-        if (auto const parent = Container::as_parent(container->get_parent().lock()))
-        {
-            auto const index = parent->get_index_of_node(container).value();
-            if (index != 0)
-            {
-                auto const node_to_select = parent->get_nth_window(index - 1);
-                window_controller->select_active_window(node_to_select->window().value());
-            }
-        }
+        return IpcValidationResult::create_success();
     }
     else if (arg == "next")
     {
-        // TODO: Move this to the policy because this is racy
-        auto const container = state->focused_container();
-        if (!container)
-            return IpcValidationResult::create_failure("No container is selected", false);
+        if (!policy->try_select_next(command_list.scope))
+            return IpcValidationResult::create_failure("Failed to select prev", false);
 
-        if (container->get_type() != ContainerType::leaf)
-            return IpcValidationResult::create_failure("Cannot focus prev when a tiling window is not selected", false);
-
-        if (auto const parent = Container::as_parent(container->get_parent().lock()))
-        {
-            auto const index = parent->get_index_of_node(container).value();
-            if (index != parent->num_nodes() - 1)
-            {
-                auto node_to_select = parent->get_nth_window(index + 1);
-                window_controller->select_active_window(node_to_select->window().value());
-            }
-        }
+        return IpcValidationResult::create_success();
     }
     else if (arg == "floating")
         policy->try_select_floating(command_list.scope);
@@ -301,98 +305,117 @@ IpcValidationResult IpcCommandExecutor::process_focus(IpcCommand const& command,
 
         auto const& arg1 = command.arguments[1];
         if (arg1 == "next")
+        {
             policy->try_select_next_output();
+            return IpcValidationResult::create_success();
+        }
         else if (arg1 == "prev")
+        {
             policy->try_select_prev_output();
+            return IpcValidationResult::create_success();
+        }
         else if (arg1 == "left")
+        {
             policy->try_select_output(Direction::left);
+            return IpcValidationResult::create_success();
+        }
         else if (arg1 == "right")
+        {
             policy->try_select_output(Direction::right);
+            return IpcValidationResult::create_success();
+        }
         else if (arg1 == "up")
+        {
             policy->try_select_output(Direction::up);
+            return IpcValidationResult::create_success();
+        }
         else if (arg1 == "down")
+        {
             policy->try_select_output(Direction::down);
+            return IpcValidationResult::create_success();
+        }
         else
         {
-            auto names = std::vector<std::string>(command.arguments.begin() + 1, command.arguments.end());
+            auto const names = std::vector<std::string>(command.arguments.begin() + 1, command.arguments.end());
             policy->try_select_output(names);
+            return IpcValidationResult::create_success();
         }
     }
-
-    return IpcValidationResult::create_success();
+    else
+    {
+        return IpcValidationResult::create_failure(std::format("Unknown argument to 'focus' command: {}", arg.c_str()), true);
+    }
 }
 
 namespace
 {
-bool parse_move_distance(std::vector<std::string> const& arguments, int& index, int total_size, int& out)
+
+
+ParseMoveResult parse_move_distance(std::vector<std::string> const& arguments, int& index)
 {
     auto const size = arguments.size() - index;
     if (size <= 1)
-        return false;
+        return ParseMoveResult{false, ParseMoveResult::MoveType::invalid, 0};
 
     try
     {
-        out = std::stoi(arguments[index]);
+        float amount = std::stoi(arguments[index]);
+        auto move_type = ParseMoveResult::MoveType::pixel;
         if (size == 2)
         {
             // We default to assuming the value is in pixels
             if (arguments[index + 1] == "ppt")
             {
-                float const ppt = static_cast<float>(out) / 100.f;
-                out = static_cast<float>(total_size) * ppt;
+                move_type = ParseMoveResult::MoveType::pixel;
+                amount = amount / 100.f;
+                index++;
+            }
+            else if (arguments[index + 1] == "px")
+            {
+                move_type = ParseMoveResult::MoveType::pixel;
+                index++;
             }
         }
 
-        return true;
+        return ParseMoveResult{true, move_type, amount};
     }
     catch (std::invalid_argument const& e)
     {
         mir::log_error("Invalid argument: %s", arguments[index].c_str());
-        return false;
+        return ParseMoveResult{false, ParseMoveResult::MoveType::invalid, 0};
     }
 }
 }
 
 IpcValidationResult IpcCommandExecutor::process_move(IpcCommand const& command, IpcParseResult const& command_list)
 {
-    auto const& active_output = output_manager->focused();
-    if (!active_output)
-        return IpcValidationResult::create_failure("process_move: output is not set", false);
-
     // https://i3wm.org/docs/userguide.html#_focusing_moving_containers
     if (command.arguments.empty())
         return IpcValidationResult::create_failure("process_move: move command expects arguments", false);
 
     int index = 0;
     auto const& arg0 = command.arguments[index++];
-    Direction direction = Direction::MAX;
-    int total_size = 0;
+    auto direction = Direction::MAX;
+
     if (arg0 == "left")
-    {
         direction = Direction::left;
-        total_size = active_output->get_area().size.width.as_int();
-    }
     else if (arg0 == "right")
-    {
         direction = Direction::right;
-        total_size = active_output->get_area().size.width.as_int();
-    }
     else if (arg0 == "up")
-    {
         direction = Direction::up;
-        total_size = active_output->get_area().size.height.as_int();
-    }
     else if (arg0 == "down")
-    {
         direction = Direction::down;
-        total_size = active_output->get_area().size.height.as_int();
-    }
 
     if (direction < Direction::MAX)
     {
-        int move_distance;
-        if (parse_move_distance(command.arguments, index, total_size, move_distance))
-            policy->try_move_by(direction, move_distance, command_list.scope);
+        const auto [success, move_type, amount] = parse_move_distance(command.arguments, index);
+        if (success)
+        {
+            if (move_type == ParseMoveResult::MoveType::ppt)
+                policy->try_move_by_ppt(direction, amount, command_list.scope);
+            else
+                policy->try_move_by_pixels(direction, static_cast<int>(amount), command_list.scope);
+        }
         else
             policy->try_move(direction, command_list.scope);
         return IpcValidationResult::create_success();
@@ -406,29 +429,30 @@ IpcValidationResult IpcCommandExecutor::process_move(IpcCommand const& command, 
         auto const& arg1 = command.arguments[index++];
         if (arg1 == "center")
         {
-            auto const active = state->focused_container().get();
-            auto const area = active_output->get_area();
-            float const x = static_cast<float>(area.size.width.as_int()) / 2.f - static_cast<float>(active->get_visible_area().size.width.as_int()) / 2.f;
-            float const y = static_cast<float>(area.size.height.as_int()) / 2.f - static_cast<float>(active->get_visible_area().size.height.as_int()) / 2.f;
-            policy->try_move_to(static_cast<int>(x), static_cast<int>(y), command_list.scope);
+            policy->try_move_to_center_of_active_output(command_list.scope);
+            return IpcValidationResult::create_success();
         }
         else if (arg1 == "mouse")
         {
-            auto const& position = state->cursor_position;
-            policy->try_move_to((int)position.x.as_int(), (int)position.y.as_int(), command_list.scope);
+            policy->try_move_to_cursor(command_list.scope);
+            return IpcValidationResult::create_success();
         }
         else
         {
-            int move_distance_x;
-            int move_distance_y;
-
-            if (!parse_move_distance(command.arguments, index, total_size, move_distance_x))
+            auto x_move_distance = parse_move_distance(command.arguments, index);
+            if (!x_move_distance.success)
                 return IpcValidationResult::create_failure("move position <x> <y>: unable to parse x", true);
 
-            if (!parse_move_distance(command.arguments, index, total_size, move_distance_y))
+            auto y_move_distance = parse_move_distance(command.arguments, index);
+            if (!y_move_distance.success)
                 return IpcValidationResult::create_failure("move position <x> <y>: unable to parse y", true);
 
-            policy->try_move_to(move_distance_x, move_distance_y, command_list.scope);
+            policy->try_move_to(
+                x_move_distance.amount,
+                x_move_distance.move_type == ParseMoveResult::MoveType::ppt,
+                y_move_distance.amount,
+                y_move_distance.move_type == ParseMoveResult::MoveType::ppt,
+                command_list.scope);
         }
 
         return IpcValidationResult::create_success();
@@ -438,27 +462,12 @@ IpcValidationResult IpcCommandExecutor::process_move(IpcCommand const& command, 
         auto const& arg1 = command.arguments[index++];
         auto const& arg2 = command.arguments[index++];
         if (arg1 != "position")
-            return IpcValidationResult::create_failure("move [absolute] ... expected 'position' as the third argument", true);
+            return IpcValidationResult::create_failure("move absolute ... expected 'position' as the third argument", true);
 
         if (arg2 != "center")
-            return IpcValidationResult::create_failure("move absolute position ... expected 'center' as the third argument", true);
+            return IpcValidationResult::create_failure("move absolute position ... expected 'center' as the fourth argument", true);
 
-        float x = 0, y = 0;
-        for (auto const& output : output_manager->outputs())
-        {
-            auto area = output->get_area();
-            float const end_x = static_cast<float>(area.size.width.as_int() + area.top_left.x.as_int());
-            float const end_y = static_cast<float>(area.size.height.as_int() + area.top_left.y.as_int());
-            if (end_x > x)
-                x = end_x;
-            if (end_y > y)
-                y = end_y;
-        }
-
-        auto const active = state->focused_container();
-        float const x_pos = x / 2.f - static_cast<float>(active->get_visible_area().size.width.as_int()) / 2.f;
-        float const y_pos = y / 2.f - static_cast<float>(active->get_visible_area().size.height.as_int()) / 2.f;
-        policy->try_move_to(static_cast<int>(x_pos), static_cast<int>(y_pos), command_list.scope);
+        policy->try_move_to_absolute_center(command_list.scope);
         return IpcValidationResult::create_success();
     }
     else if (arg0 == "window" || arg0 == "container")
@@ -634,21 +643,15 @@ IpcValidationResult IpcCommandExecutor::process_workspace(IpcCommand const& comm
     }
     else if (arg0 == "next_on_output")
     {
-        if (auto const& output = output_manager->focused())
-        {
-            policy->next_workspace_on_output(*output);
+        if (policy->next_workspace_on_output())
             return IpcValidationResult::create_success();
-        }
         else
             return IpcValidationResult::create_failure("'workspace next_on_output' has no output to go next on", false);
     }
     else if (arg0 == "prev_on_output")
     {
-        if (auto const& output = output_manager->focused())
-        {
-            policy->prev_workspace_on_output(*output);
+        if (policy->prev_workspace_on_output())
             return IpcValidationResult::create_success();
-        }
         else
             return IpcValidationResult::create_failure("'workspace prev_on_output' has no output to go prev on", false);
     }
@@ -735,91 +738,24 @@ IpcValidationResult IpcCommandExecutor::process_layout(IpcCommand const& command
             return IpcValidationResult::create_failure("Expected split/all after 'layout toggle X'", true);
         }
 
-        auto const container = state->focused_container();
-        if (!container)
-            return IpcValidationResult::create_failure("Container unavailable during 'layout'", false);
-
-        auto const current_type = container->get_layout();
-        size_t index = 0;
+        std::vector<LayoutRequestType> request_types;
         for (size_t i = 1; i < command.arguments.size(); i++)
         {
             auto const& argn = command.arguments[i];
             if (argn == "split")
-            {
-                if (current_type == LayoutScheme::horizontal || current_type == LayoutScheme::vertical)
-                {
-                    index = i;
-                    break;
-                }
-            }
+                request_types.push_back(LayoutRequestType::split);
             else if (argn == "tabbed")
-            {
-                if (current_type == LayoutScheme::tabbing)
-                {
-                    index = i;
-                    break;
-                }
-            }
+                request_types.push_back(LayoutRequestType::tabbed);
             else if (argn == "stacking")
-            {
-                if (current_type == LayoutScheme::stacking)
-                {
-                    index = i;
-                    break;
-                }
-            }
+                request_types.push_back(LayoutRequestType::stacking);
             else if (argn == "splitv")
-            {
-                if (current_type == LayoutScheme::vertical)
-                {
-                    index = i;
-                    break;
-                }
-            }
+                request_types.push_back(LayoutRequestType::splitv);
             else if (argn == "splith")
-            {
-                if (current_type == LayoutScheme::horizontal)
-                {
-                    index = i;
-                    break;
-                }
-            }
+                request_types.push_back(LayoutRequestType::splith);
         }
 
-        index++;
-        if (index == command.arguments.size())
-            index = 1;
-
-        auto const& target = command.arguments[index];
-        if (target == "split")
-        {
-            policy->try_toggle_layout(false, command_list.scope);
-            return IpcValidationResult::create_success();
-        }
-        else if (target == "tabbed")
-        {
-            policy->set_layout(LayoutScheme::tabbing, {});
-            return IpcValidationResult::create_success();
-        }
-        else if (target == "stacking")
-        {
-            policy->set_layout(LayoutScheme::stacking, {});
-            return IpcValidationResult::create_success();
-        }
-        else if (target == "splitv")
-        {
-            policy->set_layout(LayoutScheme::vertical, {});
-            return IpcValidationResult::create_success();
-        }
-        else if (target == "splith")
-        {
-            policy->set_layout(LayoutScheme::horizontal, {});
-            return IpcValidationResult::create_success();
-        }
-        else
-        {
-            return IpcValidationResult::create_failure(std::format("Unknown argument to 'layout' command, {}", target), true);
-        }
+        policy->try_cycle_through_request_types(request_types, command_list.scope);
+        return IpcValidationResult::create_success();
     }
     else
     {
@@ -847,63 +783,48 @@ struct ResizeAdjust
     bool success = true;
     std::string error;
     Direction direction = Direction::MAX;
-    int first = 0;
-    int second = 0;
+    int multiplier = 1;
+    std::optional<ParseMoveResult> first;
+    std::optional<ParseMoveResult> second;
 };
 
-ResizeAdjust parse_resize(std::shared_ptr<CompositorState> const& state, ArgumentsIndexer& indexer, int multiplier)
+ResizeAdjust parse_resize(ArgumentsIndexer& indexer, int multiplier)
 {
     if (!indexer.next())
         return { .success = false, .error = "process_resize: expected argument after 'resize grow'" };
 
-    auto const& container = state->focused_container();
-    if (!container)
-        return { .success = false, .error = "No container is selcted" };
-
-    ResizeAdjust result;
+    Direction direction;;
     if (indexer.current() == "width" || indexer.current() == "horizontal")
     {
-        result.direction = Direction::right;
+        direction = Direction::right;
     }
     else if (indexer.current() == "height" || indexer.current() == "vertical")
     {
-        result.direction = Direction::down;
+        direction = Direction::down;
     }
     else if (indexer.current() == "up")
     {
-        result.direction = Direction::up;
+        direction = Direction::up;
     }
     else if (indexer.current() == "down")
     {
-        result.direction = Direction::down;
+        direction = Direction::down;
     }
     else if (indexer.current() == "left")
     {
-        result.direction = Direction::left;
+        direction = Direction::left;
     }
     else if (indexer.current() == "right")
     {
-        result.direction = Direction::right;
+        direction = Direction::right;
     }
     else
     {
         return { .success = false, .error = std::format("Unknown direction value: {}", indexer.current().c_str()) };
     }
 
-    int available_space = 0;
-    switch (result.direction)
-    {
-    case Direction::up:
-    case Direction::down:
-        available_space = container->get_output()->get_area().size.height.as_value();
-        break;
-    default:
-        available_space = container->get_output()->get_area().size.width.as_value();
-        break;
-    }
-
-    int first = 0;
-    if (!indexer.parse_move_distance(available_space, first))
+    auto const first_move_distance = indexer.parse_move_distance();
+    if (!first_move_distance.success)
         return { .success = false, .error = "cannot parse the first value" };
 
     if (indexer.next())
@@ -912,41 +833,29 @@ ResizeAdjust parse_resize(std::shared_ptr<CompositorState> const& state, Argumen
             return { .success = false, .error = "expected 'or' after first value" };
     }
 
-    int second = 0;
-    indexer.parse_move_distance(available_space, second);
-    result.first = first * multiplier;
-    result.second = second * multiplier;
-    return result;
+    auto const second_move_distance = indexer.parse_move_distance();
+    return ResizeAdjust(true, "", direction, multiplier, first_move_distance, second_move_distance);
 }
 
 struct SetResizeResult
 {
     bool success = true;
     std::string error;
-    std::optional<int> width;
-    std::optional<int> height;
+    ParseMoveResult width;
+    ParseMoveResult height;
 };
 
-SetResizeResult parse_set_resize(std::shared_ptr<CompositorState> const& state, ArgumentsIndexer& indexer)
+SetResizeResult parse_set_resize(ArgumentsIndexer& indexer)
 {
-    auto const& container = state->focused_container();
-    if (!container)
-        return { .success = false, .error = "Container is not selected" };
-
-    SetResizeResult result;
-    int width = 0, height = 0;
-    if (!indexer.parse_move_distance(container->get_output()->get_area().size.width.as_value(), width))
+    ParseMoveResult const width_result = indexer.parse_move_distance();
+    if (!width_result.success)
         return { .success = false, .error = "invalid width" };
 
-    if (!indexer.parse_move_distance(container->get_output()->get_area().size.height.as_value(), height))
+    ParseMoveResult const height_result = indexer.parse_move_distance();
+    if (!height_result.success)
         return { .success = false, .error = "invalid height" };
 
-    if (width != 0)
-        result.width = width;
-    if (height != 0)
-        result.height = height;
-
-    return result;
+    return SetResizeResult(true, "", width_result, height_result);
 }
 }
 
@@ -959,7 +868,7 @@ IpcValidationResult IpcCommandExecutor::process_resize(IpcCommand const& command
     auto const& arg0 = indexer.current();
     if (arg0 == "grow")
     {
-        auto const adjust = parse_resize(state, indexer, 1);
+        auto const adjust = parse_resize(indexer, 1);
         if (!adjust.success)
             return IpcValidationResult::create_failure(adjust.error, true);
 
@@ -968,7 +877,7 @@ IpcValidationResult IpcCommandExecutor::process_resize(IpcCommand const& command
     }
     else if (arg0 == "shrink")
     {
-        auto const adjust = parse_resize(state, indexer, -1);
+        auto const adjust = parse_resize(indexer, -1);
         if (!adjust.success)
             return IpcValidationResult::create_failure(adjust.error, true);
 
@@ -977,7 +886,7 @@ IpcValidationResult IpcCommandExecutor::process_resize(IpcCommand const& command
     }
     else if (arg0 == "set")
     {
-        auto const result = parse_set_resize(state, indexer);
+        auto const result = parse_set_resize(indexer);
         if (!result.success)
             return IpcValidationResult::create_failure(result.error, true);
 

--- a/src/ipc_command_executor.cpp
+++ b/src/ipc_command_executor.cpp
@@ -566,11 +566,11 @@ IpcValidationResult IpcCommandExecutor::process_sticky(IpcCommand const& command
 
     auto const& arg0 = command.arguments[0];
     if (arg0 == "enable")
-        policy->set_is_pinned(true);
+        policy->set_is_pinned(true, {});
     else if (arg0 == "disable")
-        policy->set_is_pinned(false);
+        policy->set_is_pinned(false, {});
     else if (arg0 == "toggle")
-        policy->toggle_pinned_to_workspace();
+        policy->toggle_pinned_to_workspace({});
     else
         mir::log_warning("process_sticky: unknown arguments: %s", arg0.c_str());
 
@@ -688,15 +688,15 @@ IpcValidationResult IpcCommandExecutor::process_layout(IpcCommand const& command
     // https://i3wm.org/docs/userguide.html#manipulating_layout
     std::string const& arg0 = command.arguments[0];
     if (arg0 == "default")
-        policy->set_layout_default();
+        policy->set_layout_default({});
     else if (arg0 == "tabbed")
-        policy->set_layout(LayoutScheme::tabbing);
+        policy->set_layout(LayoutScheme::tabbing, {});
     else if (arg0 == "stacking")
-        policy->set_layout(LayoutScheme::stacking);
+        policy->set_layout(LayoutScheme::stacking, {});
     else if (arg0 == "splitv")
-        policy->set_layout(LayoutScheme::vertical);
+        policy->set_layout(LayoutScheme::vertical, {});
     else if (arg0 == "splith")
-        policy->set_layout(LayoutScheme::horizontal);
+        policy->set_layout(LayoutScheme::horizontal, {});
     else if (arg0 == "toggle")
     {
         if (command.arguments.size() == 1)
@@ -775,13 +775,13 @@ IpcValidationResult IpcCommandExecutor::process_layout(IpcCommand const& command
             if (target == "split")
                 policy->try_toggle_layout(false, command_list.scope);
             else if (target == "tabbed")
-                policy->set_layout(LayoutScheme::tabbing);
+                policy->set_layout(LayoutScheme::tabbing, {});
             else if (target == "stacking")
-                policy->set_layout(LayoutScheme::stacking);
+                policy->set_layout(LayoutScheme::stacking, {});
             else if (target == "splitv")
-                policy->set_layout(LayoutScheme::vertical);
+                policy->set_layout(LayoutScheme::vertical, {});
             else if (target == "splith")
-                policy->set_layout(LayoutScheme::horizontal);
+                policy->set_layout(LayoutScheme::horizontal, {});
         }
     }
 

--- a/src/ipc_command_executor.h
+++ b/src/ipc_command_executor.h
@@ -18,7 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef MIRACLEWM_I_3_COMMAND_EXECUTOR_H
 #define MIRACLEWM_I_3_COMMAND_EXECUTOR_H
 
-#include "compositor_state.h"
 #include "ipc_command.h"
 #include <mir/glib_main_loop.h>
 
@@ -70,16 +69,12 @@ class IpcCommandExecutor
 public:
     IpcCommandExecutor(
         std::shared_ptr<CommandController> const&,
-        std::shared_ptr<OutputManager> const&,
-        std::shared_ptr<CompositorState> const&,
         AutoRestartingLauncher&,
         std::shared_ptr<WindowController> const&);
     std::vector<IpcValidationResult> process(IpcParseResult const&);
 
 private:
     std::shared_ptr<CommandController> policy;
-    std::shared_ptr<OutputManager> output_manager;
-    std::shared_ptr<CompositorState> state;
     AutoRestartingLauncher& launcher;
     std::shared_ptr<WindowController> window_controller;
 

--- a/src/ipc_command_executor.h
+++ b/src/ipc_command_executor.h
@@ -48,7 +48,7 @@ public:
         std::shared_ptr<CompositorState> const&,
         AutoRestartingLauncher&,
         std::shared_ptr<WindowController> const&);
-    IpcValidationResult process(IpcParseResult const&);
+    std::vector<IpcValidationResult> process(IpcParseResult const&);
 
 private:
     std::shared_ptr<CommandController> policy;

--- a/src/ipc_command_executor.h
+++ b/src/ipc_command_executor.h
@@ -32,9 +32,35 @@ class OutputManager;
 
 struct IpcValidationResult
 {
-    bool success = true;
-    bool parse_error = false;
-    std::string error;
+private:
+    IpcValidationResult(bool success, bool parse_error, std::string error) :
+        success(success),
+        parse_error(parse_error),
+        error(std::move(error))
+    {
+    }
+
+public:
+    IpcValidationResult() = delete;
+    static IpcValidationResult create_success()
+    {
+        return IpcValidationResult(
+            true,
+            false,
+            "");
+    }
+
+    static IpcValidationResult create_failure(std::string error, bool parse_error)
+    {
+        return IpcValidationResult(
+            false,
+            parse_error,
+            std::move(error));
+    }
+
+    bool const success;
+    bool const parse_error;
+    std::string const error;
 };
 
 /// Processes all commands coming from i3 IPC. This class is mostly for organizational
@@ -68,8 +94,6 @@ private:
     IpcValidationResult process_scratchpad(IpcCommand const&, IpcParseResult const&);
     IpcValidationResult process_resize(IpcCommand const&, IpcParseResult const&);
     IpcValidationResult process_reload(IpcCommand const&, IpcParseResult const&);
-
-    IpcValidationResult parse_error(std::string error);
 };
 
 } // miracle

--- a/src/ipc_connection_manager.cpp
+++ b/src/ipc_connection_manager.cpp
@@ -15,14 +15,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
-#define MIR_LOG_COMPONENT "miracle_ipc"
+#define MIR_LOG_COMPONENT "ipc_connection_manager"
 
-#include "ipc.h"
+#include "ipc_connection_manager.h"
 #include "command_controller.h"
 #include "config.h"
 #include "ipc_command_executor.h"
-#include "version.h"
-#include "workspace_interface.h"
 
 #include <fcntl.h>
 #include <mir/log.h>
@@ -38,11 +36,9 @@ using namespace miracle;
 static const char ipc_magic[] = { 'i', '3', '-', 'i', 'p', 'c' };
 
 #define IPC_HEADER_SIZE (sizeof(ipc_magic) + 8)
-#define event_mask(ev) (1 << (ev & 0x7F))
 
 namespace
 {
-
 struct sockaddr_un* ipc_user_sockaddr()
 {
     auto ipc_sockaddr = (sockaddr_un*)malloc(sizeof(struct sockaddr_un));
@@ -113,13 +109,13 @@ json mode_event_to_json(WindowManagerMode mode)
 }
 }
 
-Ipc::Ipc(miral::MirRunner& runner,
-    std::shared_ptr<CommandController> const& policy,
-    std::unique_ptr<IpcCommandExecutor> executor,
+IpcConnectionManager::IpcConnectionManager(
+    miral::MirRunner& runner,
+    std::shared_ptr<CommandController> const& command_controller,
+    std::unique_ptr<IpcCommandExecutor> command_executor,
     std::shared_ptr<Config> const& config) :
-    policy { policy },
-    executor { std::move(executor) },
-    config { config }
+    policy(command_controller),
+    ipc_message_handler(std::make_unique<IpcMessageHandler>(command_controller, std::move(command_executor), config))
 {
     auto ipc_socket_raw = socket(AF_UNIX, SOCK_STREAM, 0);
     if (ipc_socket_raw == -1)
@@ -257,7 +253,7 @@ Ipc::Ipc(miral::MirRunner& runner,
     });
 }
 
-void Ipc::on_created(uint32_t id)
+void IpcConnectionManager::on_created(uint32_t id)
 {
     json j = {
         { "change",  "init"                        },
@@ -268,16 +264,16 @@ void Ipc::on_created(uint32_t id)
     auto serialized_value = to_string(j);
     for (auto& client : clients)
     {
-        if ((client.subscribed_events & event_mask(IPC_EVENT_WORKSPACE)) == 0)
+        if ((client.subscribed_events & event_mask(IpcType::IPC_EVENT_WORKSPACE)) == 0)
         {
             continue;
         }
 
-        send_reply(client, IPC_EVENT_WORKSPACE, serialized_value);
+        send_reply(client, IpcType::IPC_EVENT_WORKSPACE, serialized_value);
     }
 }
 
-void Ipc::on_removed(uint32_t id)
+void IpcConnectionManager::on_removed(uint32_t id)
 {
     json j = {
         { "change",  "empty"                       },
@@ -287,16 +283,16 @@ void Ipc::on_removed(uint32_t id)
     auto serialized_value = to_string(j);
     for (auto& client : clients)
     {
-        if ((client.subscribed_events & event_mask(IPC_EVENT_WORKSPACE)) == 0)
+        if ((client.subscribed_events & event_mask(IpcType::IPC_EVENT_WORKSPACE)) == 0)
         {
             continue;
         }
 
-        send_reply(client, IPC_EVENT_WORKSPACE, serialized_value);
+        send_reply(client, IpcType::IPC_EVENT_WORKSPACE, serialized_value);
     }
 }
 
-void Ipc::on_focused(
+void IpcConnectionManager::on_focused(
     std::optional<uint32_t> previous_id,
     uint32_t current_id)
 {
@@ -313,49 +309,49 @@ void Ipc::on_focused(
     auto serialized_value = to_string(j);
     for (auto& client : clients)
     {
-        if ((client.subscribed_events & event_mask(IPC_EVENT_WORKSPACE)) == 0)
+        if ((client.subscribed_events & event_mask(IpcType::IPC_EVENT_WORKSPACE)) == 0)
         {
             continue;
         }
 
-        send_reply(client, IPC_EVENT_WORKSPACE, serialized_value);
+        send_reply(client, IpcType::IPC_EVENT_WORKSPACE, serialized_value);
     }
 }
 
-void Ipc::on_changed(WindowManagerMode mode)
+void IpcConnectionManager::on_changed(WindowManagerMode mode)
 {
     auto response = to_string(mode_event_to_json(mode));
     for (auto& client : clients)
     {
-        if ((client.subscribed_events & event_mask(IPC_EVENT_MODE)) == 0)
+        if ((client.subscribed_events & event_mask(IpcType::IPC_EVENT_MODE)) == 0)
         {
             continue;
         }
 
-        send_reply(client, IPC_EVENT_MODE, response);
+        send_reply(client, IpcType::IPC_EVENT_MODE, response);
     }
 }
 
-void Ipc::on_shutdown()
+void IpcConnectionManager::on_shutdown()
 {
     auto response = to_string(json({
         { "change", "exit" }
     }));
     for (auto& client : clients)
     {
-        if ((client.subscribed_events & event_mask(IPC_EVENT_SHUTDOWN)) == 0)
+        if ((client.subscribed_events & event_mask(IpcType::IPC_EVENT_SHUTDOWN)) == 0)
         {
             continue;
         }
 
-        send_reply(client, IPC_EVENT_SHUTDOWN, response);
+        send_reply(client, IpcType::IPC_EVENT_SHUTDOWN, response);
     }
 
     for (auto& client : clients)
         disconnect(client);
 }
 
-Ipc::IpcClient& Ipc::get_client(int fd)
+IpcConnectionManager::IpcClient& IpcConnectionManager::get_client(int fd)
 {
     for (auto& client : clients)
     {
@@ -366,7 +362,7 @@ Ipc::IpcClient& Ipc::get_client(int fd)
     throw std::runtime_error("Could not find IPC client");
 }
 
-void Ipc::disconnect(Ipc::IpcClient& client)
+void IpcConnectionManager::disconnect(IpcClient& client)
 {
     auto it = std::find_if(clients.begin(), clients.end(), [&](IpcClient const& other)
     {
@@ -385,7 +381,7 @@ void Ipc::disconnect(Ipc::IpcClient& client)
     }
 }
 
-void Ipc::handle_command(miracle::Ipc::IpcClient& client, uint32_t payload_length, miracle::IpcType payload_type)
+void IpcConnectionManager::handle_command(IpcClient& client, uint32_t payload_length, IpcType payload_type)
 {
     char* buf = (char*)malloc(payload_length + 1);
     if (!buf)
@@ -408,133 +404,27 @@ void Ipc::handle_command(miracle::Ipc::IpcClient& client, uint32_t payload_lengt
         }
     }
     buf[payload_length] = '\0';
+    auto const result = ipc_message_handler->handle_msg(payload_type, buf, payload_length);
+    if (result.fatal)
+        disconnect(client);
+    else
+        send_reply(client, result.type, result.payload);
 
-    switch (payload_type)
+    client.subscribed_events |= result.subscribed_events;
+    if (result.subscribed_events & event_mask(IpcType::IPC_EVENT_TICK))
     {
-    case IPC_COMMAND:
-    {
-        mir::log_debug("Processing i3_command: %s", buf);
-        auto result = parse_i3_command(buf);
-        if (result.success)
-        {
-            const std::string msg = "[{\"success\": true}]";
-            send_reply(client, payload_type, msg);
-        }
-        else
-        {
-            json j = json::array();
-            j.push_back({
-                { "success",     false              },
-                { "parse_error", result.parse_error },
-                { "error",       result.error       },
-            });
-            const std::string msg = to_string(j);
-            send_reply(client, payload_type, msg);
-        }
-        break;
-    }
-    case IPC_GET_WORKSPACES:
-    {
-        auto json_string = to_string(policy->workspaces_json());
-        send_reply(client, payload_type, json_string);
-        break;
-    }
-    case IPC_GET_OUTPUTS:
-    {
-        auto json_string = to_string(policy->outputs_json());
-        send_reply(client, payload_type, json_string);
-        break;
-    }
-    case IPC_SUBSCRIBE:
-    {
-        json j = json::parse(buf);
-        bool success = true;
-        bool send_event_tick = false;
-        for (auto const& i : j)
-        {
-            std::string event_type = i.template get<std::string>();
-            mir::log_debug("Received subscription request from IPC client for event: %s", event_type.c_str());
-            if (event_type == "workspace")
-                client.subscribed_events |= event_mask(IPC_EVENT_WORKSPACE);
-            else if (event_type == "window")
-                client.subscribed_events |= event_mask(IPC_EVENT_WINDOW);
-            else if (event_type == "input")
-                client.subscribed_events |= event_mask(IPC_EVENT_INPUT);
-            else if (event_type == "mode")
-                client.subscribed_events |= event_mask(IPC_EVENT_MODE);
-            else if (event_type == "tick")
-            {
-                client.subscribed_events |= event_mask(IPC_EVENT_TICK);
-                send_event_tick = true;
-            }
-            else if (event_type == "shutdown")
-                client.subscribed_events |= event_mask(IPC_EVENT_SHUTDOWN);
-            else
-            {
-                mir::log_error("Cannot process IPC subscription event for event_type: %s", event_type.c_str());
-                disconnect(client);
-                success = false;
-                break;
-            }
-        }
-
-        if (success)
-        {
-            const std::string msg = "{\"success\": true}";
-            send_reply(client, payload_type, msg);
-        }
-
-        if (send_event_tick)
-        {
-            json response = {
-                { "first",   true },
-                { "payload", ""   }
-            };
-            send_reply(client, IPC_EVENT_TICK, to_string(response));
-        }
-
-        break;
-    }
-    case IPC_GET_TREE:
-    {
-        auto json_string = to_string(policy->to_json());
-        send_reply(client, payload_type, json_string);
-        break;
-    }
-    case IPC_GET_VERSION:
-    {
-        json response = {
-            { "major",                   MIRACLE_WM_MAJOR       },
-            { "minor",                   MIRACLE_WM_MINOR       },
-            { "patch",                   MIRACLE_WM_PATCH       },
-            { "human_readable",          MIRACLE_VERSION_STRING },
-            { "loaded_config_file_name", config->get_filename() }
+        json const response = {
+            { "first",   true },
+            { "payload", ""   }
         };
-        send_reply(client, payload_type, to_string(response));
-        break;
+        send_reply(client, IpcType::IPC_EVENT_TICK, to_string(response));
     }
-    case IPC_GET_BINDING_MODES:
-    {
-        json response;
-        response.push_back("default");
-        response.push_back("resize");
-        response.push_back("selecting");
-        send_reply(client, payload_type, to_string(response));
-        break;
-    }
-    case IPC_GET_BINDING_STATE:
-    {
-        send_reply(client, payload_type, to_string(policy->mode_to_json()));
-        break;
-    }
-    case IPC_SEND_TICK:
-    {
-        const std::string msg = "{\"success\": true}";
-        send_reply(client, payload_type, msg);
 
+    if (result.send_tick_event)
+    {
         for (auto& other_client : clients)
         {
-            if ((other_client.subscribed_events & event_mask(IPC_EVENT_TICK)) == 0)
+            if ((other_client.subscribed_events & event_mask(IpcType::IPC_EVENT_TICK)) == 0)
             {
                 continue;
             }
@@ -543,20 +433,14 @@ void Ipc::handle_command(miracle::Ipc::IpcClient& client, uint32_t payload_lengt
                 { "first",   false            },
                 { "payload", std::string(buf) }
             };
-            send_reply(other_client, IPC_EVENT_TICK, to_string(response));
+            send_reply(other_client, IpcType::IPC_EVENT_TICK, to_string(response));
         }
-        break;
-    }
-    default:
-        mir::log_warning("Unknown payload type: %d", payload_type);
-        disconnect(client);
-        break;
     }
 
     free(buf);
 }
 
-void Ipc::send_reply(miracle::Ipc::IpcClient& client, miracle::IpcType command_type, const std::string& payload)
+void IpcConnectionManager::send_reply(IpcClient& client, IpcType command_type, const std::string& payload)
 {
     if (!fd_is_valid(client.client_fd.operator int()))
     {
@@ -621,7 +505,7 @@ ssize_t write_nosigpipe(int fd, void* buf, size_t len)
 }
 }
 
-void Ipc::handle_writeable(miracle::Ipc::IpcClient& client)
+void IpcConnectionManager::handle_writeable(miracle::IpcConnectionManager::IpcClient& client)
 {
     while (client.write_buffer_len > 0)
     {
@@ -642,11 +526,4 @@ void Ipc::handle_writeable(miracle::Ipc::IpcClient& client)
     }
 
     client.write_buffer_len = 0;
-}
-
-IpcValidationResult Ipc::parse_i3_command(const char* command)
-{
-    IpcCommandParser parser(command);
-    auto const pending_commands = parser.parse();
-    return executor->process(pending_commands);
 }

--- a/src/ipc_connection_manager.cpp
+++ b/src/ipc_connection_manager.cpp
@@ -73,39 +73,10 @@ bool fd_is_valid(int fd)
 
 json mode_event_to_json(WindowManagerMode mode)
 {
-    switch (mode)
-    {
-    case WindowManagerMode::normal:
-        return {
-            { "change",       "default" },
-            { "pango_markup", true      }
-        };
-    case WindowManagerMode::resizing:
-        return {
-            { "change",       "resize" },
-            { "pango_markup", true     }
-        };
-    case WindowManagerMode::selecting:
-        return {
-            { "change",       "selecting" },
-            { "pango_markup", true        }
-        };
-    case WindowManagerMode::dragging:
-        return {
-            { "change",       "dragging" },
-            { "pango_markup", true       }
-        };
-    case WindowManagerMode::moving:
-        return {
-            { "change",       "moving" },
-            { "pango_markup", true     }
-        };
-    default:
-    {
-        mir::log_error("mode_event_to_json: unknown binding state: %d", static_cast<int>(mode));
-        return {};
-    }
-    }
+    return {
+        { "change",       BINDING_MODE_STRINGS[static_cast<int>(mode)] },
+        { "pango_markup", true                                         }
+    };
 }
 }
 

--- a/src/ipc_connection_manager.cpp
+++ b/src/ipc_connection_manager.cpp
@@ -255,8 +255,8 @@ IpcConnectionManager::IpcConnectionManager(
 void IpcConnectionManager::on_created(uint32_t id)
 {
     json j = {
-        { "change",  "init"                        },
-        { "old",     nullptr                       },
+        { "change",  "init"                                    },
+        { "old",     nullptr                                   },
         { "current", command_controller->workspace_to_json(id) }
     };
 
@@ -275,7 +275,7 @@ void IpcConnectionManager::on_created(uint32_t id)
 void IpcConnectionManager::on_removed(uint32_t id)
 {
     json j = {
-        { "change",  "empty"                       },
+        { "change",  "empty"                                   },
         { "current", command_controller->workspace_to_json(id) }
     };
 
@@ -296,7 +296,7 @@ void IpcConnectionManager::on_focused(
     uint32_t current_id)
 {
     json j = {
-        { "change",  "focus"                               },
+        { "change",  "focus"                                           },
         { "current", command_controller->workspace_to_json(current_id) }
     };
 

--- a/src/ipc_connection_manager.cpp
+++ b/src/ipc_connection_manager.cpp
@@ -114,7 +114,7 @@ IpcConnectionManager::IpcConnectionManager(
     std::shared_ptr<CommandController> const& command_controller,
     std::unique_ptr<IpcCommandExecutor> command_executor,
     std::shared_ptr<Config> const& config) :
-    policy(command_controller),
+    command_controller(command_controller),
     ipc_message_handler(std::make_unique<IpcMessageHandler>(command_controller, std::move(command_executor), config))
 {
     auto const ipc_socket_raw = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -257,7 +257,7 @@ void IpcConnectionManager::on_created(uint32_t id)
     json j = {
         { "change",  "init"                        },
         { "old",     nullptr                       },
-        { "current", policy->workspace_to_json(id) }
+        { "current", command_controller->workspace_to_json(id) }
     };
 
     auto const serialized_value = to_string(j);
@@ -276,7 +276,7 @@ void IpcConnectionManager::on_removed(uint32_t id)
 {
     json j = {
         { "change",  "empty"                       },
-        { "current", policy->workspace_to_json(id) }
+        { "current", command_controller->workspace_to_json(id) }
     };
 
     auto const serialized_value = to_string(j);
@@ -297,11 +297,11 @@ void IpcConnectionManager::on_focused(
 {
     json j = {
         { "change",  "focus"                               },
-        { "current", policy->workspace_to_json(current_id) }
+        { "current", command_controller->workspace_to_json(current_id) }
     };
 
     if (previous_id)
-        j["old"] = policy->workspace_to_json(previous_id.value());
+        j["old"] = command_controller->workspace_to_json(previous_id.value());
     else
         j["old"] = nullptr;
 

--- a/src/ipc_connection_manager.cpp
+++ b/src/ipc_connection_manager.cpp
@@ -33,7 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 using json = nlohmann::json;
 using namespace miracle;
 
-static const char ipc_magic[] = { 'i', '3', '-', 'i', 'p', 'c' };
+static constexpr char ipc_magic[] = { 'i', '3', '-', 'i', 'p', 'c' };
 
 #define IPC_HEADER_SIZE (sizeof(ipc_magic) + 8)
 
@@ -41,7 +41,7 @@ namespace
 {
 struct sockaddr_un* ipc_user_sockaddr()
 {
-    auto ipc_sockaddr = (sockaddr_un*)malloc(sizeof(struct sockaddr_un));
+    auto const ipc_sockaddr = static_cast<sockaddr_un*>(malloc(sizeof(struct sockaddr_un)));
     if (ipc_sockaddr == nullptr)
     {
         mir::log_error("Can't allocate ipc_sockaddr");
@@ -49,7 +49,7 @@ struct sockaddr_un* ipc_user_sockaddr()
     }
 
     ipc_sockaddr->sun_family = AF_UNIX;
-    int path_size = sizeof(ipc_sockaddr->sun_path);
+    int constexpr path_size = sizeof(ipc_sockaddr->sun_path);
 
     // Env var typically set by logind, e.g. "/run/user/<user-id>"
     const char* dir = getenv("XDG_RUNTIME_DIR");
@@ -102,7 +102,7 @@ json mode_event_to_json(WindowManagerMode mode)
         };
     default:
     {
-        mir::fatal_error("handle_command: unknown binding state: %d", (int)mode);
+        mir::log_error("mode_event_to_json: unknown binding state: %d", static_cast<int>(mode));
         return {};
     }
     }
@@ -117,7 +117,7 @@ IpcConnectionManager::IpcConnectionManager(
     policy(command_controller),
     ipc_message_handler(std::make_unique<IpcMessageHandler>(command_controller, std::move(command_executor), config))
 {
-    auto ipc_socket_raw = socket(AF_UNIX, SOCK_STREAM, 0);
+    auto const ipc_socket_raw = socket(AF_UNIX, SOCK_STREAM, 0);
     if (ipc_socket_raw == -1)
     {
         mir::log_error("Unable to create ipc socket");
@@ -136,9 +136,9 @@ IpcConnectionManager::IpcConnectionManager(
     }
 
     ipc_sockaddr = ipc_user_sockaddr();
-    if (getenv("SWAYSOCK") != nullptr && access(getenv("SWAYSOCK"), F_OK) == -1)
+    if (getenv("MIRACLESOCK") != nullptr && access(getenv("MIRACLESOCK"), F_OK) == -1)
     {
-        strncpy(ipc_sockaddr->sun_path, getenv("SWAYSOCK"), sizeof(ipc_sockaddr->sun_path) - 1);
+        strncpy(ipc_sockaddr->sun_path, getenv("MIRACLESOCK"), sizeof(ipc_sockaddr->sun_path) - 1);
         ipc_sockaddr->sun_path[sizeof(ipc_sockaddr->sun_path) - 1] = 0;
     }
 
@@ -155,7 +155,6 @@ IpcConnectionManager::IpcConnectionManager(
         exit(1);
     }
 
-    // Set i3 IPC socket path so that i3-msg works out of the box
     setenv("I3SOCK", ipc_sockaddr->sun_path, 1);
     setenv("SWAYSOCK", ipc_sockaddr->sun_path, 1);
     setenv("MIRACLESOCK", ipc_sockaddr->sun_path, 1);
@@ -188,13 +187,13 @@ IpcConnectionManager::IpcConnectionManager(
             return;
         }
 
-        auto mir_fd = mir::Fd { client_fd };
+        auto const mir_fd = mir::Fd { client_fd };
         clients.push_back({ mir_fd,
-            runner.register_fd_handler(mir_fd, [this](int fd)
+            runner.register_fd_handler(mir_fd, [this](int const fd)
         {
             auto& client = get_client(fd);
 
-            int read_available;
+            uint32_t read_available;
             if (ioctl(client.client_fd, FIONREAD, &read_available) == -1)
             {
                 mir::log_error("Unable to read IPC socket buffer size");
@@ -204,25 +203,25 @@ IpcConnectionManager::IpcConnectionManager(
 
             if (client.pending_read_length > 0)
             {
-                if ((uint32_t)read_available >= client.pending_read_length)
+                if (read_available >= client.pending_read_length)
                 {
                     // Reset pending values.
-                    uint32_t pending_length = client.pending_read_length;
-                    IpcType pending_type = client.pending_type;
+                    uint32_t const pending_length = client.pending_read_length;
+                    IpcType const pending_type = client.pending_type;
                     client.pending_read_length = 0;
                     handle_command(client, pending_length, pending_type);
                 }
                 return;
             }
 
-            if (read_available < (int)IPC_HEADER_SIZE)
+            if (read_available < IPC_HEADER_SIZE)
             {
                 return;
             }
 
             uint8_t buf[IPC_HEADER_SIZE];
             // Should be fully available, because read_available >= IPC_HEADER_SIZE
-            ssize_t received = recv(client.client_fd, buf, IPC_HEADER_SIZE, 0);
+            ssize_t const received = recv(client.client_fd, buf, IPC_HEADER_SIZE, 0);
             if (received == -1)
             {
                 mir::log_error("Unable to receive header from IPC client");
@@ -241,11 +240,11 @@ IpcConnectionManager::IpcConnectionManager(
             memcpy(&client.pending_type, buf + sizeof(ipc_magic) + sizeof(uint32_t), sizeof(uint32_t));
             mir::log_debug("Received request from IPC client: %d", (int)client.pending_type);
 
-            if (read_available - received >= (long)client.pending_read_length)
+            if (read_available - received >= static_cast<long>(client.pending_read_length))
             {
                 // Reset pending values.
-                uint32_t pending_length = client.pending_read_length;
-                IpcType pending_type = client.pending_type;
+                uint32_t const pending_length = client.pending_read_length;
+                IpcType const pending_type = client.pending_type;
                 client.pending_read_length = 0;
                 handle_command(client, pending_length, pending_type);
             }
@@ -261,7 +260,7 @@ void IpcConnectionManager::on_created(uint32_t id)
         { "current", policy->workspace_to_json(id) }
     };
 
-    auto serialized_value = to_string(j);
+    auto const serialized_value = to_string(j);
     for (auto& client : clients)
     {
         if ((client.subscribed_events & event_mask(IpcType::IPC_EVENT_WORKSPACE)) == 0)
@@ -280,7 +279,7 @@ void IpcConnectionManager::on_removed(uint32_t id)
         { "current", policy->workspace_to_json(id) }
     };
 
-    auto serialized_value = to_string(j);
+    auto const serialized_value = to_string(j);
     for (auto& client : clients)
     {
         if ((client.subscribed_events & event_mask(IpcType::IPC_EVENT_WORKSPACE)) == 0)
@@ -306,7 +305,7 @@ void IpcConnectionManager::on_focused(
     else
         j["old"] = nullptr;
 
-    auto serialized_value = to_string(j);
+    auto const serialized_value = to_string(j);
     for (auto& client : clients)
     {
         if ((client.subscribed_events & event_mask(IpcType::IPC_EVENT_WORKSPACE)) == 0)
@@ -320,7 +319,7 @@ void IpcConnectionManager::on_focused(
 
 void IpcConnectionManager::on_changed(WindowManagerMode mode)
 {
-    auto response = to_string(mode_event_to_json(mode));
+    auto const response = to_string(mode_event_to_json(mode));
     for (auto& client : clients)
     {
         if ((client.subscribed_events & event_mask(IpcType::IPC_EVENT_MODE)) == 0)
@@ -334,7 +333,7 @@ void IpcConnectionManager::on_changed(WindowManagerMode mode)
 
 void IpcConnectionManager::on_shutdown()
 {
-    auto response = to_string(json({
+    auto const response = to_string(json({
         { "change", "exit" }
     }));
     for (auto& client : clients)
@@ -364,7 +363,7 @@ IpcConnectionManager::IpcClient& IpcConnectionManager::get_client(int fd)
 
 void IpcConnectionManager::disconnect(IpcClient& client)
 {
-    auto it = std::find_if(clients.begin(), clients.end(), [&](IpcClient const& other)
+    auto const it = std::ranges::find_if(clients, [&](IpcClient const& other)
     {
         return other.client_fd.operator int() == client.client_fd.operator int();
     });
@@ -383,7 +382,7 @@ void IpcConnectionManager::disconnect(IpcClient& client)
 
 void IpcConnectionManager::handle_command(IpcClient& client, uint32_t payload_length, IpcType payload_type)
 {
-    char* buf = (char*)malloc(payload_length + 1);
+    auto const buf = static_cast<char*>(malloc(payload_length + 1));
     if (!buf)
     {
         mir::log_error("Unable to allocate IPC payload");
@@ -465,8 +464,9 @@ void IpcConnectionManager::send_reply(IpcClient& client, IpcType command_type, c
         new_buffer_size *= 2;
     }
 
-    if (new_buffer_size > 4e6)
-    { // 4 MB
+    size_t constexpr MAX_BUFFER_SIZE = 4e6; // 4 MB
+    if (new_buffer_size > MAX_BUFFER_SIZE)
+    {
         mir::log_error("Client write buffer too big (%zu), disconnecting client", client.buffer.size());
         disconnect(client);
         return;
@@ -509,7 +509,7 @@ void IpcConnectionManager::handle_writeable(miracle::IpcConnectionManager::IpcCl
 {
     while (client.write_buffer_len > 0)
     {
-        ssize_t written = write_nosigpipe(client.client_fd, client.buffer.data(), client.write_buffer_len);
+        ssize_t const written = write_nosigpipe(client.client_fd, client.buffer.data(), client.write_buffer_len);
         if (written == -1 && errno == EAGAIN)
         {
             return;

--- a/src/ipc_connection_manager.h
+++ b/src/ipc_connection_manager.h
@@ -56,7 +56,7 @@ private:
         int subscribed_events = 0;
     };
 
-    std::shared_ptr<CommandController> policy;
+    std::shared_ptr<CommandController> command_controller;
     std::unique_ptr<IpcMessageHandler> ipc_message_handler;
     mir::Fd ipc_socket;
     std::unique_ptr<miral::FdHandle> socket_handle;

--- a/src/ipc_connection_manager.h
+++ b/src/ipc_connection_manager.h
@@ -52,7 +52,7 @@ private:
         uint32_t pending_read_length = 0;
         IpcType pending_type;
         std::vector<char> buffer;
-        int write_buffer_len = 0;
+        uint32_t write_buffer_len = 0;
         int subscribed_events = 0;
     };
 

--- a/src/ipc_connection_manager.h
+++ b/src/ipc_connection_manager.h
@@ -1,0 +1,75 @@
+/**
+Copyright (C) 2024  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef IPC_CONNECTION_H
+#define IPC_CONNECTION_H
+
+#include "ipc_message_handler.h"
+#include "mode_observer.h"
+#include "workspace_manager.h"
+#include "workspace_observer.h"
+#include <mir/fd.h>
+#include <miral/runner.h>
+#include <vector>
+
+namespace miracle
+{
+
+/// Manages IPC connections and routes requests to the [IpcMessageHandler].
+class IpcConnectionManager : public virtual WorkspaceObserver, public virtual ModeObserver
+{
+public:
+    IpcConnectionManager(
+        miral::MirRunner& runner,
+        std::shared_ptr<CommandController> const&,
+        std::unique_ptr<IpcCommandExecutor>,
+        std::shared_ptr<Config> const&);
+    void on_created(uint32_t id) override;
+    void on_removed(uint32_t id) override;
+    void on_focused(std::optional<uint32_t>, uint32_t) override;
+    void on_changed(WindowManagerMode mode) override;
+    void on_shutdown();
+
+private:
+    struct IpcClient
+    {
+        mir::Fd client_fd;
+        std::unique_ptr<miral::FdHandle> handle;
+        uint32_t pending_read_length = 0;
+        IpcType pending_type;
+        std::vector<char> buffer;
+        int write_buffer_len = 0;
+        int subscribed_events = 0;
+    };
+
+    std::shared_ptr<CommandController> policy;
+    std::unique_ptr<IpcMessageHandler> ipc_message_handler;
+    mir::Fd ipc_socket;
+    std::unique_ptr<miral::FdHandle> socket_handle;
+    sockaddr_un* ipc_sockaddr = nullptr;
+    std::vector<IpcClient> clients;
+
+    void disconnect(IpcClient& client);
+    IpcClient& get_client(int fd);
+
+    void handle_command(IpcClient& client, uint32_t payload_length, IpcType payload_type);
+    void send_reply(IpcClient& client, IpcType command_type, std::string const& payload);
+    void handle_writeable(IpcClient& client);
+};
+}
+
+#endif // IPC_CONNECTION_H

--- a/src/ipc_message_handler.cpp
+++ b/src/ipc_message_handler.cpp
@@ -28,11 +28,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 using json = nlohmann::json;
 using namespace miracle;
 
-IpcMessageHandler::IpcMessageHandler(std::shared_ptr<CommandController> const& policy,
-    std::unique_ptr<IpcCommandExecutor> executor,
+IpcMessageHandler::IpcMessageHandler(std::shared_ptr<CommandController> const& command_controller,
+    std::unique_ptr<IpcCommandExecutor> ipc_command_executor,
     std::shared_ptr<Config> const& config) :
-    policy { policy },
-    executor { std::move(executor) },
+    command_controller { command_controller },
+    ipc_command_executor { std::move(ipc_command_executor) },
     config { config }
 {
 }
@@ -71,7 +71,7 @@ MessageHandlerResult IpcMessageHandler::handle_msg(IpcType payload_type, char* p
     }
     case IpcType::IPC_GET_WORKSPACES:
     {
-        auto json_string = to_string(policy->workspaces_json());
+        auto json_string = to_string(command_controller->workspaces_json());
         return {
             .type = payload_type,
             .payload = json_string
@@ -79,7 +79,7 @@ MessageHandlerResult IpcMessageHandler::handle_msg(IpcType payload_type, char* p
     }
     case IpcType::IPC_GET_OUTPUTS:
     {
-        auto json_string = to_string(policy->outputs_json());
+        auto json_string = to_string(command_controller->outputs_json());
         return {
             .type = payload_type,
             .payload = json_string
@@ -134,7 +134,7 @@ MessageHandlerResult IpcMessageHandler::handle_msg(IpcType payload_type, char* p
     {
         return {
             .type = payload_type,
-            .payload = to_string(policy->to_json())
+            .payload = to_string(command_controller->to_json())
         };
     }
     case IpcType::IPC_GET_VERSION:
@@ -166,7 +166,7 @@ MessageHandlerResult IpcMessageHandler::handle_msg(IpcType payload_type, char* p
     {
         return {
             .type = payload_type,
-            .payload = to_string(policy->mode_to_json())
+            .payload = to_string(command_controller->mode_to_json())
         };
     }
     case IpcType::IPC_SEND_TICK:
@@ -191,5 +191,5 @@ IpcValidationResult IpcMessageHandler::parse_i3_command(const char* command)
 {
     IpcCommandParser parser(command);
     auto const pending_commands = parser.parse();
-    return executor->process(pending_commands);
+    return ipc_command_executor->process(pending_commands);
 }

--- a/src/ipc_message_handler.cpp
+++ b/src/ipc_message_handler.cpp
@@ -177,6 +177,13 @@ MessageHandlerResult IpcMessageHandler::handle_msg(IpcType payload_type, char* p
             .send_tick_event = true
         };
     }
+    case IpcType::IPC_SYNC:
+    {
+        return {
+            .type = payload_type,
+            .payload = "{\"name\": \"default\"}",
+        };
+    }
     default:
         mir::log_warning("Unknown payload type: %d", payload_type);
         return {

--- a/src/ipc_message_handler.cpp
+++ b/src/ipc_message_handler.cpp
@@ -44,30 +44,29 @@ MessageHandlerResult IpcMessageHandler::handle_msg(IpcType payload_type, char* p
     case IpcType::IPC_COMMAND:
     {
         mir::log_debug("Processing miracle command: %s", payload);
-        auto const result = parse_i3_command(payload);
-        if (result.success)
+        auto const result = process_ipc_command(payload);
+        json j = json::array();
+        for (auto const& command_result : result)
         {
-            const std::string msg = "[{\"success\": true}]";
-            return {
-                .fatal = false,
-                .type = payload_type,
-                .payload = msg
-            };
+            if (command_result.success)
+            {
+                j.push_back({
+                    { "success", true }
+                });
+            }
+            else
+            {
+                j.push_back({
+                    { "success",     false                      },
+                    { "parse_error", command_result.parse_error },
+                    { "error",       command_result.error       },
+                });
+            }
         }
-        else
-        {
-            json j = json::array();
-            j.push_back({
-                { "success",     false              },
-                { "parse_error", result.parse_error },
-                { "error",       result.error       },
-            });
-            const std::string msg = to_string(j);
-            return {
-                .type = payload_type,
-                .payload = msg
-            };
-        }
+        return {
+            .type = payload_type,
+            .payload = to_string(j)
+        };
     }
     case IpcType::IPC_GET_WORKSPACES:
     {
@@ -193,7 +192,7 @@ MessageHandlerResult IpcMessageHandler::handle_msg(IpcType payload_type, char* p
     }
 }
 
-IpcValidationResult IpcMessageHandler::parse_i3_command(const char* command)
+std::vector<IpcValidationResult> IpcMessageHandler::process_ipc_command(const char* command)
 {
     IpcCommandParser parser(command);
     auto const pending_commands = parser.parse();

--- a/src/ipc_message_handler.cpp
+++ b/src/ipc_message_handler.cpp
@@ -1,0 +1,195 @@
+/**
+Copyright (C) 2024  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#define MIR_LOG_COMPONENT "ipc_message_handler"
+
+#include "ipc_message_handler.h"
+#include "command_controller.h"
+#include "config.h"
+#include "ipc_command_executor.h"
+#include "version.h"
+#include <mir/log.h>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+using namespace miracle;
+
+IpcMessageHandler::IpcMessageHandler(std::shared_ptr<CommandController> const& policy,
+    std::unique_ptr<IpcCommandExecutor> executor,
+    std::shared_ptr<Config> const& config) :
+    policy { policy },
+    executor { std::move(executor) },
+    config { config }
+{
+}
+
+MessageHandlerResult IpcMessageHandler::handle_msg(IpcType payload_type, char* payload, uint32_t)
+{
+    switch (payload_type)
+    {
+    case IpcType::IPC_COMMAND:
+    {
+        mir::log_debug("Processing miracle command: %s", payload);
+        auto const result = parse_i3_command(payload);
+        if (result.success)
+        {
+            const std::string msg = "[{\"success\": true}]";
+            return {
+                .fatal = false,
+                .type = payload_type,
+                .payload = msg
+            };
+        }
+        else
+        {
+            json j = json::array();
+            j.push_back({
+                { "success",     false              },
+                { "parse_error", result.parse_error },
+                { "error",       result.error       },
+            });
+            const std::string msg = to_string(j);
+            return {
+                .type = payload_type,
+                .payload = msg
+            };
+        }
+    }
+    case IpcType::IPC_GET_WORKSPACES:
+    {
+        auto json_string = to_string(policy->workspaces_json());
+        return {
+            .type = payload_type,
+            .payload = json_string
+        };
+    }
+    case IpcType::IPC_GET_OUTPUTS:
+    {
+        auto json_string = to_string(policy->outputs_json());
+        return {
+            .type = payload_type,
+            .payload = json_string
+        };
+    }
+    case IpcType::IPC_SUBSCRIBE:
+    {
+        json j = json::parse(payload);
+        bool success = true;
+        std::string error;
+        MessageHandlerResult result = { .type = payload_type };
+        for (auto const& i : j)
+        {
+            std::string event_type = i.template get<std::string>();
+            mir::log_debug("Received subscription request from IPC client for event: %s", event_type.c_str());
+            if (event_type == "workspace")
+                result.subscribed_events |= event_mask(IpcType::IPC_EVENT_WORKSPACE);
+            else if (event_type == "window")
+                result.subscribed_events |= event_mask(IpcType::IPC_EVENT_WINDOW);
+            else if (event_type == "input")
+                result.subscribed_events |= event_mask(IpcType::IPC_EVENT_INPUT);
+            else if (event_type == "mode")
+                result.subscribed_events |= event_mask(IpcType::IPC_EVENT_MODE);
+            else if (event_type == "tick")
+                result.subscribed_events |= event_mask(IpcType::IPC_EVENT_TICK);
+            else if (event_type == "shutdown")
+                result.subscribed_events |= event_mask(IpcType::IPC_EVENT_SHUTDOWN);
+            else
+            {
+                mir::log_warning("Cannot process IPC subscription event for event_type: %s", event_type.c_str());
+                error = "Invalid IPC subscription event: " + event_type;
+                success = false;
+                break;
+            }
+        }
+
+        if (success)
+        {
+            result.payload = "{\"success\": true}";
+        }
+        else
+        {
+            json const response = {
+                { "success", false },
+                { "error",   error }
+            };
+            result.payload = to_string(response);
+        }
+        return result;
+    }
+    case IpcType::IPC_GET_TREE:
+    {
+        return {
+            .type = payload_type,
+            .payload = to_string(policy->to_json())
+        };
+    }
+    case IpcType::IPC_GET_VERSION:
+    {
+        json response = {
+            { "major",                   MIRACLE_WM_MAJOR       },
+            { "minor",                   MIRACLE_WM_MINOR       },
+            { "patch",                   MIRACLE_WM_PATCH       },
+            { "human_readable",          MIRACLE_VERSION_STRING },
+            { "loaded_config_file_name", config->get_filename() }
+        };
+        return {
+            .type = payload_type,
+            .payload = to_string(response)
+        };
+    }
+    case IpcType::IPC_GET_BINDING_MODES:
+    {
+        json response;
+        response.push_back("default");
+        response.push_back("resize");
+        response.push_back("selecting");
+        return {
+            .type = payload_type,
+            .payload = to_string(response)
+        };
+    }
+    case IpcType::IPC_GET_BINDING_STATE:
+    {
+        return {
+            .type = payload_type,
+            .payload = to_string(policy->mode_to_json())
+        };
+    }
+    case IpcType::IPC_SEND_TICK:
+    {
+        const std::string msg = "{\"success\": true}";
+        return {
+            .type = payload_type,
+            .payload = "{\"success\": true}",
+            .send_tick_event = true
+        };
+    }
+    default:
+        mir::log_warning("Unknown payload type: %d", payload_type);
+        return {
+            .fatal = true,
+            .type = payload_type
+        };
+    }
+}
+
+IpcValidationResult IpcMessageHandler::parse_i3_command(const char* command)
+{
+    IpcCommandParser parser(command);
+    auto const pending_commands = parser.parse();
+    return executor->process(pending_commands);
+}

--- a/src/ipc_message_handler.cpp
+++ b/src/ipc_message_handler.cpp
@@ -154,9 +154,8 @@ MessageHandlerResult IpcMessageHandler::handle_msg(IpcType payload_type, char* p
     case IpcType::IPC_GET_BINDING_MODES:
     {
         json response;
-        response.push_back("default");
-        response.push_back("resize");
-        response.push_back("selecting");
+        for (auto const& str : BINDING_MODE_STRINGS)
+            response.push_back(str);
         return {
             .type = payload_type,
             .payload = to_string(response)

--- a/src/ipc_message_handler.h
+++ b/src/ipc_message_handler.h
@@ -29,6 +29,7 @@ namespace miracle
 {
 
 class CommandController;
+class Config;
 
 /// This it taken directly from sway
 enum class IpcType

--- a/src/ipc_message_handler.h
+++ b/src/ipc_message_handler.h
@@ -87,8 +87,8 @@ public:
         uint32_t payload_length);
 
 private:
-    std::shared_ptr<CommandController> policy;
-    std::unique_ptr<IpcCommandExecutor> executor;
+    std::shared_ptr<CommandController> command_controller;
+    std::unique_ptr<IpcCommandExecutor> ipc_command_executor;
     std::shared_ptr<Config> config;
 
     IpcValidationResult parse_i3_command(const char* command);

--- a/src/ipc_message_handler.h
+++ b/src/ipc_message_handler.h
@@ -91,7 +91,7 @@ private:
     std::unique_ptr<IpcCommandExecutor> ipc_command_executor;
     std::shared_ptr<Config> config;
 
-    IpcValidationResult parse_i3_command(const char* command);
+    std::vector<IpcValidationResult> process_ipc_command(const char* command);
 };
 }
 

--- a/src/ipc_message_handler.h
+++ b/src/ipc_message_handler.h
@@ -20,13 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "ipc_command.h"
 #include "ipc_command_executor.h"
-#include "mode_observer.h"
-#include "workspace_manager.h"
-#include "workspace_observer.h"
-#include <mir/fd.h>
-#include <miral/runner.h>
-#include <shared_mutex>
-#include <vector>
+
+#define event_mask(ev) (1 << (static_cast<int>(ev) & 0x7F))
 
 struct sockaddr_un;
 
@@ -35,8 +30,8 @@ namespace miracle
 
 class CommandController;
 
-/// This it taken directly from SWAY
-enum IpcType
+/// This it taken directly from sway
+enum class IpcType
 {
     // i3 command types - see i3's I3_REPLY_TYPE constants
     IPC_COMMAND = 0,
@@ -72,49 +67,30 @@ enum IpcType
     IPC_EVENT_INPUT = ((1 << 31) | 21),
 };
 
-/// Inter process communication for compositor clients (e.g. waybar).
-/// This class will implement I3's interface: https://i3wm.org/docs/ipc.html
-/// plus some of the sway-specific items.
-/// It may be extended in the future.
-class Ipc : public virtual WorkspaceObserver, public virtual ModeObserver
+struct MessageHandlerResult
+{
+    bool fatal = false;
+    IpcType type;
+    std::string payload;
+    int subscribed_events = 0;
+    bool send_tick_event = false;
+};
+
+class IpcMessageHandler
 {
 public:
-    Ipc(miral::MirRunner& runner,
-        std::shared_ptr<CommandController> const&,
+    IpcMessageHandler(std::shared_ptr<CommandController> const&,
         std::unique_ptr<IpcCommandExecutor>,
         std::shared_ptr<Config> const&);
-
-    void on_created(uint32_t id) override;
-    void on_removed(uint32_t id) override;
-    void on_focused(std::optional<uint32_t>, uint32_t) override;
-    void on_changed(WindowManagerMode mode) override;
-    void on_shutdown();
+    MessageHandlerResult handle_msg(IpcType payload_type,
+        char* payload,
+        uint32_t payload_length);
 
 private:
-    struct IpcClient
-    {
-        mir::Fd client_fd;
-        std::unique_ptr<miral::FdHandle> handle;
-        uint32_t pending_read_length = 0;
-        IpcType pending_type;
-        std::vector<char> buffer;
-        int write_buffer_len = 0;
-        int subscribed_events = 0;
-    };
-
     std::shared_ptr<CommandController> policy;
-    mir::Fd ipc_socket;
-    std::unique_ptr<miral::FdHandle> socket_handle;
-    sockaddr_un* ipc_sockaddr = nullptr;
-    std::vector<IpcClient> clients;
     std::unique_ptr<IpcCommandExecutor> executor;
     std::shared_ptr<Config> config;
 
-    void disconnect(IpcClient& client);
-    IpcClient& get_client(int fd);
-    void handle_command(IpcClient& client, uint32_t payload_length, IpcType payload_type);
-    void send_reply(IpcClient& client, IpcType command_type, std::string const& payload);
-    void handle_writeable(IpcClient& client);
     IpcValidationResult parse_i3_command(const char* command);
 };
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -30,11 +30,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/transform.hpp>
 #include <memory>
+#include <mir/graphics/edid.h>
 #include <mir/log.h>
 #include <miral/window_info.h>
 #include <miral/zone.h>
 
 using namespace miracle;
+namespace mg = mir::graphics;
 
 Output::Output(
     Policy* policy,
@@ -637,7 +639,7 @@ nlohmann::json Output::to_json(bool is_focused) const
     };
 }
 
-nlohmann::json Output::to_json_for_output_list(bool) const
+nlohmann::json Output::get_outputs_json(bool) const
 {
     auto active_workspace = active();
     nlohmann::json workspace;
@@ -665,24 +667,67 @@ nlohmann::json Output::to_json_for_output_list(bool) const
     current_mode_node["height"] = current_mode.size.height.as_int();
     current_mode_node["refresh"] = current_mode.vrefresh_hz * 1000;
 
+    auto const primary = raw_output_config.custom_attribute.contains("primary")
+        ? raw_output_config.custom_attribute.at("primary") == "true"
+        : false;
+
+    std::string subpixel_hinting;
+    switch (raw_output_config.current_format)
+    {
+    case mir_pixel_format_abgr_8888:
+    case mir_pixel_format_xbgr_8888:
+    case mir_pixel_format_bgr_888:
+        subpixel_hinting = "bgr";
+        break;
+    case mir_pixel_format_argb_8888:
+    case mir_pixel_format_xrgb_8888:
+    case mir_pixel_format_rgb_888:
+    case mir_pixel_format_rgb_565:
+    case mir_pixel_format_rgba_5551:
+    case mir_pixel_format_rgba_4444:
+    default:
+        subpixel_hinting = "rgb";
+        break;
+    }
+
+    std::string make = "Unknown";
+    std::string model = "Unknown";
+    std::string serial = "0x00000000";
+    if (raw_output_config.edid.size() >= mg::Edid::minimum_size)
+    {
+        auto const edid = reinterpret_cast<mg::Edid const*>(raw_output_config.edid.data());
+        mg::Edid::Manufacturer man;
+        edid->get_manufacturer(man);
+        mg::Edid::MonitorName name;
+        edid->get_monitor_name(name);
+
+        make = man;
+        model = name;
+        // TODO: Transform the serial number to a string
+#if (MIR_SERVER_MAJOR_VERSION > 2) || (MIR_SERVER_MAJOR_VERSION == 2 && MIR_SERVER_MINOR_VERSION >= 21)
+        serial = edid->serial_number();
+#endif
+    }
+
     return {
-        { "name",                 name_                                             },
-        { "active",               active                                            },
-        { "dpms",                 raw_output_config.power_mode == mir_power_mode_on },
-        { "scale",                raw_output_config.scale                           },
-        { "scale_filter",         "linear"                                          }, // Deprecated
-        { "adaptive_sync_status", false                                             }, // TODO: Supply this value
-        { "make",                 "Unknown"                                         }, // TODO: Supply this value
-        { "model",                "Unknown"                                         }, // TODO: Supply this value
-        { "serial",               "Unknown"                                         }, // TODO: Supply this value
+        { "name",             name_                                             },
+        { "make",             make                                              },
+        { "model",            model                                             },
+        { "serial",           serial                                            },
+        { "active",           active                                            },
+        { "dpms",             raw_output_config.power_mode == mir_power_mode_on },
+        { "power",            raw_output_config.power_mode == mir_power_mode_on },
+        { "primary",          primary                                           },
+        { "scale",            active ? raw_output_config.scale : -1             },
+        { "subpixel_hinting", subpixel_hinting                                  },
         workspace,
-        { "rect",                 {
+        { "rect",             {
                       { "x", area.top_left.x.as_int() },
                       { "y", area.top_left.y.as_int() },
                       { "width", area.size.width.as_int() },
                       { "height", area.size.height.as_int() },
-                  }                                                },
-        { "modes",                modes_node                                        },
-        { "current_mode",         current_mode_node                                 },
+                  }                                            },
+        { "modes",            modes_node                                        },
+        { "current_mode",     current_mode_node                                 },
     };
 }

--- a/src/output.h
+++ b/src/output.h
@@ -81,7 +81,7 @@ public:
     [[nodiscard]] geom::Rectangle get_workspace_rectangle(size_t i) const override final;
     [[nodiscard]] WorkspaceInterface const* workspace(uint32_t id) const override final;
     [[nodiscard]] nlohmann::json to_json(bool is_focused) const override final;
-    [[nodiscard]] nlohmann::json to_json_for_output_list(bool is_focused) const override final;
+    [[nodiscard]] nlohmann::json get_outputs_json(bool is_focused) const override final;
 
 private:
     class WorkspaceAnimation : public Animation

--- a/src/output_interface.h
+++ b/src/output_interface.h
@@ -104,7 +104,7 @@ public:
     [[nodiscard]] virtual nlohmann::json to_json(bool is_focused) const = 0;
 
     /// This method should implement https://i3wm.org/docs/ipc.html#_outputs_reply
-    [[nodiscard]] virtual nlohmann::json to_json_for_output_list(bool is_focused) const = 0;
+    [[nodiscard]] virtual nlohmann::json get_outputs_json(bool is_focused) const = 0;
 };
 
 }

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -141,7 +141,7 @@ Policy::Policy(
     ipc_connection_manager(std::make_shared<IpcConnectionManager>(
         runner,
         command_controller,
-        std::make_unique<IpcCommandExecutor>(command_controller, output_manager, state, *launcher, window_controller),
+        std::make_unique<IpcCommandExecutor>(command_controller, *launcher, window_controller),
         config)),
     animator_loop(std::make_unique<ThreadedAnimatorLoop>(animator)),
     main_loop_(server.the_main_loop()),

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -241,53 +241,53 @@ bool Policy::handle_keyboard_event(MirKeyboardEvent const* event)
         case DefaultKeyCommand::Fullscreen:
             return command_controller->try_toggle_fullscreen(empty_scope);
         case DefaultKeyCommand::SelectWorkspace1:
-            return command_controller->select_workspace(1);
+            return command_controller->select_workspace(1, true);
         case DefaultKeyCommand::SelectWorkspace2:
-            return command_controller->select_workspace(2);
+            return command_controller->select_workspace(2, true);
         case DefaultKeyCommand::SelectWorkspace3:
-            return command_controller->select_workspace(3);
+            return command_controller->select_workspace(3, true);
         case DefaultKeyCommand::SelectWorkspace4:
-            return command_controller->select_workspace(4);
+            return command_controller->select_workspace(4, true);
         case DefaultKeyCommand::SelectWorkspace5:
-            return command_controller->select_workspace(5);
+            return command_controller->select_workspace(5, true);
         case DefaultKeyCommand::SelectWorkspace6:
-            return command_controller->select_workspace(6);
+            return command_controller->select_workspace(6, true);
         case DefaultKeyCommand::SelectWorkspace7:
-            return command_controller->select_workspace(7);
+            return command_controller->select_workspace(7, true);
         case DefaultKeyCommand::SelectWorkspace8:
-            return command_controller->select_workspace(8);
+            return command_controller->select_workspace(8, true);
         case DefaultKeyCommand::SelectWorkspace9:
-            return command_controller->select_workspace(9);
+            return command_controller->select_workspace(9, true);
         case DefaultKeyCommand::SelectWorkspace0:
-            return command_controller->select_workspace(0);
+            return command_controller->select_workspace(0, true);
         case DefaultKeyCommand::MoveToWorkspace1:
-            return command_controller->move_active_to_workspace(1);
+            return command_controller->move_active_to_workspace(1, true);
         case DefaultKeyCommand::MoveToWorkspace2:
-            return command_controller->move_active_to_workspace(2);
+            return command_controller->move_active_to_workspace(2, true);
         case DefaultKeyCommand::MoveToWorkspace3:
-            return command_controller->move_active_to_workspace(3);
+            return command_controller->move_active_to_workspace(3, true);
         case DefaultKeyCommand::MoveToWorkspace4:
-            return command_controller->move_active_to_workspace(4);
+            return command_controller->move_active_to_workspace(4, true);
         case DefaultKeyCommand::MoveToWorkspace5:
-            return command_controller->move_active_to_workspace(5);
+            return command_controller->move_active_to_workspace(5, true);
         case DefaultKeyCommand::MoveToWorkspace6:
-            return command_controller->move_active_to_workspace(6);
+            return command_controller->move_active_to_workspace(6, true);
         case DefaultKeyCommand::MoveToWorkspace7:
-            return command_controller->move_active_to_workspace(7);
+            return command_controller->move_active_to_workspace(7, true);
         case DefaultKeyCommand::MoveToWorkspace8:
-            return command_controller->move_active_to_workspace(8);
+            return command_controller->move_active_to_workspace(8, true);
         case DefaultKeyCommand::MoveToWorkspace9:
-            return command_controller->move_active_to_workspace(9);
+            return command_controller->move_active_to_workspace(9, true);
         case DefaultKeyCommand::MoveToWorkspace0:
-            return command_controller->move_active_to_workspace(0);
+            return command_controller->move_active_to_workspace(0, true);
         case DefaultKeyCommand::ToggleFloating:
-            return command_controller->toggle_floating();
+            return command_controller->toggle_floating({});
         case DefaultKeyCommand::TogglePinnedToWorkspace:
-            return command_controller->toggle_pinned_to_workspace();
+            return command_controller->toggle_pinned_to_workspace({});
         case DefaultKeyCommand::ToggleTabbing:
-            return command_controller->toggle_tabbing();
+            return command_controller->toggle_tabbing({});
         case DefaultKeyCommand::ToggleStacking:
-            return command_controller->toggle_stacking();
+            return command_controller->toggle_stacking({});
         default:
             std::cerr << "Unknown key_command: " << static_cast<int>(key_command) << std::endl;
             break;

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -138,7 +138,7 @@ Policy::Policy(
     drag_and_drop_service(std::make_unique<DragAndDropService>(command_controller, config, output_manager)),
     move_service(std::make_unique<MoveService>(command_controller, config, output_manager)),
     resize_service(std::make_unique<ResizeService>(command_controller, config, state, output_manager)),
-    ipc(std::make_shared<Ipc>(
+    ipc_connection_manager(std::make_shared<IpcConnectionManager>(
         runner,
         command_controller,
         std::make_unique<IpcCommandExecutor>(command_controller, output_manager, state, *launcher, window_controller),
@@ -153,26 +153,26 @@ Policy::Policy(
         config,
         animator))
 {
-    workspace_observer_registrar->register_interest(ipc);
+    workspace_observer_registrar->register_interest(ipc_connection_manager);
     workspace_observer_registrar->register_interest(self);
-    mode_observer_registrar->register_interest(ipc);
+    mode_observer_registrar->register_interest(ipc_connection_manager);
     animator_loop->start();
 
     // TODO: This is a hack until we figure out what is happening with
     //  https://github.com/canonical/mir/issues/3823.
     runner.add_stop_callback([&]
     {
-        ipc->on_shutdown();
+        ipc_connection_manager->on_shutdown();
     });
 }
 
 Policy::~Policy()
 {
-    ipc->on_shutdown();
+    ipc_connection_manager->on_shutdown();
     animator_loop->stop();
-    workspace_observer_registrar->unregister_interest(ipc.get());
+    workspace_observer_registrar->unregister_interest(ipc_connection_manager.get());
     workspace_observer_registrar->unregister_interest(self.get());
-    mode_observer_registrar->unregister_interest(ipc.get());
+    mode_observer_registrar->unregister_interest(ipc_connection_manager.get());
 }
 
 bool Policy::handle_keyboard_event(MirKeyboardEvent const* event)

--- a/src/policy.h
+++ b/src/policy.h
@@ -24,8 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "compositor_state.h"
 #include "config.h"
 #include "drag_and_drop_service.h"
-#include "ipc.h"
 #include "ipc_command_executor.h"
+#include "ipc_connection_manager.h"
 #include "mode_observer.h"
 #include "move_service.h"
 #include "output.h"
@@ -135,7 +135,7 @@ private:
     std::unique_ptr<DragAndDropService> drag_and_drop_service;
     std::unique_ptr<MoveService> move_service;
     std::unique_ptr<ResizeService> resize_service;
-    std::shared_ptr<Ipc> ipc;
+    std::shared_ptr<IpcConnectionManager> ipc_connection_manager;
     std::unique_ptr<AnimatorLoop> animator_loop;
     std::shared_ptr<ContainerGroupContainer> group_selection;
     std::shared_ptr<mir::MainLoop> main_loop_;

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -511,6 +511,36 @@ std::string Workspace::display_name() const
     return ss.str();
 }
 
+nlohmann::json Workspace::get_workspaces_json(bool is_output_focused) const
+{
+    bool const is_active_on_output = output->active().get() == this;
+
+    // Note: The reported workspace area appears to be the placement
+    // area of the root tree.
+    //   See: https://i3wm.org/docs/ipc.html#_tree_reply
+    auto const area = root->get_logical_area();
+    auto const workspace_name = display_name();
+    auto const output_name = output->name();
+
+    return {
+        {
+         "num",
+         num_ ? num_.value() : -1,
+         },
+        { "name", workspace_name },
+        { "visible", is_active_on_output },
+        { "focused", is_output_focused && is_active_on_output },
+        { "urgent", false },
+        { "output", output_name },
+        { "rect", {
+                      { "x", area.top_left.x.as_int() },
+                      { "y", area.top_left.y.as_int() },
+                      { "width", area.size.width.as_int() },
+                      { "height", area.size.height.as_int() },
+                  } }
+    };
+}
+
 nlohmann::json Workspace::to_json(bool is_output_focused) const
 {
     bool const is_active_on_output = output->active().get() == this;

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -71,6 +71,7 @@ public:
     void on_animation_end() override;
     [[nodiscard]] uint32_t id() const override { return id_; }
     [[nodiscard]] std::optional<int> num() const override { return num_; }
+    [[nodiscard]] nlohmann::json get_workspaces_json(bool is_output_focused) const override;
     [[nodiscard]] nlohmann::json to_json(bool is_output_focused) const override;
     [[nodiscard]] std::optional<std::string> const& name() const override { return name_; }
     [[nodiscard]] std::string display_name() const override;

--- a/src/workspace_interface.h
+++ b/src/workspace_interface.h
@@ -88,6 +88,9 @@ public:
 
     [[nodiscard]] virtual uint32_t id() const = 0;
     [[nodiscard]] virtual std::optional<int> num() const = 0;
+
+    /// Json returned to IPC GET_WORKSPACES command.
+    [[nodiscard]] virtual nlohmann::json get_workspaces_json(bool is_output_focused) const = 0;
     [[nodiscard]] virtual nlohmann::json to_json(bool is_output_focused) const = 0;
     [[nodiscard]] virtual std::optional<std::string> const& name() const = 0;
     [[nodiscard]] virtual std::string display_name() const = 0;

--- a/tests/mock_output.h
+++ b/tests/mock_output.h
@@ -65,7 +65,7 @@ namespace test
         MOCK_METHOD(geom::Rectangle, get_workspace_rectangle, (size_t i), (const, override));
         MOCK_METHOD(WorkspaceInterface const*, workspace, (uint32_t id), (const, override));
         MOCK_METHOD(nlohmann::json, to_json, (bool), (const, override));
-        MOCK_METHOD(nlohmann::json, to_json_for_output_list, (bool), (const, override));
+        MOCK_METHOD(nlohmann::json, get_outputs_json, (bool), (const, override));
         MOCK_METHOD(void, set_info, (int id, std::string name), (override));
         MOCK_METHOD(void, set_defunct, (), (override));
         MOCK_METHOD(void, unset_defunct, (), (override));

--- a/tests/mock_workspace.h
+++ b/tests/mock_workspace.h
@@ -69,6 +69,7 @@ namespace test
 
         MOCK_METHOD(uint32_t, id, (), (const, override));
         MOCK_METHOD(std::optional<int>, num, (), (const, override));
+        MOCK_METHOD(nlohmann::json, get_workspaces_json, (bool), (const, override));
         MOCK_METHOD(nlohmann::json, to_json, (bool), (const, override));
         MOCK_METHOD(std::optional<std::string> const&, name, (), (const, override));
         MOCK_METHOD(std::string, display_name, (), (const, override));

--- a/tests/test_command_controller.cpp
+++ b/tests/test_command_controller.cpp
@@ -86,7 +86,7 @@ TEST_F(CommandControllerTest, CannotMoveActiveToSameWorkspaceByNumber)
     EXPECT_CALL(*workspace, num())
         .WillOnce(testing::Return(1));
 
-    ASSERT_FALSE(command_controller->move_active_to_workspace(1));
+    ASSERT_FALSE(command_controller->move_active_to_workspace(1, true));
 }
 
 TEST_F(CommandControllerTest, CannotMoveActiveToSameWorkspaceByName)

--- a/tests/test_ipc_command_parser.cpp
+++ b/tests/test_ipc_command_parser.cpp
@@ -146,3 +146,26 @@ TEST_F(IpcCommandParserTest, CanParseThreeCommands)
     ASSERT_EQ(commands.commands[2].options[0], "--opt2");
     ASSERT_EQ(commands.commands[2].arguments[0], "splitv");
 }
+
+TEST_F(IpcCommandParserTest, InvlaidCommandIsNone)
+{
+    const char* v = "meow 5";
+    IpcCommandParser parser(v);
+    auto commands = parser.parse();
+    ASSERT_EQ(commands.commands.size(), 1);
+    ASSERT_EQ(commands.commands[0].type, IpcCommandType::none);
+    ASSERT_EQ(commands.commands[0].raw_command, "meow");
+    ASSERT_EQ(commands.commands[0].arguments[0], "5");
+}
+
+TEST_F(IpcCommandParserTest, CanParseOneValidAndOneInvalidCommand)
+{
+    const char* v = "meow 5; workspace 1";
+    IpcCommandParser parser(v);
+    auto commands = parser.parse();
+    ASSERT_EQ(commands.commands.size(), 2);
+    ASSERT_EQ(commands.commands[0].type, IpcCommandType::none);
+    ASSERT_EQ(commands.commands[0].raw_command, "meow");
+    ASSERT_EQ(commands.commands[1].type, IpcCommandType::workspace);
+    ASSERT_EQ(commands.commands[1].raw_command, "workspace");
+}

--- a/tests/test_workspace.cpp
+++ b/tests/test_workspace.cpp
@@ -30,11 +30,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <gtest/gtest.h>
 
 using namespace miracle;
+using namespace testing;
 
 namespace
 {
-const float OUTPUT_WIDTH = 1280;
-const float OUTPUT_HEIGHT = 720;
+const int OUTPUT_WIDTH = 1280;
+const int OUTPUT_HEIGHT = 720;
 
 const geom::Rectangle OUTPUT_SIZE {
     geom::Point(0, 0),
@@ -49,9 +50,9 @@ const geom::Rectangle OTHER_OUTPUT_SIZE {
 std::vector<std::shared_ptr<WorkspaceInterface>> empty_workspaces;
 std::vector<miral::Zone> empty_app_zones;
 
-std::unique_ptr<test::MockOutput> create_output(geom::Rectangle const& bounds)
+std::shared_ptr<test::MockOutput> create_output(geom::Rectangle const& bounds)
 {
-    auto output = std::make_unique<testing::NiceMock<test::MockOutput>>();
+    auto output = std::make_shared<testing::NiceMock<test::MockOutput>>();
     ON_CALL(*output, get_area())
         .WillByDefault(testing::ReturnRef(bounds));
     ON_CALL(*output, get_workspaces())
@@ -69,14 +70,14 @@ public:
         state(std::make_shared<CompositorState>()),
         output(create_output(OUTPUT_SIZE)),
         window_controller(std::make_shared<StubWindowController>(pairs)),
-        workspace(
+        workspace(std::make_shared<Workspace>(
             output.get(),
             0,
             0,
             "0",
             std::make_shared<test::StubConfiguration>(),
             window_controller,
-            state)
+            state))
     {
     }
 
@@ -85,7 +86,7 @@ public:
         WorkspaceInterface* target_workspace = nullptr)
     {
         if (target_workspace == nullptr)
-            target_workspace = &workspace;
+            target_workspace = workspace.get();
         miral::WindowSpecification spec;
         miral::ApplicationInfo app_info;
         auto hint = target_workspace->allocate_position(app_info, spec, { ContainerType::leaf, parent });
@@ -111,8 +112,8 @@ public:
     std::vector<std::shared_ptr<test::StubSurface>> surfaces;
     std::vector<StubWindowData> pairs;
     std::shared_ptr<StubWindowController> window_controller;
-    std::unique_ptr<test::MockOutput> output;
-    Workspace workspace;
+    std::shared_ptr<test::MockOutput> output;
+    std::shared_ptr<Workspace> workspace;
 };
 
 TEST_F(WorkspaceTest, CanAddSingleWindowWithoutBorderAndGaps)
@@ -214,7 +215,7 @@ TEST_F(WorkspaceTest, CanMoveContainerToDifferentParent)
     ASSERT_EQ(leaf2->get_logical_area().top_left, geom::Point(0, 0));
     ASSERT_EQ(leaf3->get_logical_area().top_left, geom::Point(0, ceilf(OUTPUT_HEIGHT / 3.f)));
     ASSERT_EQ(leaf1->get_logical_area().top_left, geom::Point(0, ceilf(OUTPUT_HEIGHT * (2.f / 3.f))));
-    ASSERT_EQ(workspace.get_root()->num_nodes(), 3);
+    ASSERT_EQ(workspace->get_root()->num_nodes(), 3);
 }
 
 TEST_F(WorkspaceTest, CanMoveContainerToContainerInOtherTree)
@@ -231,7 +232,7 @@ TEST_F(WorkspaceTest, CanMoveContainerToContainerInOtherTree)
     auto leaf1 = create_leaf();
     auto leaf2 = create_leaf(std::nullopt, &other);
 
-    ASSERT_EQ(leaf1->get_workspace(), &workspace);
+    ASSERT_EQ(leaf1->get_workspace(), workspace.get());
     ASSERT_EQ(leaf2->get_workspace(), &other);
 
     ASSERT_TRUE(leaf1->move_to(*leaf2));
@@ -252,7 +253,7 @@ TEST_F(WorkspaceTest, CanMoveContainerToTree)
         state);
     auto leaf1 = create_leaf();
 
-    ASSERT_EQ(leaf1->get_workspace(), &workspace);
+    ASSERT_EQ(leaf1->get_workspace(), workspace.get());
     ASSERT_TRUE(other.add_to_root(*leaf1));
     ASSERT_EQ(leaf1->get_workspace(), &other);
     ASSERT_EQ(leaf1->get_logical_area(), OTHER_OUTPUT_SIZE);
@@ -282,7 +283,7 @@ TEST_F(WorkspaceTest, DraggedWindowsAreUnconstrained)
 TEST_F(WorkspaceTest, WorkspaceBoundsAreInitializedToOutputSizeWhenNoAppZonesArePresent)
 {
     // Assert that the first tree (w/o app zones) is equal to the output size.
-    ASSERT_EQ(workspace.get_root()->get_logical_area(), OUTPUT_SIZE);
+    ASSERT_EQ(workspace->get_root()->get_logical_area(), OUTPUT_SIZE);
 }
 
 TEST_F(WorkspaceTest, WorkspaceBoundsAreInitializedToFirstZoneSizeWhenAppZonesArePresent)
@@ -310,4 +311,25 @@ TEST_F(WorkspaceTest, WorkspaceBoundsAreInitializedToFirstZoneSizeWhenAppZonesAr
 
     // Assert that the first tree (w/o app zones) is equal to the output size.
     ASSERT_EQ(other.get_root()->get_logical_area(), zone_bounds);
+}
+
+TEST_F(WorkspaceTest, GetWorkspaceJson)
+{
+    std::string const output_name = "test";
+    EXPECT_CALL(*output, name)
+        .WillOnce(testing::ReturnRef(output_name));
+    EXPECT_CALL(*output, active)
+        .WillOnce(testing::Return(workspace));
+
+    auto const json = workspace->get_workspaces_json(true);
+    EXPECT_THAT(json["num"], Eq(0));
+    EXPECT_THAT(json["name"], Eq("0:0"));
+    EXPECT_THAT(json["visible"], Eq(true));
+    EXPECT_THAT(json["focused"], Eq(true));
+    EXPECT_THAT(json["urgent"], Eq(false));
+    EXPECT_THAT(json["output"], Eq("test"));
+    EXPECT_THAT(json["rect"]["x"], Eq(0));
+    EXPECT_THAT(json["rect"]["y"], Eq(0));
+    EXPECT_THAT(json["rect"]["width"], Eq(OUTPUT_WIDTH));
+    EXPECT_THAT(json["rect"]["height"], Eq(OUTPUT_HEIGHT));
 }


### PR DESCRIPTION
## What's new?
- Created `MIRACLESOCK`
- Create `AbstractCommandController`
- Add a `primary` designation to outputs in the display config
- IPC Validation now returns an array of results so that we can provide clients with a proper response
- Split up the `Ipc` class into a connection manager and a message handler for better abstraction and testability
- Removed potential races from the `IpcCommandExecutor`