### PR TITLE
bugfix: no longer applying an inverse transform on a flipped surface in favor of flipping the texture coordinate

### DIFF
--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -446,10 +446,11 @@ Renderer::~Renderer()
 
 void Renderer::tessellate(
     std::vector<mgl::Primitive>& primitives,
-    mg::Renderable const& renderable)
+    mg::Renderable const& renderable,
+    bool const is_flipped)
 {
     primitives.resize(1);
-    primitives[0] = mgl::tessellate_renderable_into_rectangle(renderable, geom::Displacement { 0, 0 });
+    primitives[0] = mgl::tessellate_renderable_into_rectangle(renderable, geom::Displacement { 0, 0 }, is_flipped);
 }
 
 Renderer::DrawData Renderer::get_draw_data(
@@ -576,26 +577,12 @@ void Renderer::draw(
 
     glActiveTexture(GL_TEXTURE0);
 
-    auto const& rect = renderable.screen_position();
-    auto const centrex = static_cast<GLfloat>(rect.top_left.x.as_int() + rect.size.width.as_int()) / 2.0f;
-    auto const centrey = static_cast<GLfloat>(rect.top_left.y.as_int() + rect.size.height.as_int()) / 2.0f;
+    auto const centrex = static_cast<GLfloat>(surface_size.width.as_int()) / 2.0f;
+    auto const centrey = static_cast<GLfloat>(surface_size.height.as_int()) / 2.0f;
     glUniform2f(prog->center_uniform, centrex, centrey);
 
-    glm::mat4 transform = data.data.transform;
-    if (texture->layout() == mg::gl::Texture::Layout::TopRowFirst)
-    {
-        // GL textures have (0,0) at bottom-left rather than top-left
-        // We have to invert this texture to get it the way up GL expects.
-        transform *= glm::mat4 {
-            1.0, 0.0, 0.0, 0.0,
-            0.0, -1.0, 0.0, 0.0,
-            0.0, 0.0, 1.0, 0.0,
-            0.0, 0.0, 0.0, 1.0
-        };
-    }
-
     glUniformMatrix4fv(prog->transform_uniform, 1, GL_FALSE,
-        glm::value_ptr(transform));
+        glm::value_ptr(data.data.transform));
     glUniform1f(prog->border_radius_uniform, data.data.needs_outline ? config->get_border_config().radius : 0);
     glUniform1f(prog->alpha_uniform, alpha);
     glUniform2f(prog->surface_size_uniform, static_cast<GLfloat>(surface_size.width.as_value()), static_cast<GLfloat>(surface_size.height.as_value()));
@@ -607,7 +594,7 @@ void Renderer::draw(
     glEnableVertexAttribArray(static_cast<GLuint>(prog->texcoord_attr));
 
     primitives.clear();
-    tessellate(primitives, renderable);
+    tessellate(primitives, renderable, texture->layout() == mg::gl::Texture::Layout::TopRowFirst);
 
     // if we fail to load the texture, we need to carry on (part of lp:1629275)
     try

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -71,7 +71,8 @@ public:
 
 private:
     static void tessellate(std::vector<mir::gl::Primitive>& primitives,
-        mir::graphics::Renderable const& renderable);
+        mir::graphics::Renderable const& renderable,
+        bool const is_flipped);
 
     struct DrawData
     {

--- a/src/tessellation_helpers.cpp
+++ b/src/tessellation_helpers.cpp
@@ -48,7 +48,7 @@ auto tex_coords_from_rect(geom::Size buffer_size, geom::RectangleD sample_rect) 
 }
 
 mgl::Primitive mgl::tessellate_renderable_into_rectangle(
-    mg::Renderable const& renderable, geom::Displacement const& offset)
+    mg::Renderable const& renderable, geom::Displacement const& offset, bool const is_flipped)
 {
     auto rect = renderable.screen_position();
     rect.top_left = rect.top_left - offset;
@@ -65,19 +65,19 @@ mgl::Primitive mgl::tessellate_renderable_into_rectangle(
     auto& vertices = rectangle.vertices;
     vertices[0] = {
         { left, top, 0.0f },
-        { tex_left, tex_top }
+        { tex_left, is_flipped ? 1.f - tex_top : tex_top }
     };
     vertices[1] = {
         { left, bottom, 0.0f },
-        { tex_left, tex_bottom }
+        { tex_left, is_flipped ? 1.f - tex_bottom : tex_bottom }
     };
     vertices[2] = {
         { right, top, 0.0f },
-        { tex_right, tex_top }
+        { tex_right, is_flipped ? 1.f - tex_top : tex_top }
     };
     vertices[3] = {
         { right, bottom, 0.0f },
-        { tex_right, tex_bottom }
+        { tex_right, is_flipped ? 1.f - tex_bottom : tex_bottom }
     };
     return rectangle;
 }

--- a/src/tessellation_helpers.h
+++ b/src/tessellation_helpers.h
@@ -30,7 +30,7 @@ namespace gl
 {
 
     Primitive tessellate_renderable_into_rectangle(
-        graphics::Renderable const& renderable, geometry::Displacement const& offset);
+        graphics::Renderable const& renderable, geometry::Displacement const& offset, bool const is_flipped);
 
 }
 }


### PR DESCRIPTION
So much cleaner :pray: 