### PR TITLE
(#625) bugfix: fading animations are now working properly again + using proper transform for LeafContainer::surface always

### DIFF
--- a/src/dying_surface_manager.cpp
+++ b/src/dying_surface_manager.cpp
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "compositor_state.h"
 #include "config.h"
 #include "forwarding_surface.h"
+#include "output_interface.h"
 #include "window_controller.h"
 #include <mir/main_loop.h>
 #include <mir/shell/surface_stack.h>
@@ -40,6 +41,7 @@ public:
         mir::geometry::Rectangle const& current,
         glm::mat4 const& transform,
         glm::mat4 const& workspace_transform,
+        mir::geometry::Rectangle const& output_area,
         std::function<void()> const& on_finish) :
         Animation(handle, definition, from, to, current),
         compositor_state(state),
@@ -51,7 +53,8 @@ public:
                 .needs_outline = true,
                 .is_focused = false,
                 .transform = transform,
-                .workspace_transform = workspace_transform });
+                .workspace_transform = workspace_transform,
+                .output_area = output_area });
     }
 
     ~RawSurfaceAnimation() override
@@ -109,10 +112,11 @@ void DyingSurfaceManager::animate_dying_surface(std::shared_ptr<Container> const
     if (!config->are_animations_enabled())
         return;
 
+    auto const output_area = container->get_output()->get_area();
     auto surface = container->window()->operator std::shared_ptr<mir::scene::Surface>();
-    main_loop->enqueue(this, [this, surface = surface, container = container]
+    main_loop->enqueue(this, [this, surface = surface, container = container, output_area = output_area]
     {
-        window_controller->invoke_under_lock([this, surface = surface, container = container]
+        window_controller->invoke_under_lock([this, surface = surface, container = container, output_area = output_area]
         {
             auto animating_surface = std::make_shared<ForwardingSurface>(surface);
             auto const raw_surface_animation = std::make_shared<RawSurfaceAnimation>(
@@ -125,6 +129,7 @@ void DyingSurfaceManager::animate_dying_surface(std::shared_ptr<Container> const
                 container->get_visible_area(),
                 container->get_transform(),
                 container->get_output_transform() * container->get_workspace_transform(),
+                output_area,
                 [surface_stack = surface_stack, animating_surface = animating_surface]
             {
                 surface_stack->remove_surface(animating_surface);

--- a/src/forwarding_surface.cpp
+++ b/src/forwarding_surface.cpp
@@ -159,6 +159,7 @@ void ForwardingSurface::unregister_interest(const mir::scene::SurfaceObserver& o
 #if (MIR_SERVER_MAJOR_VERSION > 2) || (MIR_SERVER_MAJOR_VERSION == 2 && MIR_SERVER_MINOR_VERSION >= 19)
 void ForwardingSurface::initial_placement_done()
 {
+    surface_->initial_placement_done();
 }
 #endif
 

--- a/src/forwarding_surface.h
+++ b/src/forwarding_surface.h
@@ -102,7 +102,7 @@ public:
     void set_focus_mode(MirFocusMode focus_mode) override;
 #ifdef MIR_VERSION_2_21_OR_GREATER
     auto tiled_edges() const -> mir::Flags<MirTiledEdge> override { return mir::Flags { mir_tiled_edge_none }; }
-    void set_tiled_edges(mir::Flags<MirTiledEdge>) override { }
+    void set_tiled_edges(mir::Flags<MirTiledEdge> flags) override { surface_->set_tiled_edges(flags); }
 #endif
 #ifdef MIR_VERSION_2_22_OR_GREATER
     void set_mirror_mode(MirMirrorMode mirror_mode) override { surface_->set_mirror_mode(mirror_mode); }

--- a/src/leaf_container.cpp
+++ b/src/leaf_container.cpp
@@ -697,13 +697,12 @@ void LeafContainer::on_workspace_transform()
         workspace.lock()->get_output()->get_area());
 
     rdm->workspace_transform_change(id, workspace_transform(*this));
-    auto const surface = window_.operator std::shared_ptr<mir::scene::Surface>();
-    if (surface)
+    if (auto const surface = window_.operator std::shared_ptr<mir::scene::Surface>())
     {
         // While we don't use this transform in rendering, we do need it
         // so that the compositor understands which surfaces overlap
         // and properly obscures them.
-        auto full_transform = get_output_transform()
+        auto const full_transform = get_output_transform()
             * get_workspace_transform()
             * get_transform();
         surface->set_transformation(full_transform);
@@ -723,9 +722,12 @@ void LeafContainer::set_alpha(float const alpha)
     //
     // This is unfortunate.
     state->render_data_manager()->alpha_change(id, alpha);
-    if (auto surface = window_.operator std::shared_ptr<mir::scene::Surface>())
+    if (auto const surface = window_.operator std::shared_ptr<mir::scene::Surface>())
     {
-        surface->set_transformation(transform);
+        auto const full_transform = get_output_transform()
+            * get_workspace_transform()
+            * get_transform();
+        surface->set_transformation(full_transform);
     }
 }
 

--- a/src/leaf_container.cpp
+++ b/src/leaf_container.cpp
@@ -674,6 +674,13 @@ std::shared_ptr<OutputInterface> LeafContainer::get_output() const
     return workspace.lock()->get_output();
 }
 
+glm::mat4 LeafContainer::full_transform() const
+{
+    return get_output_transform()
+        * get_workspace_transform()
+        * get_transform();
+}
+
 glm::mat4 LeafContainer::get_transform() const
 {
     return transform;
@@ -681,11 +688,11 @@ glm::mat4 LeafContainer::get_transform() const
 
 void LeafContainer::set_transform(glm::mat4 transform_)
 {
+    transform = transform_;
+    state->render_data_manager()->transform_change(id, transform_);
     if (auto surface = window_.operator std::shared_ptr<mir::scene::Surface>())
     {
-        surface->set_transformation(transform_);
-        transform = transform_;
-        state->render_data_manager()->transform_change(id, transform_);
+        surface->set_transformation(full_transform());
     }
 }
 
@@ -699,13 +706,7 @@ void LeafContainer::on_workspace_transform()
     rdm->workspace_transform_change(id, workspace_transform(*this));
     if (auto const surface = window_.operator std::shared_ptr<mir::scene::Surface>())
     {
-        // While we don't use this transform in rendering, we do need it
-        // so that the compositor understands which surfaces overlap
-        // and properly obscures them.
-        auto const full_transform = get_output_transform()
-            * get_workspace_transform()
-            * get_transform();
-        surface->set_transformation(full_transform);
+        surface->set_transformation(full_transform());
     }
 }
 
@@ -724,10 +725,7 @@ void LeafContainer::set_alpha(float const alpha)
     state->render_data_manager()->alpha_change(id, alpha);
     if (auto const surface = window_.operator std::shared_ptr<mir::scene::Surface>())
     {
-        auto const full_transform = get_output_transform()
-            * get_workspace_transform()
-            * get_transform();
-        surface->set_transformation(full_transform);
+        surface->set_transformation(full_transform());
     }
 }
 

--- a/src/leaf_container.h
+++ b/src/leaf_container.h
@@ -144,6 +144,7 @@ private:
 
     static void handle_resize(Container* container, Direction direction, int amount);
     static void handle_layout_scheme(Container* container, LayoutScheme scheme);
+    glm::mat4 full_transform() const;
 };
 
 } // miracle

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -151,7 +151,6 @@ Renderer::DrawData Renderer::get_draw_data(
             if (item.surface == surface.value())
             {
                 result.data = item;
-
                 if (item.output_area != viewport)
                 {
                     result.enabled = false;

--- a/tests/test_dying_surface_manager.cpp
+++ b/tests/test_dying_surface_manager.cpp
@@ -18,15 +18,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "animator.h"
 #include "compositor_state.h"
 #include "dying_surface_manager.h"
+#include "mir/geometry/forward.h"
 #include "mock_configuration.h"
 #include "mock_container.h"
 #include "mock_main_loop.h"
 #include "mock_session.h"
 #include "mock_surface.h"
+#include "mock_output.h"
 #include "mock_surface_stack.h"
 #include "mock_window_controller.h"
 
+#include "gmock/gmock.h"
 #include <gtest/gtest.h>
+#include <memory>
 
 using namespace miracle;
 
@@ -62,12 +66,19 @@ public:
 TEST_F(DyingSurfaceManagerTest, CanAnimateValidSurface)
 {
     auto const container = std::make_shared<test::MockContainer>();
-
+    auto const output = std::make_shared<test::MockOutput>();
+    geom::Rectangle constexpr output_area({0, 0}, {19280, 1080});
+    
     // Pre-conditions for starting the animation
     EXPECT_CALL(*container, get_type())
         .WillOnce(testing::Return(ContainerType::leaf));
     EXPECT_CALL(*config, are_animations_enabled())
         .WillOnce(testing::Return(true));
+    EXPECT_CALL(*container, get_output())
+        .WillOnce(testing::Return(output));
+    EXPECT_CALL(*output, get_area())
+        .WillOnce(testing::ReturnRef(output_area));
+    
 
     auto const session = std::make_shared<test::MockSession>();
     auto const surface = std::make_shared<test::MockSurface>();

--- a/tests/test_dying_surface_manager.cpp
+++ b/tests/test_dying_surface_manager.cpp
@@ -22,9 +22,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "mock_configuration.h"
 #include "mock_container.h"
 #include "mock_main_loop.h"
+#include "mock_output.h"
 #include "mock_session.h"
 #include "mock_surface.h"
-#include "mock_output.h"
 #include "mock_surface_stack.h"
 #include "mock_window_controller.h"
 
@@ -67,8 +67,8 @@ TEST_F(DyingSurfaceManagerTest, CanAnimateValidSurface)
 {
     auto const container = std::make_shared<test::MockContainer>();
     auto const output = std::make_shared<test::MockOutput>();
-    geom::Rectangle constexpr output_area({0, 0}, {19280, 1080});
-    
+    geom::Rectangle constexpr output_area({ 0, 0 }, { 19280, 1080 });
+
     // Pre-conditions for starting the animation
     EXPECT_CALL(*container, get_type())
         .WillOnce(testing::Return(ContainerType::leaf));
@@ -78,7 +78,6 @@ TEST_F(DyingSurfaceManagerTest, CanAnimateValidSurface)
         .WillOnce(testing::Return(output));
     EXPECT_CALL(*output, get_area())
         .WillOnce(testing::ReturnRef(output_area));
-    
 
     auto const session = std::make_shared<test::MockSession>();
     auto const surface = std::make_shared<test::MockSurface>();

--- a/tests/test_leaf_container.cpp
+++ b/tests/test_leaf_container.cpp
@@ -482,7 +482,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_F(LeafContainerTest, CanSetAlpha)
 {
-    EXPECT_CALL(*surface, set_transformation(leaf_container->get_transform()));
+    EXPECT_CALL(*surface, set_transformation(testing::_));
     leaf_container->set_alpha(0.5f);
 
     auto data = state->render_data_manager()->get();


### PR DESCRIPTION
fixes #625 