### PR TITLE
(#489) bugfix: slide animations no longer cause an overflow of the tile for windows with min sizes

### DIFF
--- a/src/animator.cpp
+++ b/src/animator.cpp
@@ -255,7 +255,7 @@ BuiltInAnimation::BuiltInAnimation(
     Animation { handle },
     duration_seconds { duration_seconds },
     definition { definition },
-    current { from },
+    current { current_ },
     from { from },
     to { to }
 {

--- a/src/animator.cpp
+++ b/src/animator.cpp
@@ -257,8 +257,7 @@ BuiltInAnimation::BuiltInAnimation(
     definition { definition },
     current { from },
     from { from },
-    to { to },
-    real_size { from.size }
+    to { to }
 {
     switch (definition.type)
     {
@@ -380,7 +379,7 @@ AnimationFrameResult BuiltInAnimation::step(float dt)
     case BultInAnimationType::slide:
     {
         auto const p = ease(definition, t);
-        const auto [position, clip_area_size, transform] = slide(p, from, to);
+        const auto [position, clip_area_size] = slide(p, from, to);
         current.top_left.x = geom::X { position.x };
         current.top_left.y = geom::Y { position.y };
         current.size.width = geom::Width { clip_area_size.x };
@@ -388,7 +387,7 @@ AnimationFrameResult BuiltInAnimation::step(float dt)
         return {
             false,
             current,
-            transform,
+            std::nullopt,
             1.f
         };
     }

--- a/src/animator.cpp
+++ b/src/animator.cpp
@@ -185,16 +185,6 @@ float interpolate_scale(float const p, float const start, float const end)
     return current / end;
 }
 
-float interpolate_scale2(float const p, float const start, float const end, float const real)
-{
-    float const diff = end - start;
-    if (diff == 0)
-        return 1.f;
-
-    float const current = start + diff * p;
-    return current / real;
-}
-
 struct SlideResult
 {
     /// The current position that the surface should be in.
@@ -205,12 +195,9 @@ struct SlideResult
     /// be set to this size, as it has already been set on init().
     /// This size is strictly meant for the clip area.
     glm::vec2 clip_area_size;
-
-    /// The transformation ao apply to the surface.
-    glm::mat4 transform;
 };
 
-inline SlideResult slide(float p, geom::Rectangle const& from, geom::Rectangle const& to, geom::Size const& committed_size)
+inline SlideResult slide(float p, geom::Rectangle const& from, geom::Rectangle const& to)
 {
     auto const distance = to.top_left - from.top_left;
     float const dx = static_cast<float>(distance.dx.as_int()) * p;
@@ -219,30 +206,9 @@ inline SlideResult slide(float p, geom::Rectangle const& from, geom::Rectangle c
     float const clip_scale_x = interpolate_scale(p, static_cast<float>(from.size.width.as_value()), static_cast<float>(to.size.width.as_value()));
     float const clip_scale_y = interpolate_scale(p, static_cast<float>(from.size.height.as_value()), static_cast<float>(to.size.height.as_value()));
 
-    // This bit will only make sense by example.
-    //
-    // Let's say we're growing the width from 50px to 100px. When we first start animating,
-    // the client will not have yet confirmed the size, so it will most be 50px.
-    // In this case, [real_scale_x] will still be 200%, since it will want to scale from 50px
-    // to 100px (assuming p=0).
-    //
-    // However, after a frame or two, the actual size of the window will be 100px. In this
-    // case, we will want to scale down by ~50% (assuming p~=0) from 100px to ~50px.
-    float const real_scale_x = interpolate_scale2(
-        p,
-        static_cast<float>(from.size.width.as_value()),
-        static_cast<float>(to.size.width.as_value()),
-        static_cast<float>(committed_size.width.as_value()));
-    float const real_scale_y = interpolate_scale2(
-        p,
-        static_cast<float>(from.size.height.as_value()),
-        static_cast<float>(to.size.height.as_value()),
-        static_cast<float>(committed_size.height.as_value()));
-
     return {
         .position = glm::vec2(static_cast<float>(from.top_left.x.as_int()) + dx, static_cast<float>(from.top_left.y.as_int()) + dy),
-        .clip_area_size = glm::vec2(static_cast<float>(to.size.width.as_int()) * clip_scale_x, static_cast<float>(to.size.height.as_int()) * clip_scale_y),
-        .transform = glm::scale(glm::mat4(1.0), glm::vec3(real_scale_x, real_scale_y, 0.f))
+        .clip_area_size = glm::vec2(static_cast<float>(to.size.width.as_int()) * clip_scale_x, static_cast<float>(to.size.height.as_int()) * clip_scale_y)
     };
 }
 }
@@ -285,14 +251,14 @@ BuiltInAnimation::BuiltInAnimation(
     BuiltInAnimationDefinition definition,
     mir::geometry::Rectangle const& from,
     mir::geometry::Rectangle const& to,
-    mir::geometry::Rectangle const& current) :
+    mir::geometry::Rectangle const& current_) :
     Animation { handle },
     duration_seconds { duration_seconds },
-    definition { std::move(definition) },
-    current { current },
-    from { current },
+    definition { definition },
+    current { from },
+    from { from },
     to { to },
-    real_size { current.size }
+    real_size { from.size }
 {
     switch (definition.type)
     {
@@ -361,12 +327,6 @@ AnimationFrameResult MultiBuiltInAnimation::step(float dt)
     return result;
 }
 
-void MultiBuiltInAnimation::set_current_size(mir::geometry::Size const& size)
-{
-    for (auto& anim : animations)
-        anim.set_current_size(size);
-}
-
 AnimationFrameResult BuiltInAnimation::init()
 {
     switch (definition.type)
@@ -379,7 +339,7 @@ AnimationFrameResult BuiltInAnimation::init()
     {
         // Sliding is funky. We resize immediately but remain in the same position. The transformation
         // and position are interpolated over time to give the illusion of moving and growing.
-        const auto [position, clip_area_size, transform] = slide(0, from, to, real_size);
+        const auto [position, clip_area_size] = slide(0, from, to);
         current.top_left.x = geom::X { position.x };
         current.top_left.y = geom::Y { position.y };
         current.size.width = geom::Width { clip_area_size.x };
@@ -387,7 +347,7 @@ AnimationFrameResult BuiltInAnimation::init()
         return {
             false,
             current,
-            transform,
+            std::nullopt,
             std::nullopt
         };
     }
@@ -420,7 +380,7 @@ AnimationFrameResult BuiltInAnimation::step(float dt)
     case BultInAnimationType::slide:
     {
         auto const p = ease(definition, t);
-        const auto [position, clip_area_size, transform] = slide(p, from, to, real_size);
+        const auto [position, clip_area_size, transform] = slide(p, from, to);
         current.top_left.x = geom::X { position.x };
         current.top_left.y = geom::Y { position.y };
         current.size.width = geom::Width { clip_area_size.x };
@@ -465,11 +425,6 @@ AnimationFrameResult BuiltInAnimation::step(float dt)
     }
 }
 
-void BuiltInAnimation::set_current_size(mir::geometry::Size const& size)
-{
-    real_size = size;
-}
-
 AnimationHandle Animator::register_animateable()
 {
     std::lock_guard<std::mutex> lock(processing_lock);
@@ -510,17 +465,6 @@ void Animator::tick(float dt)
     {
         return animation->is_being_removed();
     });
-}
-
-void Animator::set_size_hack(AnimationHandle handle, mir::geometry::Size const& size)
-{
-    std::lock_guard<std::mutex> lock(processing_lock);
-
-    for (auto const& animation : active)
-    {
-        if (animation->get_handle() == handle)
-            animation->set_current_size(size);
-    }
 }
 
 void Animator::remove_by_animation_handle(AnimationHandle handle)

--- a/src/animator.h
+++ b/src/animator.h
@@ -70,7 +70,6 @@ public:
     virtual AnimationFrameResult init() = 0;
     virtual AnimationFrameResult step(float dt) = 0;
     [[nodiscard]] AnimationHandle get_handle() const;
-    virtual void set_current_size(mir::geometry::Size const& size) = 0;
     virtual void mark_for_removal();
     [[nodiscard]] virtual bool is_being_removed() const;
     virtual void on_tick(AnimationFrameResult const&) = 0;
@@ -98,7 +97,6 @@ public:
 
     AnimationFrameResult init() override;
     AnimationFrameResult step(float dt) override;
-    void set_current_size(mir::geometry::Size const& size) override;
 
     /// TODO: We shouldn't provide an empty function implementation here, but
     ///  it is useful for MultiBuiltInAnimation
@@ -110,7 +108,6 @@ private:
     mir::geometry::Rectangle current;
     mir::geometry::Rectangle from;
     mir::geometry::Rectangle to;
-    mir::geometry::Size real_size;
 };
 
 class MultiBuiltInAnimation : public Animation
@@ -127,7 +124,6 @@ public:
 
     AnimationFrameResult init() override;
     AnimationFrameResult step(float dt) override;
-    void set_current_size(mir::geometry::Size const& size) override;
 
 private:
     std::vector<BuiltInAnimation> animations;
@@ -156,7 +152,6 @@ public:
 
     /// Append a new animation to the queue.
     void append(std::shared_ptr<Animation> const& animation);
-    void set_size_hack(AnimationHandle handle, mir::geometry::Size const& size);
 
     /// Remove an animation by its handle.
     void remove_by_animation_handle(AnimationHandle handle);

--- a/src/leaf_container.cpp
+++ b/src/leaf_container.cpp
@@ -555,11 +555,6 @@ void LeafContainer::on_move_to(geom::Point const&)
 {
 }
 
-void LeafContainer::on_resize(geom::Size const& size)
-{
-    window_controller->set_size_hack(animation_handle_, size);
-}
-
 bool LeafContainer::is_fullscreen() const
 {
     return window_controller->get_state(window_) == mir_window_state_fullscreen;

--- a/src/leaf_container.h
+++ b/src/leaf_container.h
@@ -75,7 +75,7 @@ public:
     void on_focus_gained() override;
     void on_focus_lost() override;
     void on_move_to(geom::Point const&) override;
-    void on_resize(geom::Size const&) override;
+    void on_resize(geom::Size const&) override { }
     void handle_request_move(MirInputEvent const* input_event) override;
     void handle_request_resize(MirInputEvent const* input_event, MirResizeEdge edge) override;
     void request_horizontal_layout() override;

--- a/src/window_controller.h
+++ b/src/window_controller.h
@@ -55,7 +55,6 @@ public:
     virtual miral::ApplicationInfo& info_for(miral::Application const&) = 0;
     virtual miral::ApplicationInfo& app_info(miral::Window const&) = 0;
     virtual void move_cursor_to(float x, float y) = 0;
-    virtual void set_size_hack(AnimationHandle handle, geom::Size const& size) = 0;
     virtual miral::Window window_at(float x, float y) = 0;
     virtual void process_animation(AnimationFrameResult const&, std::shared_ptr<Container> const&) = 0;
     virtual void invoke_under_lock(std::function<void()> const& f) = 0;

--- a/src/window_manager_tools_window_controller.cpp
+++ b/src/window_manager_tools_window_controller.cpp
@@ -116,7 +116,7 @@ void WindowManagerToolsWindowController::set_rectangle(
         config->get_animation_definition(AnimateableEvent::window_move),
         from,
         to,
-        geom::Rectangle { window.top_left(), window.size() },
+        from,
         this,
         container);
 

--- a/src/window_manager_tools_window_controller.cpp
+++ b/src/window_manager_tools_window_controller.cpp
@@ -93,19 +93,9 @@ void WindowManagerToolsWindowController::set_rectangle(
 
     auto const& info = info_for(window);
 
-    // TODO: Remove once a real fix is added upstream
-    // Fixes: https://github.com/miracle-wm-org/miracle-wm/issues/489
-    // Workaround for: https://github.com/canonical/mir/issues/4222
-    auto const adjusted_to = geom::Rectangle {
-        to.top_left,
-        geom::Size {
-                    geom::Width(std::max(to.size.width.as_int(), info.min_width().as_value())),
-                    geom::Height(std::max(to.size.height.as_int(), info.min_height().as_value())) }
-    };
-
     if (info.parent())
     {
-        policy->handle_animation({ true, adjusted_to, std::nullopt, std::nullopt }, container);
+        policy->handle_animation({ true, to, std::nullopt, std::nullopt }, container);
         return;
     }
 
@@ -114,7 +104,7 @@ void WindowManagerToolsWindowController::set_rectangle(
         policy->handle_animation(
             AnimationFrameResult {
                 true,
-                adjusted_to,
+                to,
                 glm::mat4(1.f),
                 std::nullopt },
             container);
@@ -125,7 +115,7 @@ void WindowManagerToolsWindowController::set_rectangle(
         container->animation_handle(),
         config->get_animation_definition(AnimateableEvent::window_move),
         from,
-        adjusted_to,
+        to,
         geom::Rectangle { window.top_left(), window.size() },
         this,
         container);
@@ -235,7 +225,15 @@ void WindowManagerToolsWindowController::process_animation(
         if (rectangle)
         {
             spec.top_left() = rectangle->top_left;
-            spec.size() = rectangle->size;
+            // TODO: Remove once a real fix is added upstream
+            // Fixes: https://github.com/miracle-wm-org/miracle-wm/issues/489
+            // Workaround for: https://github.com/canonical/mir/issues/4222
+            auto const& info = tools.info_for(container->window().value());
+            spec.size() = geom::Size {
+                geom::Width(std::max(rectangle->size.width.as_int(), info.min_width().as_value())),
+                geom::Height(std::max(rectangle->size.height.as_int(), info.min_height().as_value()))
+            };
+
             needs_modify = true;
         }
 
@@ -303,11 +301,6 @@ void WindowManagerToolsWindowController::close(miral::Window const& window)
 void WindowManagerToolsWindowController::move_cursor_to(float x, float y)
 {
     tools.move_cursor_to(geom::PointF { x, y });
-}
-
-void WindowManagerToolsWindowController::set_size_hack(AnimationHandle handle, mir::geometry::Size const& size)
-{
-    animator->set_size_hack(handle, size);
 }
 
 miral::Window WindowManagerToolsWindowController::window_at(float x, float y)

--- a/src/window_manager_tools_window_controller.h
+++ b/src/window_manager_tools_window_controller.h
@@ -59,7 +59,6 @@ public:
     miral::ApplicationInfo& app_info(miral::Window const&) override;
     void close(miral::Window const& window) override;
     void move_cursor_to(float x, float y) override;
-    void set_size_hack(AnimationHandle handle, mir::geometry::Size const& size) override;
     miral::Window window_at(float x, float y) override;
     void process_animation(AnimationFrameResult const&, std::shared_ptr<Container> const&) override;
     void invoke_under_lock(std::function<void()> const& f) override;

--- a/tests/mock_window_controller.h
+++ b/tests/mock_window_controller.h
@@ -29,7 +29,6 @@ namespace test
         MOCK_METHOD(miral::ApplicationInfo&, info_for, (miral::Application const&), (override));
         MOCK_METHOD(miral::ApplicationInfo&, app_info, (miral::Window const&), (override));
         MOCK_METHOD(void, move_cursor_to, (float, float), (override));
-        MOCK_METHOD(void, set_size_hack, (AnimationHandle, geom::Size const&), (override));
         MOCK_METHOD(miral::Window, window_at, (float, float), (override));
         MOCK_METHOD(void, process_animation, (AnimationFrameResult const&, std::shared_ptr<Container> const&), (override));
         MOCK_METHOD(void, invoke_under_lock, (std::function<void()> const&), (override));

--- a/tests/stub_window_controller.h
+++ b/tests/stub_window_controller.h
@@ -110,8 +110,6 @@ public:
         return stub_app_info;
     }
 
-    void set_size_hack(AnimationHandle, mir::geometry::Size const&) override { }
-
     void move_cursor_to(float x, float y) override { }
 
     StubWindowData const& get_window_data(std::shared_ptr<Container> const& container)


### PR DESCRIPTION
fixes #489 