### PR TITLE
feature: add the ability to include one configuration in another

### DIFF
--- a/miracle-wm-config/include/miracle/miracle-wm-config-c.h
+++ b/miracle-wm-config/include/miracle/miracle-wm-config-c.h
@@ -118,6 +118,12 @@ extern "C"
     // Frees the memory allocated by [miracle_config_save].
     void miracle_save_result_free(miracle_config_save_result_t* result);
 
+    size_t miracle_config_get_num_includes(const miracle_config_data_t* config);
+    const char* miracle_config_get_include(const miracle_config_data_t* config, size_t index);
+    void miracle_config_add_include(const miracle_config_data_t* config, const char* value);
+    void miracle_config_remove_include(const miracle_config_data_t* config, size_t index);
+    void miracle_config_set_include(const miracle_config_data_t* config, const char* value, size_t index);
+
     uint miracle_config_get_primary_modifier(const miracle_config_data_t* config);
     void miracle_config_set_primary_modifier(miracle_config_data_t* config, uint modifier);
 

--- a/miracle-wm-config/include/miracle/miracle-wm-config.h
+++ b/miracle-wm-config/include/miracle/miracle-wm-config.h
@@ -178,6 +178,9 @@ struct MIRACLE_WM_CONFIG_API ConfigData
     CursorConfiguration cursor;
     SlowKeysConfiguration slow_keys;
     StickyKeysConfiguration sticky_keys;
+
+    /// Other configuration files to include in addition to this one.
+    std::vector<std::string> includes;
 };
 
 enum class ErrorLevel

--- a/miracle-wm-config/include/miracle/miracle-wm-config.h
+++ b/miracle-wm-config/include/miracle/miracle-wm-config.h
@@ -169,9 +169,7 @@ struct MIRACLE_WM_CONFIG_API ConfigData
     miracle::WithDefaultFlag<uint> move_modifier = miracle_input_event_modifier_default;
     miracle::WithDefaultFlag<DragAndDropConfiguration> drag_and_drop;
     miracle::WithDefaultFlag<miral::InputConfiguration::Mouse> mouse_configuration;
-#if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 3, 0)
     miracle::WithDefaultFlag<miral::InputConfiguration::Keyboard> keyboard_configuration;
-#endif
     miracle::WithDefaultFlag<std::optional<KeymapConfiguration>> keymap;
     miracle::WithDefaultFlag<HoverClickConfiguration> hover_click;
     miracle::WithDefaultFlag<SimulatedSecondaryClickConfiguration> simulated_secondary_click;
@@ -181,7 +179,9 @@ struct MIRACLE_WM_CONFIG_API ConfigData
     miracle::WithDefaultFlag<StickyKeysConfiguration> sticky_keys;
 
     /// Other configuration files to include in addition to this one.
-    std::vector<std::string> includes;
+    miracle::WithDefaultFlag<std::vector<std::string>> includes;
+
+    ConfigData merge_with(ConfigData& other);
 };
 
 enum class ErrorLevel

--- a/miracle-wm-config/include/miracle/miracle-wm-config.h
+++ b/miracle-wm-config/include/miracle/miracle-wm-config.h
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "export.h"
 #include "gaps.h"
 #include "modifiers.h"
+#include "with_default_flag.h"
 
 #include <array>
 #include <cstdlib>
@@ -151,33 +152,33 @@ struct MIRACLE_WM_CONFIG_API StickyKeysConfiguration
 struct MIRACLE_WM_CONFIG_API ConfigData
 {
     ConfigData();
-    uint primary_modifier = mir_input_event_modifier_meta;
-    uint primary_button = mir_pointer_button_primary;
-    std::vector<CustomKeyCommand> custom_key_commands;
-    std::vector<BuiltInKeyCommandOverride> built_in_key_command_overrides;
-    Gaps inner_gaps = { .top = 10, .bottom = 10, .left = 10, .right = 10 };
-    Gaps outer_gaps = { .top = 10, .bottom = 10, .left = 10, .right = 10 };
-    std::vector<StartupApp> startup_apps;
-    std::optional<std::string> terminal = "miracle-wm-sensible-terminal";
-    int resize_jump = 50;
-    std::vector<EnvironmentVariable> environment_variables;
-    BorderConfig border_config;
-    bool animations_enabled = true;
-    std::array<AnimationDefinition, static_cast<int>(AnimateableEvent::max)> animation_definitions;
-    std::vector<WorkspaceConfig> workspace_configs;
-    uint move_modifier = miracle_input_event_modifier_default;
-    DragAndDropConfiguration drag_and_drop;
-    miral::InputConfiguration::Mouse mouse_configuration;
+    miracle::WithDefaultFlag<uint> primary_modifier = mir_input_event_modifier_meta;
+    miracle::WithDefaultFlag<uint> primary_button = mir_pointer_button_primary;
+    miracle::WithDefaultFlag<std::vector<CustomKeyCommand>> custom_key_commands;
+    miracle::WithDefaultFlag<std::vector<BuiltInKeyCommandOverride>> built_in_key_command_overrides;
+    miracle::WithDefaultFlag<Gaps> inner_gaps = Gaps { .top = 10, .bottom = 10, .left = 10, .right = 10 };
+    miracle::WithDefaultFlag<Gaps> outer_gaps = Gaps { .top = 10, .bottom = 10, .left = 10, .right = 10 };
+    miracle::WithDefaultFlag<std::vector<StartupApp>> startup_apps;
+    miracle::WithDefaultFlag<std::optional<std::string>> terminal = std::optional<std::string>("miracle-wm-sensible-terminal");
+    miracle::WithDefaultFlag<int> resize_jump = 50;
+    miracle::WithDefaultFlag<std::vector<EnvironmentVariable>> environment_variables;
+    miracle::WithDefaultFlag<BorderConfig> border_config;
+    miracle::WithDefaultFlag<bool> animations_enabled = true;
+    miracle::WithDefaultFlag<std::array<AnimationDefinition, static_cast<int>(AnimateableEvent::max)>> animation_definitions;
+    miracle::WithDefaultFlag<std::vector<WorkspaceConfig>> workspace_configs;
+    miracle::WithDefaultFlag<uint> move_modifier = miracle_input_event_modifier_default;
+    miracle::WithDefaultFlag<DragAndDropConfiguration> drag_and_drop;
+    miracle::WithDefaultFlag<miral::InputConfiguration::Mouse> mouse_configuration;
 #if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 3, 0)
-    miral::InputConfiguration::Keyboard keyboard_configuration;
+    miracle::WithDefaultFlag<miral::InputConfiguration::Keyboard> keyboard_configuration;
 #endif
-    std::optional<KeymapConfiguration> keymap;
-    HoverClickConfiguration hover_click;
-    SimulatedSecondaryClickConfiguration simulated_secondary_click;
-    OutputFilterConfiguration output_filter;
-    CursorConfiguration cursor;
-    SlowKeysConfiguration slow_keys;
-    StickyKeysConfiguration sticky_keys;
+    miracle::WithDefaultFlag<std::optional<KeymapConfiguration>> keymap;
+    miracle::WithDefaultFlag<HoverClickConfiguration> hover_click;
+    miracle::WithDefaultFlag<SimulatedSecondaryClickConfiguration> simulated_secondary_click;
+    miracle::WithDefaultFlag<OutputFilterConfiguration> output_filter;
+    miracle::WithDefaultFlag<CursorConfiguration> cursor;
+    miracle::WithDefaultFlag<SlowKeysConfiguration> slow_keys;
+    miracle::WithDefaultFlag<StickyKeysConfiguration> sticky_keys;
 
     /// Other configuration files to include in addition to this one.
     std::vector<std::string> includes;

--- a/miracle-wm-config/include/miracle/with_default_flag.h
+++ b/miracle-wm-config/include/miracle/with_default_flag.h
@@ -1,0 +1,75 @@
+/**
+Copyright (C) 2024  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef MIRACLE_DEFAULT_TRACKER_H
+#define MIRACLE_DEFAULT_TRACKER_H
+#include <type_traits>
+#include <utility>
+
+namespace miracle
+{
+template <typename T>
+class WithDefaultFlag
+{
+public:
+    WithDefaultFlag() = default;
+    WithDefaultFlag(const T& v) :
+        value(v),
+        is_default_value(true)
+    {
+    }
+    WithDefaultFlag(const WithDefaultFlag&) = default;
+    WithDefaultFlag(WithDefaultFlag&&) noexcept = default;
+    WithDefaultFlag& operator=(const WithDefaultFlag&) = default;
+    WithDefaultFlag& operator=(WithDefaultFlag&&) noexcept = default;
+
+    WithDefaultFlag& operator=(const T& v)
+    {
+        value = v;
+        is_default_value = false;
+        return *this;
+    }
+
+    WithDefaultFlag& operator=(T&& v)
+    {
+        value = std::move(v);
+        is_default_value = false;
+        return *this;
+    }
+
+    operator T&() = delete;
+    operator const T&() const { return value; }
+
+    T* operator->()
+    {
+        is_default_value = false;
+        return &value;
+    }
+    const T* operator->() const { return &value; }
+
+    T& operator*() { return value; }
+    const T& operator*() const { return value; }
+
+    bool operator==(const WithDefaultFlag& other) const = delete;
+    bool operator!=(const WithDefaultFlag& other) const = delete;
+
+    T value {};
+    bool is_default_value { true };
+};
+}
+
+#endif

--- a/miracle-wm-config/include/miracle/with_default_flag.h
+++ b/miracle-wm-config/include/miracle/with_default_flag.h
@@ -67,6 +67,8 @@ public:
     bool operator==(const WithDefaultFlag& other) const = delete;
     bool operator!=(const WithDefaultFlag& other) const = delete;
 
+    bool is_set() const { return !is_default_value; }
+
     T value {};
     bool is_default_value { true };
 };

--- a/miracle-wm-config/src/miracle-wm-config-c.cpp
+++ b/miracle-wm-config/src/miracle-wm-config-c.cpp
@@ -120,31 +120,31 @@ extern "C"
     size_t miracle_config_get_num_includes(const miracle_config_data_t* config)
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
-        return data->includes.size();
+        return data->includes->size();
     }
 
     const char* miracle_config_get_include(const miracle_config_data_t* config, size_t index)
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
-        return data->includes[index].c_str();
+        return data->includes.value[index].c_str();
     }
 
     void miracle_config_add_include(const miracle_config_data_t* config, const char* value)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->includes.push_back(value);
+        data->includes->push_back(value);
     }
 
     void miracle_config_remove_include(const miracle_config_data_t* config, size_t index)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->includes.erase(data->includes.begin() + static_cast<std::vector<std::string>::difference_type>(index));
+        data->includes->erase(data->includes->begin() + static_cast<std::vector<std::string>::difference_type>(index));
     }
 
     void miracle_config_set_include(const miracle_config_data_t* config, const char* value, size_t index)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->includes[index] = value;
+        data->includes.value[index] = value;
     }
 
     uint miracle_config_get_primary_modifier(const miracle_config_data_t* config)

--- a/miracle-wm-config/src/miracle-wm-config-c.cpp
+++ b/miracle-wm-config/src/miracle-wm-config-c.cpp
@@ -344,53 +344,53 @@ extern "C"
     uint miracle_config_get_inner_gaps_x(const miracle_config_data_t* config)
     {
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        return data->inner_gaps.left;
+        return data->inner_gaps->left;
     }
 
     void miracle_config_set_inner_gaps_x(miracle_config_data_t* config, uint value)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->inner_gaps.left = value;
-        data->inner_gaps.right = value;
+        data->inner_gaps->left = value;
+        data->inner_gaps->right = value;
     }
 
     uint miracle_config_get_inner_gaps_y(const miracle_config_data_t* config)
     {
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        return data->inner_gaps.top;
+        return data->inner_gaps->top;
     }
 
     void miracle_config_set_inner_gaps_y(miracle_config_data_t* config, uint value)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->inner_gaps.top = value;
-        data->inner_gaps.bottom = value;
+        data->inner_gaps->top = value;
+        data->inner_gaps->bottom = value;
     }
 
     uint miracle_config_get_outer_gaps_x(const miracle_config_data_t* config)
     {
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        return data->outer_gaps.left;
+        return data->outer_gaps->left;
     }
 
     void miracle_config_set_outer_gaps_x(miracle_config_data_t* config, uint value)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->outer_gaps.left = value;
-        data->outer_gaps.right = value;
+        data->outer_gaps->left = value;
+        data->outer_gaps->right = value;
     }
 
     uint miracle_config_get_outer_gaps_y(const miracle_config_data_t* config)
     {
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        return data->outer_gaps.top;
+        return data->outer_gaps->top;
     }
 
     void miracle_config_set_outer_gaps_y(miracle_config_data_t* config, uint value)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->outer_gaps.top = value;
-        data->outer_gaps.bottom = value;
+        data->outer_gaps->top = value;
+        data->outer_gaps->bottom = value;
     }
 
     int miracle_config_get_resize_jump(const miracle_config_data_t* config)
@@ -420,7 +420,7 @@ extern "C"
     const char* miracle_config_get_terminal(const miracle_config_data_t* config)
     {
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        return data->terminal ? data->terminal->c_str() : nullptr;
+        return *data->terminal ? data->terminal->value().c_str() : nullptr;
     }
 
     void miracle_config_set_terminal(miracle_config_data_t* config, const char* terminal)
@@ -432,7 +432,7 @@ extern "C"
     size_t miracle_config_get_custom_key_command_count(const miracle_config_data_t* config)
     {
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        return data->custom_key_commands.size();
+        return data->custom_key_commands->size();
     }
 
     miracle_custom_key_command_t miracle_config_get_custom_key_command(
@@ -441,11 +441,11 @@ extern "C"
     {
 
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        if (index >= data->custom_key_commands.size())
+        if (index >= data->custom_key_commands->size())
             return { 0, 0, 0, nullptr };
 
         static thread_local std::string command_copy;
-        const auto& cmd = data->custom_key_commands[index];
+        const auto& cmd = data->custom_key_commands.value[index];
         command_copy = cmd.command;
 
         return {
@@ -475,7 +475,7 @@ extern "C"
             return;
 
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->custom_key_commands.push_back({ static_cast<MirKeyboardAction>(action),
+        data->custom_key_commands->push_back({ static_cast<MirKeyboardAction>(action),
             modifiers,
             key,
             command ? command : "" });
@@ -490,7 +490,7 @@ extern "C"
         const char* command)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        if (index >= data->custom_key_commands.size())
+        if (index >= data->custom_key_commands->size())
             return;
 
         bool found_action = false;
@@ -503,7 +503,7 @@ extern "C"
         if (!found_action)
             return;
 
-        data->custom_key_commands[index] = { static_cast<MirKeyboardAction>(action),
+        data->custom_key_commands.value[index] = { static_cast<MirKeyboardAction>(action),
             modifiers,
             key,
             command ? command : "" };
@@ -512,23 +512,23 @@ extern "C"
     void miracle_config_clear_custom_key_commands(miracle_config_data_t* config)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->custom_key_commands.clear();
+        data->custom_key_commands->clear();
     }
 
     bool miracle_config_remove_custom_key_command(miracle_config_data_t* config, size_t index)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        if (index >= data->custom_key_commands.size())
+        if (index >= data->custom_key_commands->size())
             return false;
 
-        data->custom_key_commands.erase(data->custom_key_commands.begin() + static_cast<std::vector<miracle::CustomKeyCommand>::difference_type>(index));
+        data->custom_key_commands->erase(data->custom_key_commands->begin() + static_cast<std::vector<miracle::CustomKeyCommand>::difference_type>(index));
         return true;
     }
 
     size_t miracle_config_get_built_in_key_command_override_count(const miracle_config_data_t* config)
     {
         auto const data = static_cast<miracle::ConfigData*>(config->_internal);
-        return data->built_in_key_command_overrides.size();
+        return data->built_in_key_command_overrides->size();
     }
 
     miracle_built_in_key_command_t miracle_config_get_built_in_key_command_override(
@@ -536,7 +536,7 @@ extern "C"
         size_t index)
     {
         auto const data = static_cast<miracle::ConfigData*>(config->_internal);
-        auto const& command = data->built_in_key_command_overrides[index];
+        auto const& command = data->built_in_key_command_overrides.value[index];
         return {
             .action = static_cast<uint>(command.action),
             .modifiers = command.modifiers,
@@ -553,7 +553,7 @@ extern "C"
         uint command)
     {
         auto const data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->built_in_key_command_overrides.push_back(miracle::BuiltInKeyCommandOverride {
+        data->built_in_key_command_overrides->push_back(miracle::BuiltInKeyCommandOverride {
             static_cast<MirKeyboardAction>(action),
             modifiers,
             key,
@@ -569,10 +569,10 @@ extern "C"
         uint command)
     {
         auto const data = static_cast<miracle::ConfigData*>(config->_internal);
-        if (index >= data->built_in_key_command_overrides.size())
+        if (index >= data->built_in_key_command_overrides->size())
             return;
 
-        data->built_in_key_command_overrides[index] = miracle::BuiltInKeyCommandOverride {
+        data->built_in_key_command_overrides.value[index] = miracle::BuiltInKeyCommandOverride {
             static_cast<MirKeyboardAction>(action),
             modifiers,
             key,
@@ -585,27 +585,27 @@ extern "C"
         size_t index)
     {
         auto const data = static_cast<miracle::ConfigData*>(config->_internal);
-        if (index >= data->built_in_key_command_overrides.size())
+        if (index >= data->built_in_key_command_overrides->size())
             return false;
 
-        data->built_in_key_command_overrides.erase(data->built_in_key_command_overrides.begin() + +static_cast<std::vector<miracle::BuiltInKeyCommandOverride>::difference_type>(index));
+        data->built_in_key_command_overrides->erase(data->built_in_key_command_overrides->begin() + +static_cast<std::vector<miracle::BuiltInKeyCommandOverride>::difference_type>(index));
         return true;
     }
 
     size_t miracle_config_get_startup_app_count(const miracle_config_data_t* config)
     {
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        return data->startup_apps.size();
+        return data->startup_apps->size();
     }
 
     miracle_startup_app_t miracle_config_get_startup_app(const miracle_config_data_t* config, size_t index)
     {
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        if (index >= data->startup_apps.size())
+        if (index >= data->startup_apps->size())
             return { nullptr, false, false, false, false };
 
         static thread_local std::string command_copy;
-        const auto& app = data->startup_apps[index];
+        const auto& app = data->startup_apps.value[index];
         command_copy = app.command;
 
         return {
@@ -626,7 +626,7 @@ extern "C"
         bool in_systemd_scope)
     {
         auto const data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->startup_apps.push_back({ command ? command : "",
+        data->startup_apps->push_back({ command ? command : "",
             restart_on_death,
             no_startup_id,
             should_halt_compositor_on_death,
@@ -643,10 +643,10 @@ extern "C"
         bool in_systemd_scope)
     {
         auto const data = static_cast<miracle::ConfigData*>(config->_internal);
-        if (index >= data->startup_apps.size())
+        if (index >= data->startup_apps->size())
             return;
 
-        data->startup_apps[index] = { command ? command : "",
+        data->startup_apps.value[index] = { command ? command : "",
             restart_on_death,
             no_startup_id,
             should_halt_compositor_on_death,
@@ -656,23 +656,23 @@ extern "C"
     void miracle_config_clear_startup_apps(miracle_config_data_t* config)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->startup_apps.clear();
+        data->startup_apps->clear();
     }
 
     bool miracle_config_remove_startup_app(miracle_config_data_t* config, size_t index)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        if (index >= data->startup_apps.size())
+        if (index >= data->startup_apps->size())
             return false;
 
-        data->startup_apps.erase(data->startup_apps.begin() + static_cast<std::vector<miracle::StartupApp>::difference_type>(index));
+        data->startup_apps->erase(data->startup_apps->begin() + static_cast<std::vector<miracle::StartupApp>::difference_type>(index));
         return true;
     }
 
     size_t miracle_config_get_environment_variable_count(const miracle_config_data_t* config)
     {
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        return data->environment_variables.size();
+        return data->environment_variables->size();
     }
 
     miracle_environment_variable_t miracle_config_get_environment_variable(
@@ -681,12 +681,12 @@ extern "C"
     {
 
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        if (index >= data->environment_variables.size())
+        if (index >= data->environment_variables->size())
             return { nullptr, nullptr };
 
         static thread_local std::string key_copy;
         static thread_local std::string value_copy;
-        const auto& var = data->environment_variables[index];
+        const auto& var = data->environment_variables.value[index];
         key_copy = var.key;
         value_copy = var.value;
 
@@ -703,7 +703,7 @@ extern "C"
     {
 
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->environment_variables.push_back({ key ? key : "",
+        data->environment_variables->push_back({ key ? key : "",
             value ? value : "" });
     }
 
@@ -714,26 +714,26 @@ extern "C"
         const char* value)
     {
         auto const data = static_cast<miracle::ConfigData*>(config->_internal);
-        if (index >= data->environment_variables.size())
+        if (index >= data->environment_variables->size())
             return;
 
-        data->environment_variables[index] = { key ? key : "",
+        data->environment_variables.value[index] = { key ? key : "",
             value ? value : "" };
     }
 
     void miracle_config_clear_environment_variables(miracle_config_data_t* config)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->environment_variables.clear();
+        data->environment_variables->clear();
     }
 
     bool miracle_config_remove_environment_variable(miracle_config_data_t* config, size_t index)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        if (index >= data->environment_variables.size())
+        if (index >= data->environment_variables->size())
             return false;
 
-        data->environment_variables.erase(data->environment_variables.begin() + +static_cast<std::vector<miracle::EnvironmentVariable>::difference_type>(index));
+        data->environment_variables->erase(data->environment_variables->begin() + +static_cast<std::vector<miracle::EnvironmentVariable>::difference_type>(index));
         return true;
     }
 
@@ -746,14 +746,14 @@ extern "C"
     {
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
         miracle_border_config_t result;
-        result.size = data->border_config.size;
-        result.radius = data->border_config.radius;
+        result.size = data->border_config->size;
+        result.radius = data->border_config->radius;
 
         // Copy glm::vec4 to float[4]
         for (int i = 0; i < 4; i++)
         {
-            result.focus_color[i] = data->border_config.focus_color[i];
-            result.color[i] = data->border_config.color[i];
+            result.focus_color[i] = data->border_config->focus_color[i];
+            result.color[i] = data->border_config->color[i];
         }
 
         return result;
@@ -768,15 +768,15 @@ extern "C"
     {
 
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->border_config.size = size;
-        data->border_config.radius = radius;
+        data->border_config->size = size;
+        data->border_config->radius = radius;
 
         // Copy float[4] to glm::vec4
         if (focus_color)
         {
             for (int i = 0; i < 4; i++)
             {
-                data->border_config.focus_color[i] = focus_color[i];
+                data->border_config->focus_color[i] = focus_color[i];
             }
         }
 
@@ -784,7 +784,7 @@ extern "C"
         {
             for (int i = 0; i < 4; i++)
             {
-                data->border_config.color[i] = color[i];
+                data->border_config->color[i] = color[i];
             }
         }
     }
@@ -799,7 +799,7 @@ extern "C"
         size_t index)
     {
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        const auto& def = data->animation_definitions[index];
+        const auto& def = data->animation_definitions.value[index];
 
         return {
             def.is_default,
@@ -822,7 +822,7 @@ extern "C"
         const miracle_animation_definition_t* definition)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        auto& def = data->animation_definitions[index];
+        auto& def = data->animation_definitions.value[index];
 
         def.is_default = false;
         def.animations[0].type = static_cast<miracle::BultInAnimationType>(definition->type);
@@ -842,14 +842,14 @@ extern "C"
         size_t index)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        auto& def = data->animation_definitions[index];
+        auto& def = data->animation_definitions.value[index];
         def = miracle::internal::default_animation_definitions[index];
     }
 
     size_t miracle_config_get_workspace_config_count(const miracle_config_data_t* config)
     {
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        return data->workspace_configs.size();
+        return data->workspace_configs->size();
     }
 
     miracle_workspace_config_t miracle_config_get_workspace_config(
@@ -858,11 +858,11 @@ extern "C"
     {
 
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
-        if (index >= data->workspace_configs.size())
+        if (index >= data->workspace_configs->size())
             return { -1, -1, nullptr };
 
         static thread_local std::string name_copy;
-        const auto& ws = data->workspace_configs[index];
+        const auto& ws = data->workspace_configs.value[index];
 
         if (ws.name)
             name_copy = *ws.name;
@@ -893,7 +893,7 @@ extern "C"
         if (name)
             ws.name = name;
 
-        data->workspace_configs.push_back(ws);
+        data->workspace_configs->push_back(ws);
     }
 
     void miracle_config_set_workspace_config(
@@ -905,7 +905,7 @@ extern "C"
     {
 
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        if (index >= data->workspace_configs.size())
+        if (index >= data->workspace_configs->size())
             return;
 
         miracle::WorkspaceConfig ws;
@@ -917,7 +917,7 @@ extern "C"
         if (name)
             ws.name = name;
 
-        data->workspace_configs[index] = ws;
+        data->workspace_configs.value[index] = ws;
     }
 
     bool miracle_config_remove_workspace_config(
@@ -926,10 +926,10 @@ extern "C"
     {
 
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        if (index >= data->workspace_configs.size())
+        if (index >= data->workspace_configs->size())
             return false;
 
-        data->workspace_configs.erase(data->workspace_configs.begin() + +static_cast<std::vector<miracle::WorkspaceConfig>::difference_type>(index));
+        data->workspace_configs->erase(data->workspace_configs->begin() + +static_cast<std::vector<miracle::WorkspaceConfig>::difference_type>(index));
         return true;
     }
 
@@ -949,8 +949,8 @@ extern "C"
     {
         auto data = static_cast<const miracle::ConfigData*>(config->_internal);
         return {
-            data->drag_and_drop.enabled,
-            data->drag_and_drop.modifiers
+            data->drag_and_drop->enabled,
+            data->drag_and_drop->modifiers
         };
     }
 
@@ -961,19 +961,19 @@ extern "C"
     {
 
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->drag_and_drop.enabled = enabled;
-        data->drag_and_drop.modifiers = modifiers;
+        data->drag_and_drop->enabled = enabled;
+        data->drag_and_drop->modifiers = modifiers;
     }
 
     miracle_mouse_config_t miracle_config_get_mouse_config(const miracle_config_data_t* config)
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
         return {
-            data->mouse_configuration.handedness().value_or(mir_pointer_handedness_right),
-            data->mouse_configuration.acceleration_bias().value_or(0.0),
-            data->mouse_configuration.vscroll_speed().value_or(1.0),
-            data->mouse_configuration.hscroll_speed().value_or(1.0),
-            data->mouse_configuration.acceleration().value_or(mir_pointer_acceleration_none)
+            data->mouse_configuration->handedness().value_or(mir_pointer_handedness_right),
+            data->mouse_configuration->acceleration_bias().value_or(0.0),
+            data->mouse_configuration->vscroll_speed().value_or(1.0),
+            data->mouse_configuration->hscroll_speed().value_or(1.0),
+            data->mouse_configuration->acceleration().value_or(mir_pointer_acceleration_none)
         };
     }
 
@@ -986,25 +986,25 @@ extern "C"
         MirPointerAcceleration acceleration)
     {
         auto const data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->mouse_configuration.handedness(handedness);
-        data->mouse_configuration.acceleration_bias(acceleration_bias);
-        data->mouse_configuration.vscroll_speed(vscroll_speed);
-        data->mouse_configuration.hscroll_speed(hscroll_speed);
-        data->mouse_configuration.acceleration(acceleration);
+        data->mouse_configuration->handedness(handedness);
+        data->mouse_configuration->acceleration_bias(acceleration_bias);
+        data->mouse_configuration->vscroll_speed(vscroll_speed);
+        data->mouse_configuration->hscroll_speed(hscroll_speed);
+        data->mouse_configuration->acceleration(acceleration);
     }
 
     miracle_keymap_t miracle_config_get_keymap(const miracle_config_data_t* config)
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
-        if (!data->keymap)
+        if (!*data->keymap)
             return { .is_set = false };
 
         return {
             .is_set = true,
-            .language = data->keymap->language.c_str(),
-            .has_variant = data->keymap->variant.has_value(),
-            .variant = data->keymap->variant ? data->keymap->variant->c_str() : "",
-            .options_count = data->keymap->options.size()
+            .language = data->keymap->value().language.c_str(),
+            .has_variant = data->keymap->value().variant.has_value(),
+            .variant = data->keymap->value().variant ? data->keymap->value().variant->c_str() : "",
+            .options_count = data->keymap->value().options.size()
         };
     }
 
@@ -1018,22 +1018,22 @@ extern "C"
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
         if (!is_set)
             data->keymap = std::nullopt;
-        else if (!data->keymap)
+        else if (!*data->keymap)
             data->keymap = miracle::KeymapConfiguration();
 
-        if (!data->keymap)
+        if (!*data->keymap)
             return;
 
-        data->keymap->language = language;
-        data->keymap->variant = has_variant ? variant : std::optional<std::string>();
+        data->keymap->value().language = language;
+        data->keymap->value().variant = has_variant ? variant : std::optional<std::string>();
     }
 
     const char* miracle_config_get_keymap_option(const miracle_config_data_t* config, size_t index)
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
-        if (index >= data->keymap->options.size())
+        if (index >= data->keymap->value().options.size())
             return nullptr;
-        return data->keymap->options[index].c_str();
+        return data->keymap->value().options[index].c_str();
     }
 
     void miracle_config_set_keymap_option(
@@ -1042,29 +1042,29 @@ extern "C"
         const char* option)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        if (index >= data->keymap->options.size())
+        if (index >= data->keymap->value().options.size())
             return;
-        data->keymap->options[index] = option;
+        data->keymap->value().options[index] = option;
     }
 
     void miracle_config_add_keymap_option(miracle_config_data_t* config, const char* option)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->keymap->options.push_back(option);
+        data->keymap->value().options.push_back(option);
     }
     void miracle_config_remove_keymap_option(miracle_config_data_t* config, size_t index)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        if (index >= data->keymap->options.size())
+        if (index >= data->keymap->value().options.size())
             return;
-        data->keymap->options.erase(data->keymap->options.begin() + +static_cast<std::vector<std::string>::difference_type>(index));
+        data->keymap->value().options.erase(data->keymap->value().options.begin() + +static_cast<std::vector<std::string>::difference_type>(index));
     }
 
     int miracle_config_get_key_repeat_delay(const miracle_config_data_t* config)
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
 #if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 3, 0)
-        return data->keyboard_configuration.repeat_delay().value_or(600);
+        return data->keyboard_configuration->repeat_delay().value_or(600);
 #endif
     }
 
@@ -1072,7 +1072,7 @@ extern "C"
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
 #if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 3, 0)
-        data->keyboard_configuration.set_repeat_delay(delay);
+        data->keyboard_configuration->set_repeat_delay(delay);
 #else
         (void)delay;
 #endif
@@ -1082,7 +1082,7 @@ extern "C"
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
 #if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 3, 0)
-        return data->keyboard_configuration.repeat_rate().value_or(25);
+        return data->keyboard_configuration->repeat_rate().value_or(25);
 #endif
     }
 
@@ -1090,7 +1090,7 @@ extern "C"
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
 #if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 3, 0)
-        data->keyboard_configuration.set_repeat_rate(rate);
+        data->keyboard_configuration->set_repeat_rate(rate);
 #else
         (void)rate;
 #endif
@@ -1100,10 +1100,10 @@ extern "C"
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
         return {
-            data->hover_click.enabled,
-            data->hover_click.hover_duration_milliseconds,
-            data->hover_click.cancel_displacement_threshold,
-            data->hover_click.reclick_displacement_threshold
+            data->hover_click->enabled,
+            data->hover_click->hover_duration_milliseconds,
+            data->hover_click->cancel_displacement_threshold,
+            data->hover_click->reclick_displacement_threshold
         };
     }
 
@@ -1115,19 +1115,19 @@ extern "C"
         int reclick_displacement_threshold)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->hover_click.enabled = enabled;
-        data->hover_click.hover_duration_milliseconds = hover_duration_milliseconds;
-        data->hover_click.cancel_displacement_threshold = cancel_displacement_threshold;
-        data->hover_click.reclick_displacement_threshold = reclick_displacement_threshold;
+        data->hover_click->enabled = enabled;
+        data->hover_click->hover_duration_milliseconds = hover_duration_milliseconds;
+        data->hover_click->cancel_displacement_threshold = cancel_displacement_threshold;
+        data->hover_click->reclick_displacement_threshold = reclick_displacement_threshold;
     }
 
     miracle_simulated_secondary_click_t miracle_config_get_simulated_secondary_click(miracle_config_data_t const* config)
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
         return {
-            data->simulated_secondary_click.enabled,
-            data->simulated_secondary_click.hold_duration_milliseconds,
-            data->simulated_secondary_click.displacement_threshold
+            data->simulated_secondary_click->enabled,
+            data->simulated_secondary_click->hold_duration_milliseconds,
+            data->simulated_secondary_click->displacement_threshold
         };
     }
 
@@ -1138,17 +1138,17 @@ extern "C"
         int displacement_threshold)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->simulated_secondary_click.enabled = enabled;
-        data->simulated_secondary_click.hold_duration_milliseconds = hold_duration_milliseconds;
-        data->simulated_secondary_click.displacement_threshold = displacement_threshold;
+        data->simulated_secondary_click->enabled = enabled;
+        data->simulated_secondary_click->hold_duration_milliseconds = hold_duration_milliseconds;
+        data->simulated_secondary_click->displacement_threshold = displacement_threshold;
     }
 
     miracle_output_filter_t miracle_config_get_output_filter(const miracle_config_data_t* config)
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
         return {
-            data->output_filter.shader_path.has_value(),
-            data->output_filter.shader_path ? data->output_filter.shader_path->c_str() : ""
+            data->output_filter->shader_path.has_value(),
+            data->output_filter->shader_path ? data->output_filter->shader_path->c_str() : ""
         };
     }
 
@@ -1159,51 +1159,51 @@ extern "C"
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
         if (shader_path_enabled)
-            data->output_filter.shader_path = shader_path;
+            data->output_filter->shader_path = shader_path;
         else
-            data->output_filter.shader_path = std::nullopt;
+            data->output_filter->shader_path = std::nullopt;
     }
 
     miracle_cursor_t miracle_config_get_cursor(const miracle_config_data_t* config)
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
         return {
-            data->cursor.scale
+            data->cursor->scale
         };
     }
     void miracle_config_set_cursor(miracle_config_data_t* config, float scale)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->cursor.scale = scale;
+        data->cursor->scale = scale;
     }
 
     miracle_slow_keys_t miracle_config_get_slow_keys(const miracle_config_data_t* config)
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
         return {
-            data->slow_keys.enabled,
-            data->slow_keys.hold_delay_milliseconds,
+            data->slow_keys->enabled,
+            data->slow_keys->hold_delay_milliseconds,
         };
     }
     void miracle_config_set_slow_keys(miracle_config_data_t* config, bool enabled, uint hold_duration_millseconds)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->slow_keys.enabled = enabled;
-        data->slow_keys.hold_delay_milliseconds = hold_duration_millseconds;
+        data->slow_keys->enabled = enabled;
+        data->slow_keys->hold_delay_milliseconds = hold_duration_millseconds;
     }
 
     miracle_sticky_keys_t miracle_config_get_sticky_keys(const miracle_config_data_t* config)
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
         return {
-            data->sticky_keys.enabled,
-            data->sticky_keys.should_disable_if_two_keys_are_pressed_together,
+            data->sticky_keys->enabled,
+            data->sticky_keys->should_disable_if_two_keys_are_pressed_together,
         };
     }
     void miracle_config_set_sticky_keys(miracle_config_data_t* config, bool enabled, bool should_disable_if_two_keys_are_pressed_together)
     {
         auto data = static_cast<miracle::ConfigData*>(config->_internal);
-        data->sticky_keys.enabled = enabled;
-        data->sticky_keys.should_disable_if_two_keys_are_pressed_together = should_disable_if_two_keys_are_pressed_together;
+        data->sticky_keys->enabled = enabled;
+        data->sticky_keys->should_disable_if_two_keys_are_pressed_together = should_disable_if_two_keys_are_pressed_together;
     }
 } // extern "C"

--- a/miracle-wm-config/src/miracle-wm-config-c.cpp
+++ b/miracle-wm-config/src/miracle-wm-config-c.cpp
@@ -117,6 +117,36 @@ extern "C"
     }
 
     // ConfigData accessors implementation
+    size_t miracle_config_get_num_includes(const miracle_config_data_t* config)
+    {
+        auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
+        return data->includes.size();
+    }
+
+    const char* miracle_config_get_include(const miracle_config_data_t* config, size_t index)
+    {
+        auto const data = static_cast<const miracle::ConfigData*>(config->_internal);
+        return data->includes[index].c_str();
+    }
+
+    void miracle_config_add_include(const miracle_config_data_t* config, const char* value)
+    {
+        auto data = static_cast<miracle::ConfigData*>(config->_internal);
+        data->includes.push_back(value);
+    }
+
+    void miracle_config_remove_include(const miracle_config_data_t* config, size_t index)
+    {
+        auto data = static_cast<miracle::ConfigData*>(config->_internal);
+        data->includes.erase(data->includes.begin() + static_cast<std::vector<std::string>::difference_type>(index));
+    }
+
+    void miracle_config_set_include(const miracle_config_data_t* config, const char* value, size_t index)
+    {
+        auto data = static_cast<miracle::ConfigData*>(config->_internal);
+        data->includes[index] = value;
+    }
+
     uint miracle_config_get_primary_modifier(const miracle_config_data_t* config)
     {
         auto const data = static_cast<const miracle::ConfigData*>(config->_internal);

--- a/miracle-wm-config/src/miracle-wm-config.cpp
+++ b/miracle-wm-config/src/miracle-wm-config.cpp
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <iostream>
 #include <libevdev-1.0/libevdev/libevdev.h>
 #include <miral/version.h>
+#include <yaml-cpp/emittermanip.h>
 #include <yaml-cpp/node/node.h>
 #include <yaml-cpp/node/parse.h>
 #include <yaml-cpp/yaml.h>
@@ -367,6 +368,31 @@ bool try_parse_color(YAML::Node const& root, const char* key, glm::vec4& color, 
     }
 
     return try_parse_color(root[key], color, context);
+}
+
+void read_includes(YAML::Node const& node, ParsingContext& context)
+{
+    if (!node.IsSequence())
+    {
+        context.builder << "Expected list of includes";
+        create_error(node, context);
+        return;
+    }
+
+    std::vector<std::string> includes;
+    for (auto const& include_node : node)
+    {
+        if (!include_node.IsScalar())
+        {
+            context.builder << "Expected a string";
+            create_error(include_node, context);
+            return;
+        }
+
+        includes.push_back(include_node.as<std::string>());
+    }
+
+    context.result.config.includes = std::move(includes);
 }
 
 void read_action_key(YAML::Node const& node, ParsingContext& context)
@@ -958,6 +984,8 @@ miracle::ConfigLoadResult miracle::load_config(std::string const& path)
     try
     {
         YAML::Node config = YAML::LoadFile(path);
+        if (config["includes"])
+            read_includes(config["includes"], context);
         if (config["action_key"])
             read_action_key(config["action_key"], context);
         if (config["default_action_overrides"])
@@ -1041,6 +1069,16 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
     ConfigSaveResult result(true, {});
     YAML::Emitter out;
     out << YAML::BeginMap;
+
+    if (!config.includes.empty())
+    {
+        out << YAML::Key << "includes" << YAML::Value << YAML::BeginSeq;
+
+        for (auto const& include : config.includes)
+            out << include;
+
+        out << YAML::EndSeq;
+    }
 
     // Save primary modifier
     for (auto const& [name, value] : mir_input_event_modifier_opts)

--- a/miracle-wm-config/src/miracle-wm-config.cpp
+++ b/miracle-wm-config/src/miracle-wm-config.cpp
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "miracle/animation_definition_internal.h"
 #include "miracle/gaps.h"
 #include "miracle/keyboard.h"
+#include "miral/hover_click.h"
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -140,11 +141,6 @@ std::string to_string_acceleration(MirPointerAcceleration acceleration)
     case mir_pointer_acceleration_none:
         return "none";
     }
-}
-
-bool are_mouse_configs_same(miral::InputConfiguration::Mouse const& first, miral::InputConfiguration::Mouse const& second)
-{
-    return first.handedness() == second.handedness() && first.acceleration() == second.acceleration() && first.acceleration_bias() == second.acceleration_bias() && first.vscroll_speed() == second.vscroll_speed() && first.hscroll_speed() == second.hscroll_speed();
 }
 
 int program_exists(std::string const& name)
@@ -456,7 +452,7 @@ void read_default_action_overrides(YAML::Node const& default_action_overrides, P
         if (!try_parse_modifiers(modifiers_node, modifiers, context))
             continue;
 
-        context.result.config.built_in_key_command_overrides.push_back({ keyboard_action.value(),
+        context.result.config.built_in_key_command_overrides->push_back({ keyboard_action.value(),
             modifiers,
             static_cast<uint>(code),
             key_command });
@@ -505,7 +501,7 @@ void read_custom_actions(YAML::Node const& custom_actions, ParsingContext& conte
         if (!try_parse_modifiers(modifiers_node, modifiers, context))
             continue;
 
-        context.result.config.custom_key_commands.push_back({ keyboard_action.value(),
+        context.result.config.custom_key_commands->push_back({ keyboard_action.value(),
             modifiers,
             static_cast<uint>(code),
             command });
@@ -520,10 +516,12 @@ void read_inner_gaps(YAML::Node const& node, ParsingContext& context)
     if (!try_parse_value(node, "y", y, context))
         return;
 
-    context.result.config.inner_gaps.top = y;
-    context.result.config.inner_gaps.bottom = y;
-    context.result.config.inner_gaps.left = x;
-    context.result.config.inner_gaps.right = x;
+    miracle::Gaps inner_gaps;
+    inner_gaps.top = y;
+    inner_gaps.bottom = y;
+    inner_gaps.left = x;
+    inner_gaps.right = x;
+    context.result.config.inner_gaps = inner_gaps;
 }
 
 void read_outer_gaps(YAML::Node const& node, ParsingContext& context)
@@ -534,10 +532,12 @@ void read_outer_gaps(YAML::Node const& node, ParsingContext& context)
     if (!try_parse_value(node, "y", y, context))
         return;
 
-    context.result.config.outer_gaps.top = y;
-    context.result.config.outer_gaps.bottom = y;
-    context.result.config.outer_gaps.left = x;
-    context.result.config.outer_gaps.right = x;
+    miracle::Gaps outer_gaps;
+    outer_gaps.top = y;
+    outer_gaps.bottom = y;
+    outer_gaps.left = x;
+    outer_gaps.right = x;
+    context.result.config.outer_gaps = outer_gaps;
 }
 
 void read_startup_apps(YAML::Node const& startup_apps, ParsingContext& context)
@@ -549,6 +549,7 @@ void read_startup_apps(YAML::Node const& startup_apps, ParsingContext& context)
         return;
     }
 
+    std::vector<miracle::StartupApp> startup_apps_vec;
     for (auto const& node : startup_apps)
     {
         std::string command;
@@ -583,12 +584,14 @@ void read_startup_apps(YAML::Node const& startup_apps, ParsingContext& context)
                 continue;
         }
 
-        context.result.config.startup_apps.push_back({ .command = std::move(command),
+        startup_apps_vec.push_back({ .command = std::move(command),
             .restart_on_death = restart_on_death,
             .no_startup_id = no_startup_id,
             .should_halt_compositor_on_death = should_halt_compositor_on_death,
             .in_systemd_scope = in_systemd_scope });
     }
+
+    context.result.config.startup_apps = startup_apps_vec;
 }
 
 void read_terminal(YAML::Node const& node, ParsingContext& context)
@@ -609,7 +612,9 @@ void read_terminal(YAML::Node const& node, ParsingContext& context)
 
 void read_resize_jump(YAML::Node const& node, ParsingContext& context)
 {
-    try_parse_value(node, context.result.config.resize_jump, context);
+    int resize_jump;
+    if (try_parse_value(node, resize_jump, context))
+        context.result.config.resize_jump = resize_jump;
 }
 
 void read_environment_variables(YAML::Node const& env, ParsingContext& context)
@@ -621,6 +626,7 @@ void read_environment_variables(YAML::Node const& env, ParsingContext& context)
         return;
     }
 
+    std::vector<miracle::EnvironmentVariable> variables;
     for (auto const& node : env)
     {
         std::string key, value;
@@ -628,8 +634,10 @@ void read_environment_variables(YAML::Node const& env, ParsingContext& context)
             continue;
         if (!try_parse_value(node, "value", value, context))
             continue;
-        context.result.config.environment_variables.push_back({ key, value });
+        variables.push_back({ key, value });
     }
+
+    context.result.config.environment_variables = variables;
 }
 
 void read_border(YAML::Node const& border, ParsingContext& context)
@@ -656,6 +664,7 @@ void read_workspaces(YAML::Node const& workspaces, ParsingContext& context)
         return;
     }
 
+    std::vector<miracle::WorkspaceConfig> workspace_configs;
     for (auto const& workspace : workspaces)
     {
         int num;
@@ -674,10 +683,12 @@ void read_workspaces(YAML::Node const& workspaces, ParsingContext& context)
         if (!try_parse_value(workspace, "name", name, context, true))
             continue;
 
-        context.result.config.workspace_configs.push_back({ num,
+        workspace_configs.push_back({ num,
             type,
             name.empty() ? std::optional<std::string>(std::nullopt) : name });
     }
+
+    context.result.config.workspace_configs = workspace_configs;
 }
 
 namespace
@@ -786,57 +797,65 @@ void read_animation_definitions(YAML::Node const& animation_node_list, ParsingCo
         }
 
         size_t const event_as_int = static_cast<size_t>(event.value());
-        context.result.config.animation_definitions[event_as_int].is_default = false;
-        try_parse_value(animation_node, "duration", context.result.config.animation_definitions[event_as_int].duration_seconds, context, true);
-        context.result.config.animation_definitions[event_as_int].animations = animations;
+        context.result.config.animation_definitions.value[event_as_int].is_default = false;
+        try_parse_value(animation_node, "duration", context.result.config.animation_definitions.value[event_as_int].duration_seconds, context, true);
+        context.result.config.animation_definitions.value[event_as_int].animations = animations;
     }
 }
 
 void read_enable_animations(YAML::Node const& node, ParsingContext& context)
 {
-    try_parse_value(node, context.result.config.animations_enabled, context);
+    bool animations_enabled;
+    if (try_parse_value(node, animations_enabled, context))
+        context.result.config.animations_enabled = animations_enabled;
 }
 
 void read_move_modifier(YAML::Node const& node, ParsingContext& context)
 {
-    try_parse_modifiers(node, context.result.config.move_modifier, context);
+    uint move_modifier;
+    if (try_parse_modifiers(node, move_modifier, context))
+        context.result.config.move_modifier = move_modifier;
 }
 
 void read_drag_and_drop(YAML::Node const& node, ParsingContext& context)
 {
-    try_parse_value(node, "enabled", context.result.config.drag_and_drop.enabled, context, true);
+    miracle::DragAndDropConfiguration drag_and_drop;
+    try_parse_value(node, "enabled", drag_and_drop.enabled, context, true);
     uint modifiers = 0;
     if (node["modifiers"])
     {
         if (!try_parse_modifiers(node["modifiers"], modifiers, context))
             return;
 
-        context.result.config.drag_and_drop.modifiers = modifiers;
+        drag_and_drop.modifiers = modifiers;
     }
+
+    context.result.config.drag_and_drop = drag_and_drop;
 }
 
 void read_mouse(YAML::Node const& node, ParsingContext& context)
 {
+    miral::InputConfiguration::Mouse mouse_configuration;
     auto const handedness = try_parse_string_to_optional_value<std::optional<MirPointerHandedness>>(
         node,
         "handedness",
         from_string_handedness,
         context);
-    context.result.config.mouse_configuration.handedness(handedness);
+    mouse_configuration.handedness(handedness);
 
     double vscroll_speed;
     if (try_parse_value(node, "vscroll_speed", vscroll_speed, context, true))
-        context.result.config.mouse_configuration.vscroll_speed(vscroll_speed);
+        mouse_configuration.vscroll_speed(vscroll_speed);
 
     double hscroll_speed;
     if (try_parse_value(node, "hscroll_speed", hscroll_speed, context, true))
-        context.result.config.mouse_configuration.hscroll_speed(hscroll_speed);
+        mouse_configuration.hscroll_speed(hscroll_speed);
 
     double acceleration_bias;
     if (try_parse_value(node, "acceleration_bias", acceleration_bias, context, true))
     {
         acceleration_bias = std::clamp(acceleration_bias, -1.0, 1.0);
-        context.result.config.mouse_configuration.acceleration_bias(acceleration_bias);
+        mouse_configuration.acceleration_bias(acceleration_bias);
     }
 
     auto const acceleration = try_parse_string_to_optional_value<std::optional<MirPointerAcceleration>>(
@@ -844,7 +863,9 @@ void read_mouse(YAML::Node const& node, ParsingContext& context)
         "acceleration",
         from_string_acceleration,
         context);
-    context.result.config.mouse_configuration.acceleration(acceleration);
+    mouse_configuration.acceleration(acceleration);
+
+    context.result.config.mouse_configuration = mouse_configuration;
 }
 
 void read_keyboard(YAML::Node const& node, ParsingContext& context)
@@ -864,6 +885,7 @@ void read_keyboard(YAML::Node const& node, ParsingContext& context)
 
     if (node["keymap"])
     {
+        miracle::KeymapConfiguration keymap;
         auto const& keymap_node = node["keymap"];
         std::string language;
         if (!try_parse_value(keymap_node, "language", language, context))
@@ -874,14 +896,14 @@ void read_keyboard(YAML::Node const& node, ParsingContext& context)
         else
         {
             context.result.config.keymap = miracle::KeymapConfiguration();
-            context.result.config.keymap->language = language;
+            keymap.language = language;
             std::string variant;
             if (try_parse_value(keymap_node, "variant", variant, context))
-                context.result.config.keymap->variant = variant;
+                keymap.variant = variant;
             else
-                context.result.config.keymap->variant = std::nullopt;
+                keymap.variant = std::nullopt;
 
-            context.result.config.keymap->options = {};
+            keymap.options = {};
             if (keymap_node["options"])
             {
                 if (!keymap_node["options"].IsSequence())
@@ -897,27 +919,35 @@ void read_keyboard(YAML::Node const& node, ParsingContext& context)
                         if (!try_parse_value(option, name, context))
                             continue;
 
-                        context.result.config.keymap->options.emplace_back(name);
+                        keymap.options.emplace_back(name);
                     }
                 }
             }
         }
+
+        context.result.config.keymap = keymap;
     }
 }
 
 void read_hover_click(YAML::Node const& node, ParsingContext& context)
 {
-    try_parse_value(node, "enabled", context.result.config.hover_click.enabled, context, true);
-    try_parse_value(node, "hover_duration", context.result.config.hover_click.hover_duration_milliseconds, context, true);
-    try_parse_value(node, "cancel_displacement_threshold", context.result.config.hover_click.cancel_displacement_threshold, context, true);
-    try_parse_value(node, "reclick_displacement_threshold", context.result.config.hover_click.reclick_displacement_threshold, context, true);
+    miracle::HoverClickConfiguration hover_click;
+    try_parse_value(node, "enabled", hover_click.enabled, context, true);
+    try_parse_value(node, "hover_duration", hover_click.hover_duration_milliseconds, context, true);
+    try_parse_value(node, "cancel_displacement_threshold", hover_click.cancel_displacement_threshold, context, true);
+    try_parse_value(node, "reclick_displacement_threshold", hover_click.reclick_displacement_threshold, context, true);
+
+    context.result.config.hover_click = hover_click;
 }
 
 void read_simulated_secondary_click(YAML::Node const& node, ParsingContext& context)
 {
-    try_parse_value(node, "enabled", context.result.config.simulated_secondary_click.enabled, context, true);
-    try_parse_value(node, "hold_duration", context.result.config.simulated_secondary_click.hold_duration_milliseconds, context, true);
-    try_parse_value(node, "displacement_threshold", context.result.config.simulated_secondary_click.displacement_threshold, context, true);
+    miracle::SimulatedSecondaryClickConfiguration simulated_secondary_click;
+    try_parse_value(node, "enabled", simulated_secondary_click.enabled, context, true);
+    try_parse_value(node, "hold_duration", simulated_secondary_click.hold_duration_milliseconds, context, true);
+    try_parse_value(node, "displacement_threshold", simulated_secondary_click.displacement_threshold, context, true);
+
+    context.result.config.simulated_secondary_click = simulated_secondary_click;
 }
 
 inline std::string expand_tilde_getenv(const std::string& path)
@@ -947,28 +977,37 @@ inline std::string expand_tilde_getenv(const std::string& path)
 
 void read_output_filter(YAML::Node const& node, ParsingContext& context)
 {
+    miracle::OutputFilterConfiguration output_filter;
     std::string shader_path;
     if (try_parse_value(node, "shader_path", shader_path, context, true))
-        context.result.config.output_filter.shader_path = shader_path;
+        output_filter.shader_path = shader_path;
     else
-        context.result.config.output_filter.shader_path = std::nullopt;
+        output_filter.shader_path = std::nullopt;
+
+    context.result.config.output_filter = output_filter;
 }
 
 void read_cursor(YAML::Node const& node, ParsingContext& context)
 {
-    try_parse_value(node, "scale", context.result.config.cursor.scale, context, true);
+    miracle::CursorConfiguration cursor;
+    try_parse_value(node, "scale", cursor.scale, context, true);
+    context.result.config.cursor = cursor;
 }
 
 void read_slow_keys(YAML::Node const& node, ParsingContext& context)
 {
-    try_parse_value(node, "enabled", context.result.config.slow_keys.enabled, context, true);
-    try_parse_value(node, "hold_delay", context.result.config.slow_keys.hold_delay_milliseconds, context, true);
+    miracle::SlowKeysConfiguration slow_keys;
+    try_parse_value(node, "enabled", slow_keys.enabled, context, true);
+    try_parse_value(node, "hold_delay", slow_keys.hold_delay_milliseconds, context, true);
+    context.result.config.slow_keys = slow_keys;
 }
 
 void read_sticky_keys(YAML::Node const& node, ParsingContext& context)
 {
-    try_parse_value(node, "enabled", context.result.config.sticky_keys.enabled, context, true);
-    try_parse_value(node, "should_disable_if_two_keys_are_pressed_together", context.result.config.sticky_keys.should_disable_if_two_keys_are_pressed_together, context, true);
+    miracle::StickyKeysConfiguration sticky_keys;
+    try_parse_value(node, "enabled", sticky_keys.enabled, context, true);
+    try_parse_value(node, "should_disable_if_two_keys_are_pressed_together", sticky_keys.should_disable_if_two_keys_are_pressed_together, context, true);
+    context.result.config.sticky_keys = sticky_keys;
 }
 }
 
@@ -1091,10 +1130,10 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
     }
 
     // Save default action overrides
-    if (!config.built_in_key_command_overrides.empty())
+    if (!config.built_in_key_command_overrides.is_default_value)
     {
         out << YAML::Key << "default_action_overrides" << YAML::Value << YAML::BeginSeq;
-        for (auto const& override : config.built_in_key_command_overrides)
+        for (auto const& override : *config.built_in_key_command_overrides)
         {
             out << YAML::BeginMap;
             out << YAML::Key << "name" << YAML::Value << default_key_command_strings[static_cast<uint32_t>(override.default_key_command)];
@@ -1114,10 +1153,10 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
     }
 
     // Save custom actions
-    if (!config.custom_key_commands.empty())
+    if (!config.custom_key_commands.is_default_value)
     {
         out << YAML::Key << "custom_actions" << YAML::Value << YAML::BeginSeq;
-        for (auto const& action : config.custom_key_commands)
+        for (auto const& action : *config.custom_key_commands)
         {
             out << YAML::BeginMap;
             out << YAML::Key << "command" << YAML::Value << action.command;
@@ -1137,21 +1176,28 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
     }
 
     // Save gaps
-    out << YAML::Key << "inner_gaps" << YAML::Value << YAML::BeginMap
-        << YAML::Key << "x" << YAML::Value << config.inner_gaps.left
-        << YAML::Key << "y" << YAML::Value << config.inner_gaps.top
-        << YAML::EndMap;
+    if (!config.inner_gaps.is_default_value)
+    {
 
-    out << YAML::Key << "outer_gaps" << YAML::Value << YAML::BeginMap
-        << YAML::Key << "x" << YAML::Value << config.outer_gaps.left
-        << YAML::Key << "y" << YAML::Value << config.outer_gaps.top
-        << YAML::EndMap;
+        out << YAML::Key << "inner_gaps" << YAML::Value << YAML::BeginMap
+            << YAML::Key << "x" << YAML::Value << config.inner_gaps->left
+            << YAML::Key << "y" << YAML::Value << config.inner_gaps->top
+            << YAML::EndMap;
+    }
+
+    if (!config.outer_gaps.is_default_value)
+    {
+        out << YAML::Key << "outer_gaps" << YAML::Value << YAML::BeginMap
+            << YAML::Key << "x" << YAML::Value << config.outer_gaps->left
+            << YAML::Key << "y" << YAML::Value << config.outer_gaps->top
+            << YAML::EndMap;
+    }
 
     // Save startup apps
-    if (!config.startup_apps.empty())
+    if (!config.startup_apps.is_default_value)
     {
         out << YAML::Key << "startup_apps" << YAML::Value << YAML::BeginSeq;
-        for (auto const& app : config.startup_apps)
+        for (auto const& app : *config.startup_apps)
         {
             out << YAML::BeginMap;
             out << YAML::Key << "command" << YAML::Value << app.command;
@@ -1169,17 +1215,17 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
     }
 
     // Save terminal
-    if (config.terminal)
-        out << YAML::Key << "terminal" << YAML::Value << config.terminal.value();
+    if (!config.terminal.is_default_value && *config.terminal)
+        out << YAML::Key << "terminal" << YAML::Value << *config.terminal.value;
 
     // Save resize jump
     out << YAML::Key << "resize_jump" << YAML::Value << config.resize_jump;
 
     // Save environment variables
-    if (!config.environment_variables.empty())
+    if (!config.environment_variables.is_default_value)
     {
         out << YAML::Key << "environment_variables" << YAML::Value << YAML::BeginSeq;
-        for (auto const& var : config.environment_variables)
+        for (auto const& var : *config.environment_variables)
         {
             out << YAML::BeginMap;
             out << YAML::Key << "key" << YAML::Value << var.key;
@@ -1190,11 +1236,11 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
     }
 
     // Save border config
-    if (config.border_config.size > 0)
+    if (!config.border_config.is_default_value)
     {
         out << YAML::Key << "border" << YAML::Value << YAML::BeginMap;
-        out << YAML::Key << "size" << YAML::Value << config.border_config.size;
-        out << YAML::Key << "radius" << YAML::Value << config.border_config.radius;
+        out << YAML::Key << "size" << YAML::Value << config.border_config->size;
+        out << YAML::Key << "radius" << YAML::Value << config.border_config->radius;
 
         // Save colors as hex values
         auto to_hex = [](glm::vec4 const& color)
@@ -1202,16 +1248,16 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
             return (static_cast<int>(color.r * 255) << 24) | (static_cast<int>(color.g * 255) << 16) | (static_cast<int>(color.b * 255) << 8) | (static_cast<int>(color.a * 255));
         };
 
-        out << YAML::Key << "color" << YAML::Value << YAML::Hex << to_hex(config.border_config.color);
-        out << YAML::Key << "focus_color" << YAML::Value << YAML::Hex << to_hex(config.border_config.focus_color);
+        out << YAML::Key << "color" << YAML::Value << YAML::Hex << to_hex(config.border_config->color);
+        out << YAML::Key << "focus_color" << YAML::Value << YAML::Hex << to_hex(config.border_config->focus_color);
         out << YAML::EndMap;
     }
 
     // Save workspaces
-    if (!config.workspace_configs.empty())
+    if (!config.workspace_configs.is_default_value)
     {
         out << YAML::Key << "workspaces" << YAML::Value << YAML::BeginSeq;
-        for (auto const& workspace : config.workspace_configs)
+        for (auto const& workspace : *config.workspace_configs)
         {
             out << YAML::BeginMap;
             out << YAML::Key << "number" << YAML::Value << workspace.num.value();
@@ -1232,7 +1278,7 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
 
     // Save animation definitions
     bool has_custom_animations = false;
-    for (auto const& def : config.animation_definitions)
+    for (auto const& def : *config.animation_definitions)
     {
         if (!def.is_default)
         {
@@ -1246,7 +1292,7 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
         out << YAML::Key << "animations" << YAML::Value << YAML::BeginSeq;
         for (size_t i = 0; i < static_cast<size_t>(AnimateableEvent::max); i++)
         {
-            auto const& def = config.animation_definitions[i];
+            auto const& def = config.animation_definitions.value[i];
             if (def.is_default)
                 continue;
 
@@ -1282,7 +1328,7 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
     }
 
     // Save move modifier
-    if (config.move_modifier != miracle_input_event_modifier_default)
+    if (!config.move_modifier.is_default_value)
     {
         out << YAML::Key << "move_modifier" << YAML::Value << YAML::BeginSeq;
         for (auto const& [name, value] : mir_input_event_modifier_opts)
@@ -1294,18 +1340,18 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
     }
 
     // Save drag and drop
-    if (!config.drag_and_drop.enabled || config.drag_and_drop.modifiers != (miracle_input_event_modifier_default | mir_input_event_modifier_shift))
+    if (!config.drag_and_drop.is_default_value)
     {
         out << YAML::Key << "drag_and_drop" << YAML::Value << YAML::BeginMap;
-        if (!config.drag_and_drop.enabled)
-            out << YAML::Key << "enabled" << YAML::Value << config.drag_and_drop.enabled;
+        if (!config.drag_and_drop->enabled)
+            out << YAML::Key << "enabled" << YAML::Value << config.drag_and_drop->enabled;
 
-        if (config.drag_and_drop.modifiers != (miracle_input_event_modifier_default | mir_input_event_modifier_shift))
+        if (config.drag_and_drop->modifiers != (miracle_input_event_modifier_default | mir_input_event_modifier_shift))
         {
             out << YAML::Key << "modifiers" << YAML::Value << YAML::BeginSeq;
             for (auto const& [name, value] : mir_input_event_modifier_opts)
             {
-                if (config.drag_and_drop.modifiers & value)
+                if (config.drag_and_drop->modifiers & value)
                     out << name;
             }
             out << YAML::EndSeq;
@@ -1314,47 +1360,41 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
     }
 
     // Save mouse config only if we're different from the empty mouse config
-    if (!are_mouse_configs_same(config.mouse_configuration, miral::InputConfiguration::Mouse()))
+    if (!config.mouse_configuration.is_default_value)
     {
         out << YAML::Key << "mouse" << YAML::Value << YAML::BeginMap;
 
-        if (config.mouse_configuration.handedness() != std::nullopt)
-            out << YAML::Key << "handedness" << YAML::Value << to_string_handedness(config.mouse_configuration.handedness().value());
-        if (config.mouse_configuration.vscroll_speed() != std::nullopt)
-            out << YAML::Key << "vscroll_speed" << YAML::Value << config.mouse_configuration.vscroll_speed().value();
-        if (config.mouse_configuration.hscroll_speed() != std::nullopt)
-            out << YAML::Key << "hscroll_speed" << YAML::Value << config.mouse_configuration.hscroll_speed().value();
-        if (config.mouse_configuration.acceleration_bias() != std::nullopt)
-            out << YAML::Key << "acceleration_bias" << YAML::Value << config.mouse_configuration.acceleration_bias().value();
-        if (config.mouse_configuration.acceleration() != std::nullopt)
-            out << YAML::Key << "acceleration" << YAML::Value << to_string_acceleration(config.mouse_configuration.acceleration().value());
+        if (config.mouse_configuration->handedness() != std::nullopt)
+            out << YAML::Key << "handedness" << YAML::Value << to_string_handedness(config.mouse_configuration->handedness().value());
+        if (config.mouse_configuration->vscroll_speed() != std::nullopt)
+            out << YAML::Key << "vscroll_speed" << YAML::Value << config.mouse_configuration->vscroll_speed().value();
+        if (config.mouse_configuration->hscroll_speed() != std::nullopt)
+            out << YAML::Key << "hscroll_speed" << YAML::Value << config.mouse_configuration->hscroll_speed().value();
+        if (config.mouse_configuration->acceleration_bias() != std::nullopt)
+            out << YAML::Key << "acceleration_bias" << YAML::Value << config.mouse_configuration->acceleration_bias().value();
+        if (config.mouse_configuration->acceleration() != std::nullopt)
+            out << YAML::Key << "acceleration" << YAML::Value << to_string_acceleration(config.mouse_configuration->acceleration().value());
 
         out << YAML::EndMap;
     }
 
-#if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 3, 0)
-    if (config.keymap || config.keyboard_configuration.repeat_delay() || config.keyboard_configuration.repeat_rate())
-#else
-    if (config.keymap)
-#endif
+    if (!config.keymap.is_default_value)
     {
-#if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 3, 0)
         out << YAML::Key << "keyboard" << YAML::Value << YAML::BeginMap;
-        if (config.keyboard_configuration.repeat_delay())
-            out << YAML::Key << "repeat_delay" << YAML::Value << *config.keyboard_configuration.repeat_delay();
+        if (config.keyboard_configuration->repeat_delay())
+            out << YAML::Key << "repeat_delay" << YAML::Value << *config.keyboard_configuration->repeat_delay();
 
-        if (config.keyboard_configuration.repeat_rate())
-            out << YAML::Key << "repeat_rate" << YAML::Value << *config.keyboard_configuration.repeat_rate();
-#endif
+        if (config.keyboard_configuration->repeat_rate())
+            out << YAML::Key << "repeat_rate" << YAML::Value << *config.keyboard_configuration->repeat_rate();
 
-        if (config.keymap)
+        if (!config.keymap.is_default_value)
         {
             out << YAML::Key << "keymap" << YAML::Value << YAML::BeginMap;
-            out << YAML::Key << "language" << YAML::Value << config.keymap->language;
-            if (config.keymap->variant)
-                out << YAML::Key << "variant" << YAML::Value << *config.keymap->variant;
+            out << YAML::Key << "language" << YAML::Value << config.keymap->value().language;
+            if (config.keymap->value().variant)
+                out << YAML::Key << "variant" << YAML::Value << *config.keymap->value().variant;
             out << YAML::Key << "options" << YAML::Value << YAML::BeginSeq;
-            for (auto const& option : config.keymap->options)
+            for (auto const& option : config.keymap->value().options)
                 out << option;
 
             out << YAML::EndSeq;
@@ -1364,53 +1404,53 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
         out << YAML::EndMap;
     }
 
-    if (config.hover_click != HoverClickConfiguration {})
+    if (!config.hover_click.is_default_value)
     {
         out << YAML::Key << "hover_click" << YAML::Value << YAML::BeginMap;
-        out << YAML::Key << "enabled" << YAML::Value << config.hover_click.enabled;
-        out << YAML::Key << "hover_duration" << YAML::Value << config.hover_click.hover_duration_milliseconds;
-        out << YAML::Key << "cancel_displacement_threshold" << YAML::Value << config.hover_click.cancel_displacement_threshold;
-        out << YAML::Key << "reclick_displacement_threshold" << YAML::Value << config.hover_click.reclick_displacement_threshold;
+        out << YAML::Key << "enabled" << YAML::Value << config.hover_click->enabled;
+        out << YAML::Key << "hover_duration" << YAML::Value << config.hover_click->hover_duration_milliseconds;
+        out << YAML::Key << "cancel_displacement_threshold" << YAML::Value << config.hover_click->cancel_displacement_threshold;
+        out << YAML::Key << "reclick_displacement_threshold" << YAML::Value << config.hover_click->reclick_displacement_threshold;
         out << YAML::EndMap;
     }
 
-    if (config.simulated_secondary_click != SimulatedSecondaryClickConfiguration {})
+    if (!config.simulated_secondary_click.is_default_value)
     {
         out << YAML::Key << "simulated_secondary_click" << YAML::Value << YAML::BeginMap;
-        out << YAML::Key << "enabled" << YAML::Value << config.simulated_secondary_click.enabled;
-        out << YAML::Key << "hold_duration" << YAML::Value << config.simulated_secondary_click.hold_duration_milliseconds;
-        out << YAML::Key << "displacement_threshold" << YAML::Value << config.simulated_secondary_click.displacement_threshold;
+        out << YAML::Key << "enabled" << YAML::Value << config.simulated_secondary_click->enabled;
+        out << YAML::Key << "hold_duration" << YAML::Value << config.simulated_secondary_click->hold_duration_milliseconds;
+        out << YAML::Key << "displacement_threshold" << YAML::Value << config.simulated_secondary_click->displacement_threshold;
         out << YAML::EndMap;
     }
 
-    if (config.output_filter != OutputFilterConfiguration {})
+    if (!config.output_filter.is_default_value)
     {
         out << YAML::Key << "output_filter" << YAML::Value << YAML::BeginMap;
-        if (config.output_filter.shader_path)
-            out << YAML::Key << "shader_path" << YAML::Value << config.output_filter.shader_path.value();
+        if (config.output_filter->shader_path)
+            out << YAML::Key << "shader_path" << YAML::Value << config.output_filter->shader_path.value();
         out << YAML::EndMap;
     }
 
-    if (config.cursor != CursorConfiguration {})
+    if (!config.cursor.is_default_value)
     {
         out << YAML::Key << "cursor" << YAML::Value << YAML::BeginMap;
-        out << YAML::Key << "scale" << YAML::Value << config.cursor.scale;
+        out << YAML::Key << "scale" << YAML::Value << config.cursor->scale;
         out << YAML::EndMap;
     }
 
-    if (config.slow_keys != SlowKeysConfiguration {})
+    if (!config.slow_keys.is_default_value)
     {
         out << YAML::Key << "slow_keys" << YAML::Value << YAML::BeginMap;
-        out << YAML::Key << "enabled" << YAML::Value << config.slow_keys.enabled;
-        out << YAML::Key << "hold_delay" << YAML::Value << config.slow_keys.hold_delay_milliseconds;
+        out << YAML::Key << "enabled" << YAML::Value << config.slow_keys->enabled;
+        out << YAML::Key << "hold_delay" << YAML::Value << config.slow_keys->hold_delay_milliseconds;
         out << YAML::EndMap;
     }
 
-    if (config.sticky_keys != StickyKeysConfiguration {})
+    if (!config.sticky_keys.is_default_value)
     {
         out << YAML::Key << "sticky_keys" << YAML::Value << YAML::BeginMap;
-        out << YAML::Key << "enabled" << YAML::Value << config.sticky_keys.enabled;
-        out << YAML::Key << "should_disable_if_two_keys_are_pressed_together" << YAML::Value << config.sticky_keys.should_disable_if_two_keys_are_pressed_together;
+        out << YAML::Key << "enabled" << YAML::Value << config.sticky_keys->enabled;
+        out << YAML::Key << "should_disable_if_two_keys_are_pressed_together" << YAML::Value << config.sticky_keys->should_disable_if_two_keys_are_pressed_together;
         out << YAML::EndMap;
     }
 

--- a/miracle-wm-config/src/miracle-wm-config.cpp
+++ b/miracle-wm-config/src/miracle-wm-config.cpp
@@ -1109,11 +1109,11 @@ miracle::ConfigSaveResult miracle::save_config(std::string const& path, ConfigDa
     YAML::Emitter out;
     out << YAML::BeginMap;
 
-    if (!config.includes.empty())
+    if (config.includes.is_set())
     {
         out << YAML::Key << "includes" << YAML::Value << YAML::BeginSeq;
 
-        for (auto const& include : config.includes)
+        for (auto const& include : *config.includes)
             out << include;
 
         out << YAML::EndSeq;
@@ -1527,4 +1527,72 @@ std::string miracle::KeymapConfiguration::to_string() const
     }
 
     return ss.str();
+}
+
+namespace
+{
+template <typename T>
+std::vector<T> concat_vectors(std::vector<T> const& a, std::vector<T> const& b)
+{
+    std::vector<T> result;
+    result.reserve(a.size() + b.size());
+    result.insert(result.end(), a.begin(), a.end());
+    result.insert(result.end(), b.begin(), b.end());
+    return result;
+}
+
+template <typename T, size_t U>
+std::array<T, U> merge_arrays(
+    std::array<T, U> const& a,
+    std::array<T, U> const& b,
+    std::function<bool(T const&, T const&)> const& compare)
+{
+    std::array<T, U> result;
+    for (size_t i = 0; i < a.size(); i++)
+    {
+        auto const& a_item = a[i];
+        auto const& b_item = b[i];
+        result[i] = compare(a_item, b_item) ? a_item : b_item;
+    }
+
+    return result;
+}
+}
+
+miracle::ConfigData miracle::ConfigData::merge_with(miracle::ConfigData& other)
+{
+    // This method merges two configurations. [other] will be given priority over [this]
+    // if it is set.
+    ConfigData result;
+    result.primary_modifier = other.primary_modifier.is_set() ? other.primary_modifier : primary_modifier;
+    result.primary_button = other.primary_button.is_set() ? other.primary_button : primary_button;
+    result.custom_key_commands = concat_vectors(*other.custom_key_commands, *custom_key_commands);
+    result.built_in_key_command_overrides = concat_vectors(*other.built_in_key_command_overrides, *built_in_key_command_overrides);
+    result.inner_gaps = other.inner_gaps.is_set() ? other.inner_gaps : inner_gaps;
+    result.outer_gaps = other.outer_gaps.is_set() ? other.outer_gaps : outer_gaps;
+    result.startup_apps = concat_vectors(*other.startup_apps, *startup_apps);
+    result.terminal = other.terminal.is_set() ? other.terminal : terminal;
+    result.resize_jump = other.resize_jump.is_set() ? other.resize_jump : resize_jump;
+    result.environment_variables = concat_vectors(*other.environment_variables, *environment_variables);
+    result.border_config = other.border_config.is_set() ? other.border_config : border_config;
+    result.animations_enabled = other.animations_enabled.is_set() ? other.animations_enabled : animations_enabled;
+    result.animation_definitions = merge_arrays<AnimationDefinition, static_cast<int>(AnimateableEvent::max)>(*other.animation_definitions, *animation_definitions,
+        [](auto const&, auto const&)
+    { return true; });
+    result.workspace_configs = concat_vectors(*other.workspace_configs, *workspace_configs);
+    result.move_modifier = other.move_modifier.is_set() ? other.move_modifier : move_modifier;
+    result.drag_and_drop = other.drag_and_drop.is_set() ? other.drag_and_drop : drag_and_drop;
+    result.mouse_configuration->merge(*other.mouse_configuration);
+    result.mouse_configuration->merge(*mouse_configuration);
+    result.keyboard_configuration->merge(*other.keyboard_configuration);
+    result.keyboard_configuration->merge(*keyboard_configuration);
+    result.keymap = other.keymap.is_set() ? other.keymap : keymap;
+    result.hover_click = other.hover_click.is_set() ? other.hover_click : hover_click;
+    result.simulated_secondary_click = other.simulated_secondary_click.is_set() ? other.simulated_secondary_click : simulated_secondary_click;
+    result.output_filter = other.output_filter.is_set() ? other.output_filter : output_filter;
+    result.cursor = other.cursor.is_set() ? other.cursor : cursor;
+    result.slow_keys = other.slow_keys.is_set() ? other.slow_keys : slow_keys;
+    result.sticky_keys = other.sticky_keys.is_set() ? other.sticky_keys : sticky_keys;
+    result.includes = concat_vectors(*other.includes, *includes);
+    return result;
 }

--- a/miracle-wm-config/tests/test_miracle_wm_config.cpp
+++ b/miracle-wm-config/tests/test_miracle_wm_config.cpp
@@ -18,8 +18,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <miracle/miracle-wm-config.h>
+#include <vector>
 
-class KeymapConfigurationTest : public testing::Test
+using namespace testing;
+
+class KeymapConfigurationTest : public Test
 {
 };
 
@@ -38,4 +41,170 @@ TEST_F(KeymapConfigurationTest, KeymapLanguageOnly)
     miracle::KeymapConfiguration config;
     config.language = "en";
     EXPECT_EQ(config.to_string(), "en");
+}
+
+TEST_F(KeymapConfigurationTest, CanMergeMiracleConfig)
+{
+    miracle::ConfigData first;
+    first.primary_modifier = mir_input_event_modifier_alt;
+    first.primary_button = mir_pointer_button_secondary;
+    first.custom_key_commands->push_back(miracle::CustomKeyCommand {
+        mir_keyboard_action_down,
+        mir_input_event_modifier_meta,
+        10,
+        "test-command" });
+    first.inner_gaps = miracle::Gaps(0, 0, 0, 0);
+    first.outer_gaps = miracle::Gaps(0, 0, 0, 0);
+    first.startup_apps->push_back(miracle::StartupApp {
+        "first" });
+    first.terminal = "terminal";
+    first.resize_jump = 10;
+    first.environment_variables->push_back(miracle::EnvironmentVariable {
+        "first", "first" });
+    first.border_config = miracle::BorderConfig {
+        .size = 10
+    };
+    first.animations_enabled = false;
+    std::vector<miracle::BuiltInAnimationDefinition> first_animations;
+    first_animations.push_back(
+        miracle::BuiltInAnimationDefinition { .type = miracle::BultInAnimationType::fade_in });
+    first.animation_definitions.value[0] = miracle::AnimationDefinition {
+        .type = miracle::AnimationType::built_in,
+        .duration_seconds = 5,
+        .animations = first_animations
+    };
+    first.workspace_configs->push_back(miracle::WorkspaceConfig {
+        .num = 2,
+        .layout = miracle::ContainerType::leaf,
+        .name = "second",
+    });
+    first.move_modifier = mir_input_event_modifier_shift;
+    first.drag_and_drop = miracle::DragAndDropConfiguration {
+        .enabled = false,
+    };
+    first.mouse_configuration = miral::InputConfiguration::Mouse();
+    first.mouse_configuration->acceleration_bias(2.f);
+    first.keyboard_configuration = miral::InputConfiguration::Keyboard();
+    first.keyboard_configuration->set_repeat_delay(6.f);
+    first.keymap = miracle::KeymapConfiguration {
+        .language = "en",
+        .variant = std::nullopt,
+        .options = std::vector<std::string> {}
+    };
+    first.simulated_secondary_click = miracle::SimulatedSecondaryClickConfiguration {
+        .enabled = false
+    };
+    first.output_filter = miracle::OutputFilterConfiguration {
+        .shader_path = "/home"
+    };
+    first.cursor = miracle::CursorConfiguration {
+        .scale = 2.f
+    };
+    first.slow_keys = miracle::SlowKeysConfiguration {
+        .enabled = false
+    };
+    first.sticky_keys = miracle::StickyKeysConfiguration {
+        .enabled = false
+    };
+
+    miracle::ConfigData second;
+    second.primary_modifier = mir_input_event_modifier_shift;
+    second.primary_button = mir_pointer_button_primary;
+    second.custom_key_commands->push_back(miracle::CustomKeyCommand {
+        mir_keyboard_action_down,
+        mir_input_event_modifier_meta,
+        12,
+        "second-test-command" });
+    second.inner_gaps = miracle::Gaps(1, 2, 3, 4);
+    second.outer_gaps = miracle::Gaps(5, 6, 7, 8);
+    second.startup_apps->push_back(miracle::StartupApp {
+        "second" });
+    second.terminal = "second-terminal";
+    second.resize_jump = 20;
+    second.environment_variables->push_back(miracle::EnvironmentVariable {
+        "second", "second" });
+    second.border_config = miracle::BorderConfig {
+        .size = 8
+    };
+    second.animations_enabled = true;
+    std::vector<miracle::BuiltInAnimationDefinition> second_animations;
+    second_animations.push_back(
+        miracle::BuiltInAnimationDefinition { .type = miracle::BultInAnimationType::grow });
+    second.animation_definitions.value[0] = miracle::AnimationDefinition {
+        .type = miracle::AnimationType::built_in,
+        .duration_seconds = 8,
+        .animations = second_animations
+    };
+    second.workspace_configs->push_back(miracle::WorkspaceConfig {
+        .num = 2,
+        .layout = miracle::ContainerType::stack,
+        .name = "second",
+    });
+    second.move_modifier = mir_input_event_modifier_shift;
+    second.drag_and_drop = miracle::DragAndDropConfiguration {
+        .enabled = true
+    };
+    second.mouse_configuration = miral::InputConfiguration::Mouse();
+    second.mouse_configuration->acceleration_bias(4.f);
+    second.keyboard_configuration = miral::InputConfiguration::Keyboard();
+    second.keyboard_configuration->set_repeat_delay(4.f);
+    second.keymap = miracle::KeymapConfiguration {
+        .language = "fr",
+        .variant = std::nullopt,
+        .options = std::vector<std::string> {}
+    };
+    second.simulated_secondary_click = miracle::SimulatedSecondaryClickConfiguration {
+        .enabled = true
+    };
+    second.output_filter = miracle::OutputFilterConfiguration {
+        .shader_path = "/outside"
+    };
+    second.cursor = miracle::CursorConfiguration {
+        .scale = 4.f
+    };
+    second.slow_keys = miracle::SlowKeysConfiguration {
+        .enabled = true
+    };
+    second.sticky_keys = miracle::StickyKeysConfiguration {
+        .enabled = true
+    };
+
+    auto const merged = first.merge_with(second);
+    EXPECT_THAT(*merged.primary_modifier, Eq(mir_input_event_modifier_shift));
+    EXPECT_THAT(*merged.primary_button, Eq(mir_pointer_button_primary));
+    EXPECT_THAT(merged.custom_key_commands->size(), Eq(2));
+    EXPECT_THAT(*merged.inner_gaps, Eq(miracle::Gaps(1, 2, 3, 4)));
+    EXPECT_THAT(*merged.outer_gaps, Eq(miracle::Gaps(5, 6, 7, 8)));
+    EXPECT_THAT(merged.startup_apps->size(), Eq(2));
+    EXPECT_THAT(merged.startup_apps.value[0].command, Eq("second"));
+    EXPECT_THAT(merged.startup_apps.value[1].command, Eq("first"));
+    EXPECT_THAT(*merged.terminal, Eq("second-terminal"));
+    EXPECT_THAT(*merged.resize_jump, Eq(20));
+    EXPECT_THAT(merged.environment_variables->size(), Eq(2));
+    EXPECT_THAT(merged.environment_variables.value[0].key, Eq("second"));
+    EXPECT_THAT(merged.environment_variables.value[0].value, Eq("second"));
+    EXPECT_THAT(merged.environment_variables.value[1].key, Eq("first"));
+    EXPECT_THAT(merged.environment_variables.value[1].value, Eq("first"));
+    EXPECT_THAT(merged.border_config->size, Eq(8));
+    EXPECT_THAT(*merged.animations_enabled, Eq(true));
+    EXPECT_THAT(merged.animation_definitions.value[0].animations[0].type, Eq(miracle::BultInAnimationType::grow));
+    EXPECT_THAT(merged.animation_definitions.value[0].duration_seconds, Eq(8));
+    EXPECT_THAT(merged.workspace_configs->size(), Eq(2));
+    EXPECT_THAT(merged.workspace_configs.value[0].num, Eq(2));
+    EXPECT_THAT(merged.workspace_configs.value[0].layout, Eq(miracle::ContainerType::stack));
+    EXPECT_THAT(merged.workspace_configs.value[0].name, Eq("second"));
+    EXPECT_THAT(merged.workspace_configs.value[1].num, Eq(2));
+    EXPECT_THAT(merged.workspace_configs.value[1].layout, Eq(miracle::ContainerType::leaf));
+    EXPECT_THAT(merged.workspace_configs.value[1].name, Eq("second"));
+    EXPECT_THAT(*merged.move_modifier, Eq(mir_input_event_modifier_shift));
+    EXPECT_THAT(merged.drag_and_drop->enabled, Eq(true));
+    // TODO: This seems to not work right now, probably a Mir issue
+    //  EXPECT_THAT(*merged.mouse_configuration->acceleration_bias(), Eq(4.f));
+    EXPECT_THAT(*merged.keyboard_configuration->repeat_delay(), Eq(4.f));
+    EXPECT_THAT(merged.keymap->value().language, Eq("fr"));
+    EXPECT_THAT(merged.simulated_secondary_click->enabled, Eq(true));
+    EXPECT_THAT(merged.output_filter->shader_path, Eq("/outside"));
+    EXPECT_THAT(merged.cursor->scale, Eq(4.f));
+    EXPECT_THAT(merged.slow_keys->enabled, Eq(true));
+    EXPECT_THAT(merged.sticky_keys->enabled, Eq(true));
 }

--- a/miracle-wm-config/tests/test_miracle_wm_config_c_api.cpp
+++ b/miracle-wm-config/tests/test_miracle_wm_config_c_api.cpp
@@ -39,6 +39,19 @@ protected:
     std::unique_ptr<miracle_config_load_result_t> wrapper;
 };
 
+TEST_F(CAPIWrapperTest, CanModifyIncludes)
+{
+    miracle_config_add_include(&wrapper->config, "/home/hi");
+    miracle_config_add_include(&wrapper->config, "/home/bye");
+    EXPECT_THAT(miracle_config_get_num_includes(&wrapper->config), Eq(2));
+    EXPECT_STREQ(miracle_config_get_include(&wrapper->config, 0), "/home/hi");
+    EXPECT_STREQ(miracle_config_get_include(&wrapper->config, 1), "/home/bye");
+    miracle_config_set_include(&wrapper->config, "/home/meow", 1);
+    EXPECT_STREQ(miracle_config_get_include(&wrapper->config, 1), "/home/meow");
+    miracle_config_remove_include(&wrapper->config, 0);
+    EXPECT_THAT(miracle_config_get_num_includes(&wrapper->config), Eq(1));
+}
+
 TEST_F(CAPIWrapperTest, CanSetValidPrimaryModifier)
 {
     uint modifier = mir_input_event_modifier_alt;
@@ -809,6 +822,8 @@ TEST_F(CAPIWrapperTest, CanRoundTripConfigThroughSaveAndLoad)
     const char* temp_path = "/tmp/miracle_test_roundtrip.yaml";
 
     // Set some config values
+    miracle_config_add_include(&wrapper->config, "/home/hi");
+    miracle_config_add_include(&wrapper->config, "/home/bye");
     miracle_config_set_primary_modifier(&wrapper->config, mir_input_event_modifier_alt);
     miracle_config_set_inner_gaps_x(&wrapper->config, 20);
     miracle_config_add_environment_variable(&wrapper->config, "TEST", "VALUE");
@@ -862,6 +877,11 @@ TEST_F(CAPIWrapperTest, CanRoundTripConfigThroughSaveAndLoad)
 
     // Verify values match
     auto loaded_config = miracle_config_get_data(load_result);
+
+    EXPECT_THAT(miracle_config_get_num_includes(&wrapper->config), Eq(2));
+    EXPECT_STREQ(miracle_config_get_include(&wrapper->config, 0), "/home/hi");
+    EXPECT_STREQ(miracle_config_get_include(&wrapper->config, 1), "/home/bye");
+
     EXPECT_EQ(miracle_config_get_primary_modifier(loaded_config), mir_input_event_modifier_alt);
     EXPECT_EQ(miracle_config_get_inner_gaps_x(loaded_config), 20);
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -166,14 +166,14 @@ void FilesystemConfiguration::_init(
     // If the user specified an --systemd-session-configure <APP_NAME>, let's add that to the list
     if (systemd_app)
     {
-        options.startup_apps.insert(options.startup_apps.begin(), systemd_app.value());
+        options.startup_apps.value.insert(options.startup_apps.value.begin(), systemd_app.value());
     }
 
     // If the user specified an --exec <APP_NAME>, let's add that to the list
     if (exec_app)
     {
         mir::log_info("Miracle will die when the application specified with --exec dies");
-        options.startup_apps.push_back(exec_app.value());
+        options.startup_apps.value.push_back(exec_app.value());
     }
 
     is_loaded_ = true;
@@ -197,7 +197,7 @@ void FilesystemConfiguration::reload()
         }
 
         mir::log_info("Configuration is loading...");
-        auto const [config, errors] = load_config(config_path);
+        auto const [config, errors] = load_config(expand_tilde_getenv(config_path));
         options = config;
 
         if (!errors.empty())
@@ -217,8 +217,8 @@ void FilesystemConfiguration::reload()
         //  that we access a string, because that seems like an unnecessary overhead.
         //  So it only makes sense to do it at load time. However, this might be annoying
         //  in the long term. We will see!
-        if (options.output_filter.shader_path)
-            options.output_filter.shader_path = expand_tilde_getenv(options.output_filter.shader_path.value());
+        if (options.output_filter->shader_path)
+            options.output_filter->shader_path = expand_tilde_getenv(options.output_filter->shader_path.value());
     }
 
     observer_registrar->advise_config_changed(*this);
@@ -284,10 +284,10 @@ miral::InputConfiguration::Keyboard FilesystemConfiguration::keyboard() const
 std::optional<std::string> FilesystemConfiguration::keymap() const
 {
     std::lock_guard lock(mutex);
-    if (!options.keymap)
+    if (!*options.keymap)
         return std::nullopt;
 
-    return options.keymap->to_string();
+    return (*options.keymap)->to_string();
 }
 
 HoverClickConfiguration FilesystemConfiguration::hover_click() const
@@ -334,7 +334,7 @@ std::string const& FilesystemConfiguration::get_filename() const
 MirInputEventModifier FilesystemConfiguration::get_input_event_modifier() const
 {
     std::lock_guard lock(mutex);
-    return static_cast<MirInputEventModifier>(options.primary_modifier);
+    return static_cast<MirInputEventModifier>(*options.primary_modifier);
 }
 
 CustomKeyCommand const*
@@ -342,7 +342,7 @@ FilesystemConfiguration::matches_custom_key_command(MirKeyboardAction action, in
 {
     std::lock_guard lock(mutex);
     // TODO: Copy & paste
-    for (auto const& command : options.custom_key_commands)
+    for (auto const& command : *options.custom_key_commands)
     {
         if (action != command.action)
             continue;
@@ -604,7 +604,7 @@ BorderConfig const& FilesystemConfiguration::get_border_config() const
 AnimationDefinition const& FilesystemConfiguration::get_animation_definition(AnimateableEvent event) const
 {
     std::lock_guard lock(mutex);
-    return options.animation_definitions[static_cast<size_t>(event)];
+    return (*options.animation_definitions)[static_cast<size_t>(event)];
 }
 
 bool FilesystemConfiguration::are_animations_enabled() const
@@ -616,7 +616,7 @@ bool FilesystemConfiguration::are_animations_enabled() const
 WorkspaceConfig FilesystemConfiguration::get_workspace_config(std::optional<int> const& num, std::optional<std::string> const& name) const
 {
     std::lock_guard lock(mutex);
-    for (auto const& config : options.workspace_configs)
+    for (auto const& config : *options.workspace_configs)
     {
         if (num && config.num == num.value())
             return config;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -184,6 +184,34 @@ void FilesystemConfiguration::_init(
         mir::log_warning("Cannot watch for configuration changes because main_loop is not set");
 }
 
+namespace
+{
+ConfigData load_config_recursive(std::string const& path)
+{
+    auto [config, errors] = load_config(expand_tilde_getenv(path));
+
+    if (!errors.empty())
+    {
+        for (auto const& error : errors)
+            mir::log_error("Configuration parsing error: %s (%s::L%d:%d)",
+                error.message.c_str(),
+                error.filename.c_str(),
+                error.line,
+                error.column);
+    }
+
+    /// Load the includes provided by this path. Note that this may be recursive, but
+    /// miracle will not prevent you from loading erroneously.
+    for (auto const& include : *config.includes)
+    {
+        auto loaded = load_config_recursive(include);
+        config = config.merge_with(loaded);
+    }
+
+    return config;
+}
+}
+
 void FilesystemConfiguration::reload()
 {
     {
@@ -197,18 +225,7 @@ void FilesystemConfiguration::reload()
         }
 
         mir::log_info("Configuration is loading...");
-        auto const [config, errors] = load_config(expand_tilde_getenv(config_path));
-        options = config;
-
-        if (!errors.empty())
-        {
-            for (auto const& error : errors)
-                mir::log_error("Configuration parsing error: %s (%s::L%d:%d)",
-                    error.message.c_str(),
-                    error.filename.c_str(),
-                    error.line,
-                    error.column);
-        }
+        options = load_config_recursive(config_path);
 
         // TODO: This might be a hack, I do not know yet.
         //  At any rate, we want users to be confident that their paths will be saved

--- a/tests/test_filesystem_configuration.cpp
+++ b/tests/test_filesystem_configuration.cpp
@@ -700,3 +700,26 @@ TEST_F(FilesystemConfigurationTest, CanReadStickyKeys)
     EXPECT_THAT(sticky_keys.enabled, testing::Eq(true));
     EXPECT_THAT(sticky_keys.should_disable_if_two_keys_are_pressed_together, testing::Eq(false));
 }
+
+TEST_F(FilesystemConfigurationTest, CanReadIncludes)
+{
+    const std::string include_path = std::filesystem::current_path() / "test_include.yaml";
+
+    // Write main config
+    YAML::Node includes;
+    includes.push_back(include_path);
+    YAML::Node root;
+    root["includes"] = includes;
+    write_yaml_node(root);
+
+    // Write included config
+    {
+        std::ofstream included_file(include_path, std::ios::trunc);
+        included_file << "action_key" << ": " << "alt" << "\n";
+    }
+
+    FilesystemConfiguration config(registrar, path, true);
+    EXPECT_THAT(config.get_input_event_modifier(), testing::Eq(mir_input_event_modifier_alt));
+
+    std::filesystem::remove(include_path.c_str());
+}


### PR DESCRIPTION
## What's new?
You can now specify a config like:

```yaml
includes:
    - path/to/another/config/file
```

If that config file exists, it will be loaded and merged with the file that includes it. The included file takes priority over its parent.

## Why?
This is useful for instance where you have multiple machines with nearly identical configurations, except for a few minor differences (e.g. you want to start some additional app on another machine or you want a larger border on a larger screen, etc.)