### PR TITLE
bugfix: default configuration is now copied to `~/.config` instead of `~/.config/miracle-wm` on accident

### DIFF
--- a/miracle-wm-config/include/miracle/miracle-wm-config.h
+++ b/miracle-wm-config/include/miracle/miracle-wm-config.h
@@ -202,6 +202,8 @@ MIRACLE_WM_CONFIG_API ConfigSaveResult save_config(std::string const& path, Conf
 
 MIRACLE_WM_CONFIG_API std::string get_config_path();
 
+MIRACLE_WM_CONFIG_API std::string get_user_config_dir();
+
 MIRACLE_WM_CONFIG_API std::string get_display_config_path();
 
 }

--- a/miracle-wm-config/src/miracle-wm-config.cpp
+++ b/miracle-wm-config/src/miracle-wm-config.cpp
@@ -1378,6 +1378,11 @@ std::string miracle::get_config_path()
     return config_path_stream.str();
 }
 
+std::string miracle::get_user_config_dir()
+{
+    return g_get_user_config_dir();
+}
+
 std::string miracle::get_display_config_path()
 {
     std::stringstream config_path_stream;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -149,8 +149,9 @@ void FilesystemConfiguration::_init(
             if (std::filesystem::exists(MIRACLE_DEFAULT_CONFIG_DIR))
             {
                 mir::log_info("Configuration hierarchy being copied from %s", MIRACLE_DEFAULT_CONFIG_DIR);
+                auto const config_dir = get_user_config_dir();
                 const auto fs_copyopts = std::filesystem::copy_options::recursive;
-                std::filesystem::copy(MIRACLE_DEFAULT_CONFIG_DIR, std::filesystem::path(config_path).parent_path(), fs_copyopts);
+                std::filesystem::copy(MIRACLE_DEFAULT_CONFIG_DIR, std::filesystem::path(config_dir), fs_copyopts);
             }
             else
             {


### PR DESCRIPTION
This fixes a bug in the Fedora spin