### PR TITLE
feature: rework how workspace transformations are done so that they no longer actually live at a particular offset

### DIFF
--- a/src/leaf_container.cpp
+++ b/src/leaf_container.cpp
@@ -669,13 +669,6 @@ std::shared_ptr<OutputInterface> LeafContainer::get_output() const
     return workspace.lock()->get_output();
 }
 
-glm::mat4 LeafContainer::full_transform() const
-{
-    return get_output_transform()
-        * get_workspace_transform()
-        * get_transform();
-}
-
 glm::mat4 LeafContainer::get_transform() const
 {
     return transform;
@@ -687,7 +680,7 @@ void LeafContainer::set_transform(glm::mat4 transform_)
     state->render_data_manager()->transform_change(id, transform_);
     if (auto surface = window_.operator std::shared_ptr<mir::scene::Surface>())
     {
-        surface->set_transformation(full_transform());
+        surface->set_transformation(get_transform());
     }
 }
 
@@ -701,7 +694,7 @@ void LeafContainer::on_workspace_transform()
     rdm->workspace_transform_change(id, workspace_transform(*this));
     if (auto const surface = window_.operator std::shared_ptr<mir::scene::Surface>())
     {
-        surface->set_transformation(full_transform());
+        surface->set_transformation(get_transform());
     }
 }
 
@@ -720,7 +713,7 @@ void LeafContainer::set_alpha(float const alpha)
     state->render_data_manager()->alpha_change(id, alpha);
     if (auto const surface = window_.operator std::shared_ptr<mir::scene::Surface>())
     {
-        surface->set_transformation(full_transform());
+        surface->set_transformation(get_transform());
     }
 }
 

--- a/src/leaf_container.h
+++ b/src/leaf_container.h
@@ -144,7 +144,6 @@ private:
 
     static void handle_resize(Container* container, Direction direction, int amount);
     static void handle_layout_scheme(Container* container, LayoutScheme scheme);
-    glm::mat4 full_transform() const;
 };
 
 } // miracle

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -59,11 +59,7 @@ Output::Output(
     config { config },
     window_controller { window_controller },
     animator { animator },
-    handle { animator->register_animateable() },
-    position_offset { 0.f, 0.f },
-    transform { glm::mat4(1.f) },
-    final_transform { glm::mat4(1.f) },
-    is_defunct_ { false }
+    handle { animator->register_animateable() }
 {
 }
 
@@ -86,8 +82,22 @@ std::shared_ptr<Container> Output::intersect(float x, float y)
     if (animator->is_animating(handle))
         return nullptr;
 
-    if (auto const window = window_controller->window_at(x, y))
-        return window_controller->get_container(window);
+    if (auto const active_workspace = active())
+    {
+        std::shared_ptr<Container> result = nullptr;
+        active_workspace->for_each_window([&](std::shared_ptr<Container> const& container)
+        {
+            if (container->get_visible_area().contains(geom::Point(x, y)))
+            {
+                result = container;
+                return true;
+            }
+
+            return false;
+        });
+
+        return result;
+    }
 
     return nullptr;
 }
@@ -182,7 +192,7 @@ void Output::advise_new_workspace(WorkspaceCreationData const&& data)
 {
     // Workspaces are always kept in sorted order with numbered workspaces in front followed by all other workspaces
     auto const new_workspace = std::make_shared<Workspace>(
-        shared_from_this(), data.id, data.num, data.name, config, window_controller, state, data.registrar);
+        shared_from_this(), data.id, data.num, data.name, config, window_controller, state, data.registrar, animator);
     insert_workspace_sorted(new_workspace);
 }
 
@@ -277,149 +287,24 @@ bool Output::advise_workspace_active(WorkspaceManager& workspace_manager, uint32
     if (!from || to == from)
     {
         active_workspace = to;
-        to->show();
-
-        auto const to_rectangle = get_workspace_rectangle(to_index);
-        set_position(glm::vec2(
-            -to_rectangle.top_left.x.as_int(),
-            -to_rectangle.top_left.y.as_int()));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-        to->workspace_transform_change_hack();
-#pragma GCC diagnostic pop
+        to->show(geom::Point(0, 0));
         return true;
     }
 
-    // If we have a 'from' and a 'to', we want to animate between them.
-
-    // Note: It is very important that [active_workspace] be modified before notifications
-    // are sent out.
+    // It is very important that [active_workspace] be modified before notifications are sent out.
     active_workspace = to;
 
-    auto const from_src = get_workspace_rectangle(from_index);
-    auto const to_src = get_workspace_rectangle(to_index);
     from->transfer_pinned_windows_to(to);
+    auto const from_end = to_index > from_index ? geom::Point(-area.size.width.as_int(), 0) : geom::Point(area.size.width.as_int(), 0);
+    auto const to_start = to_index > from_index ? geom::Point(area.size.width.as_int(), 0) : geom::Point(-area.size.width.as_int(), 0);
+    to->show(to_start);
 
-    geom::Rectangle const real {
-        { geom::X { position_offset.x }, geom::Y { position_offset.y } },
-        area.size
-    };
-    geom::Rectangle const src {
-        { geom::X { -from_src.top_left.x.as_int() }, geom::Y { from_src.top_left.y.as_int() } },
-        area.size
-    };
-    geom::Rectangle const dest {
-        { geom::X { -to_src.top_left.x.as_int() }, geom::Y { to_src.top_left.y.as_int() } },
-        area.size
-    };
-
-    // If 'from' is empty, we can delete the workspace. However, this means that from_src is now incorrect
+    // If [from] is empty, we can delete the workspace.
     if (from->is_empty())
         workspace_manager.delete_workspace(from->id());
-
-    if (!config->are_animations_enabled())
-    {
-        to->show();
-        from->hide();
-        to->on_animation_start();
-        handle_workspace_animation(
-            AnimationFrameResult {
-                true,
-                dest,
-                glm::mat4(1.f),
-                std::nullopt },
-            to,
-            from);
-        to->on_animation_end();
-        return true;
-    }
-
-    auto const animation = std::make_shared<WorkspaceAnimation>(
-        handle,
-        config->get_animation_definition(AnimateableEvent::workspace_switch),
-        src,
-        dest,
-        real,
-        to,
-        from,
-        this);
-
-    animator->append(animation);
-
-    // Show all workspaces so that we can animate over all workspaces.
-    // Important: Make sure that we show _after_ the "append" has
-    // happened so that we are showing with the correct initial
-    // transform.
-    for (auto const& workspace : workspaces)
-    {
-        if (workspace != from)
-            workspace->show();
-    }
-
-    to->on_animation_start();
+    else
+        from->hide(from_end);
     return true;
-}
-
-Output::WorkspaceAnimation::WorkspaceAnimation(
-    AnimationHandle handle,
-    AnimationDefinition definition,
-    mir::geometry::Rectangle const& from,
-    mir::geometry::Rectangle const& to,
-    mir::geometry::Rectangle const& current,
-    std::shared_ptr<WorkspaceInterface> const& to_workspace,
-    std::shared_ptr<WorkspaceInterface> const& from_workspace,
-    Output* output) :
-    MultiBuiltInAnimation(handle, definition, from, to, current, 1.f, 1.f),
-    to_workspace { to_workspace },
-    from_workspace { from_workspace },
-    output { output }
-{
-}
-
-void Output::WorkspaceAnimation::on_tick(miracle::AnimationFrameResult const& asr)
-{
-    output->policy->main_loop()->enqueue(this, [asr = asr, to_workspace = to_workspace, from_workspace = from_workspace, output = output]()
-    {
-        output->policy->handle_workspace_animation(asr, to_workspace, from_workspace);
-    });
-}
-
-void Output::handle_workspace_animation(
-    AnimationFrameResult const& asr,
-    std::shared_ptr<WorkspaceInterface> const& to,
-    std::shared_ptr<WorkspaceInterface> const&)
-{
-    auto const rectangle = asr.rectangle;
-    if (asr.is_complete)
-    {
-        if (rectangle)
-            set_position(glm::vec2(rectangle->top_left.x.as_int(), rectangle->top_left.y.as_int()));
-        if (asr.transform)
-            set_transform(asr.transform.value());
-
-        for (auto const& workspace : workspaces)
-        {
-            if (workspace != to)
-                workspace->hide();
-        }
-
-        to->workspace_transform_change_hack();
-        to->on_animation_end();
-        return;
-    }
-
-    if (rectangle)
-        set_position(glm::vec2(rectangle->top_left.x.as_int(), rectangle->top_left.y.as_int()));
-    if (asr.transform)
-        set_transform(asr.transform.value());
-
-    for (auto const& workspace : workspaces)
-    {
-        if (!workspace)
-            continue;
-
-        workspace->workspace_transform_change_hack();
-    }
 }
 
 void Output::advise_application_zone_create(miral::Zone const& application_zone)
@@ -475,32 +360,6 @@ void Output::graft(std::shared_ptr<Container> const& container)
     active()->graft(container);
 }
 
-geom::Rectangle Output::get_workspace_rectangle(size_t i) const
-{
-    // TODO: Support vertical workspaces one day in the future
-    auto const& workspace = workspaces[i];
-    size_t x = 0;
-    if (workspace->num())
-        x = static_cast<size_t>((workspace->num().value() - 1) * area.size.width.as_int());
-    else
-    {
-        // Find the index of the first non-numbered workspace
-        size_t j = 0;
-        for (; j < workspaces.size(); j++)
-        {
-            if (workspaces[j]->num() == std::nullopt)
-                break;
-        }
-
-        x = (WorkspaceManager::NUM_DEFAULT_WORKSPACES - 1) + (i - j) * static_cast<size_t>(area.size.width.as_int());
-    }
-
-    return geom::Rectangle {
-        geom::Point { geom::X { x },            geom::Y { 0 }             },
-        geom::Size { area.size.width.as_int(), area.size.height.as_int() }
-    };
-}
-
 [[nodiscard]] WorkspaceInterface const* Output::workspace(uint32_t id) const
 {
     for (auto const& workspace : workspaces)
@@ -514,19 +373,12 @@ geom::Rectangle Output::get_workspace_rectangle(size_t i) const
 
 glm::mat4 Output::get_transform() const
 {
-    return final_transform;
+    return transform;
 }
 
 void Output::set_transform(glm::mat4 const& in)
 {
     transform = in;
-    final_transform = glm::translate(transform, glm::vec3(position_offset.x, position_offset.y, 0));
-}
-
-void Output::set_position(glm::vec2 const& v)
-{
-    position_offset = v;
-    final_transform = glm::translate(transform, glm::vec3(position_offset.x, position_offset.y, 0));
 }
 
 void Output::set_info(int next_id, std::string next_name)

--- a/src/output.h
+++ b/src/output.h
@@ -60,14 +60,9 @@ public:
     void update_area(geom::Rectangle const& area) override;
     void graft(std::shared_ptr<Container> const& container) override;
     void set_transform(glm::mat4 const& in) override;
-    void set_position(glm::vec2 const&) override;
     void set_info(int id, std::string name) override;
     void set_defunct() override;
     void unset_defunct() override;
-    void handle_workspace_animation(
-        AnimationFrameResult const& result,
-        std::shared_ptr<WorkspaceInterface> const& to,
-        std::shared_ptr<WorkspaceInterface> const& from) override;
 
     [[nodiscard]] std::shared_ptr<WorkspaceInterface> active() const override;
     [[nodiscard]] std::vector<std::shared_ptr<WorkspaceInterface>> const& get_workspaces() const override { return workspaces; }
@@ -77,34 +72,12 @@ public:
     [[nodiscard]] bool is_defunct() const override { return is_defunct_; }
     [[nodiscard]] int id() const override { return id_; }
     [[nodiscard]] glm::mat4 get_transform() const override;
-    [[nodiscard]] geom::Rectangle get_workspace_rectangle(size_t i) const override;
     [[nodiscard]] WorkspaceInterface const* workspace(uint32_t id) const override;
     [[nodiscard]] nlohmann::json to_json(bool is_focused) const override;
     [[nodiscard]] nlohmann::json get_outputs_json(bool is_focused) const override;
     [[nodiscard]] bool is_primary() const override;
 
 private:
-    class WorkspaceAnimation : public MultiBuiltInAnimation
-    {
-    public:
-        WorkspaceAnimation(
-            AnimationHandle handle,
-            AnimationDefinition definition,
-            mir::geometry::Rectangle const& from,
-            mir::geometry::Rectangle const& to,
-            mir::geometry::Rectangle const& current,
-            std::shared_ptr<WorkspaceInterface> const& to_workspace,
-            std::shared_ptr<WorkspaceInterface> const& from_workspace,
-            Output* output);
-
-        void on_tick(AnimationFrameResult const&) override;
-
-    private:
-        std::shared_ptr<WorkspaceInterface> to_workspace;
-        std::shared_ptr<WorkspaceInterface> from_workspace;
-        Output* output;
-    };
-
     void insert_workspace_sorted(std::shared_ptr<WorkspaceInterface> const& new_workspace);
 
     Policy* policy;
@@ -121,14 +94,8 @@ private:
     std::vector<miral::Zone> application_zone_list;
     AnimationHandle handle;
 
-    /// The position of the output for scrolling across workspaces
-    glm::vec2 position_offset = glm::vec2(0.f);
-
-    /// The transform applied to the workspace
+    /// The transform applied to the entire output..
     glm::mat4 transform = glm::mat4(1.f);
-
-    /// A matrix resulting from combining position + transform
-    glm::mat4 final_transform = glm::mat4(1.f);
 
     bool is_defunct_ = false;
 };

--- a/src/output_interface.h
+++ b/src/output_interface.h
@@ -87,7 +87,6 @@ public:
     /// on the active [Workspace].
     virtual void graft(std::shared_ptr<Container> const& container) = 0;
     virtual void set_transform(glm::mat4 const& in) = 0;
-    virtual void set_position(glm::vec2 const&) = 0;
 
     /// Set the [id] and [name] associated with this output.
     virtual void set_info(int id, std::string name) = 0;
@@ -96,11 +95,6 @@ public:
     /// around to be reassociated with a "true" output.
     virtual void set_defunct() = 0;
     virtual void unset_defunct() = 0;
-    virtual void handle_workspace_animation(
-        AnimationFrameResult const& result,
-        std::shared_ptr<WorkspaceInterface> const& to,
-        std::shared_ptr<WorkspaceInterface> const& from)
-        = 0;
 
     // Getters
     [[nodiscard]] virtual std::shared_ptr<WorkspaceInterface> active() const = 0;
@@ -120,7 +114,6 @@ public:
     ///
     /// \returns the transformation
     [[nodiscard]] virtual glm::mat4 get_transform() const = 0;
-    [[nodiscard]] virtual geom::Rectangle get_workspace_rectangle(size_t i) const = 0;
     [[nodiscard]] virtual WorkspaceInterface const* workspace(uint32_t id) const = 0;
     [[nodiscard]] virtual nlohmann::json to_json(bool is_focused) const = 0;
     [[nodiscard]] virtual bool is_primary() const = 0;

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -800,7 +800,7 @@ void Policy::handle_workspace_animation(
     std::shared_ptr<WorkspaceInterface> const& from)
 {
     std::lock_guard lock(self->mutex);
-    to->get_output()->handle_workspace_animation(asr, to, from);
+    // TODO?
 }
 
 mir::geometry::Rectangle Policy::confirm_inherited_move(

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -103,6 +103,67 @@ geom::Rectangle get_output_area(std::shared_ptr<OutputInterface> const& output)
 
     return output->get_area();
 }
+
+class WorkspaceAnimation : public MultiBuiltInAnimation
+{
+public:
+    WorkspaceAnimation(
+        AnimationHandle handle,
+        AnimationDefinition const& definition,
+        mir::geometry::Rectangle const& from,
+        mir::geometry::Rectangle const& to,
+        mir::geometry::Rectangle const& current,
+        float opacity_start,
+        float opacity_end,
+        std::shared_ptr<Workspace> const& workspace,
+        bool is_hiding) :
+        MultiBuiltInAnimation(handle, definition, from, to, current, opacity_start, opacity_end),
+        workspace(workspace),
+        is_hiding(is_hiding)
+    {
+    }
+
+    AnimationFrameResult init() override
+    {
+        auto const locked = workspace.lock();
+        if (!locked)
+            return {};
+
+        locked->on_animation_start(is_hiding);
+        return MultiBuiltInAnimation::init();
+    }
+
+    void on_tick(AnimationFrameResult const& asr) override
+    {
+        auto const locked = workspace.lock();
+        if (!locked)
+            return;
+
+        glm::mat4 matrix(1.f);
+        if (asr.transform)
+            matrix = matrix * asr.transform.value();
+        if (asr.rectangle)
+        {
+            matrix = glm::translate(
+                matrix,
+                glm::vec3(
+                    asr.rectangle->top_left.x.as_value(),
+                    asr.rectangle->top_left.y.as_value(),
+                    0));
+        }
+
+        locked->transform(matrix);
+        if (asr.is_complete)
+        {
+            locked->on_animation_end(is_hiding);
+            return;
+        }
+    }
+
+private:
+    std::weak_ptr<Workspace> workspace;
+    bool is_hiding;
+};
 }
 
 Workspace::Workspace(
@@ -113,7 +174,8 @@ Workspace::Workspace(
     std::shared_ptr<Config> const& config,
     std::shared_ptr<WindowController> const& window_controller,
     std::shared_ptr<CompositorState> const& state,
-    std::shared_ptr<WorkspaceObserverRegistrar> const& registry) :
+    std::shared_ptr<WorkspaceObserverRegistrar> const& registry,
+    std::shared_ptr<Animator> const& animator) :
     output { output },
     id_ { id },
     num_ { num },
@@ -121,7 +183,9 @@ Workspace::Workspace(
     window_controller { window_controller },
     state { state },
     registry { registry },
-    config { config }
+    config { config },
+    animator { animator },
+    animation_handle { animator->register_animateable() }
 {
 }
 
@@ -239,25 +303,50 @@ void Workspace::advise_focus_gained(std::shared_ptr<Container> const& container)
         last_selected_container = container;
 }
 
-void Workspace::show()
+void Workspace::show(geom::Point const& origin)
 {
-    // HACK: miral will try to select a newly visible window if none is currently
-    // selected. In most instances, we do not want this, as we would rather
-    // select our [last_selected_container] instead. To work around this, we set
-    // a flag that tells miral not to select the last focused container while we
-    // are in the process of becoming visible.
-    is_showing = true;
-    root()->show();
-    for (auto const& floating : floating_trees)
-        floating->show();
-    is_showing = false;
+    if (!config->are_animations_enabled())
+    {
+        on_animation_end(false);
+        return;
+    }
+
+    auto const area = root()->get_logical_area();
+    auto const animation = std::make_shared<WorkspaceAnimation>(
+        animation_handle,
+        config->get_animation_definition(AnimateableEvent::workspace_switch),
+        geom::Rectangle(origin, area.size),
+        geom::Rectangle(geom::Point(0, 0), area.size),
+        geom::Rectangle(origin, area.size),
+        0,
+        1,
+        shared_from_this(),
+        false);
+
+    animator->append(animation);
 }
 
-void Workspace::hide()
+void Workspace::hide(geom::Point const& end)
 {
-    root()->hide();
-    for (auto const& floating : floating_trees)
-        floating->hide();
+    if (!config->are_animations_enabled())
+    {
+        on_animation_end(true);
+        return;
+    }
+
+    auto const area = root()->get_logical_area();
+    auto const animation = std::make_shared<WorkspaceAnimation>(
+        animation_handle,
+        config->get_animation_definition(AnimateableEvent::workspace_switch),
+        geom::Rectangle(geom::Point(0, 0), area.size),
+        geom::Rectangle(end, area.size),
+        geom::Rectangle(geom::Point(0, 0), area.size),
+        0,
+        1,
+        shared_from_this(),
+        true);
+
+    animator->append(animation);
 }
 
 bool Workspace::for_each_window(std::function<bool(std::shared_ptr<Container>)> const& f) const
@@ -418,18 +507,6 @@ void Workspace::set_output(std::shared_ptr<OutputInterface> const& new_output)
     set_area(new_output->get_area());
 }
 
-void Workspace::workspace_transform_change_hack()
-{
-    for (auto const& container : state->containers())
-    {
-        if (auto const locked = container.lock())
-        {
-            if (locked->get_workspace().get() == this)
-                locked->on_workspace_transform();
-        }
-    }
-}
-
 bool Workspace::is_empty() const
 {
     return root()->num_nodes() == 0 && floating_trees.empty();
@@ -469,7 +546,6 @@ void Workspace::graft(std::shared_ptr<Container> const& container)
 void Workspace::num(std::optional<int> n)
 {
     num_ = n;
-    workspace_transform_change_hack();
 }
 
 void Workspace::name(std::optional<std::string> const& name)
@@ -499,59 +575,67 @@ void Workspace::inner_gaps(std::optional<Gaps> const& gaps)
     recalculate_area();
 }
 
+void Workspace::transform(glm::mat4 const& transform)
+{
+    transform_ = transform;
+    for (auto const& container : state->containers())
+    {
+        if (auto const locked = container.lock())
+        {
+            if (locked->get_workspace().get() == this)
+                locked->on_workspace_transform();
+        }
+    }
+}
+
 glm::mat4 Workspace::transform() const
 {
-    auto const output = get_output();
-    if (!output)
-        return glm::mat4(1.f);
-
-    // The workspace transform is calculated based off the index of the workspace in
-    // the output that owns it. This value is cached to avoid recalculating it over
-    // and over again. If the index of the workspace changes, the transform is
-    // recalculated on the next access.
-    auto const& workspaces = output->get_workspaces();
-    for (size_t i = 0; i < workspaces.size(); i++)
-    {
-        if (workspaces[i].get() == this)
-        {
-            if (workspace_index == i)
-                return cached_transform;
-
-            auto const workspace_rect = output->get_workspace_rectangle(i);
-            workspace_index = static_cast<int>(i);
-            cached_transform = glm::translate(
-                glm::vec3(workspace_rect.top_left.x.as_int(), workspace_rect.top_left.y.as_int(), 0));
-            return cached_transform;
-        }
-    }
-
-    mir::log_error("Cannot resolve workspace transform for workspace %d", id());
-    return glm::mat4(1.f);
+    return transform_;
 }
 
-void Workspace::on_animation_start()
+void Workspace::on_animation_start(bool is_hiding)
 {
-    if (auto const sh_last_selected = last_selected_container.lock())
-    {
-        if (sh_last_selected->window().has_value())
-            window_controller->select_active_window(sh_last_selected->window().value());
-        return;
-    }
+    // HACK: miral will try to select a newly visible window if none is currently
+    // selected. In most instances, we do not want this, as we would rather
+    // select our [last_selected_container] instead. To work around this, we set
+    // a flag that tells miral not to select the last focused container while we
+    // are in the process of becoming visible.
+    is_showing = true;
+    root()->show();
+    for (auto const& floating : floating_trees)
+        floating->show();
+    is_showing = false;
 
-    for_each_window([&](std::shared_ptr<Container> const& container)
+    if (!is_hiding)
     {
-        if (container->window().has_value())
+        if (auto const sh_last_selected = last_selected_container.lock())
         {
-            window_controller->select_active_window(container->window().value());
-            return true;
+            if (sh_last_selected->window().has_value())
+                window_controller->select_active_window(sh_last_selected->window().value());
+            return;
         }
 
-        return false;
-    });
+        for_each_window([&](std::shared_ptr<Container> const& container)
+        {
+            if (container->window().has_value())
+            {
+                window_controller->select_active_window(container->window().value());
+                return true;
+            }
+
+            return false;
+        });
+    }
 }
 
-void Workspace::on_animation_end()
+void Workspace::on_animation_end(bool is_hiding)
 {
+    if (is_hiding)
+    {
+        root()->hide();
+        for (auto const& floating : floating_trees)
+            floating->hide();
+    }
 }
 
 std::shared_ptr<ParentContainer> Workspace::get_layout_container()

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef MIRACLEWM_WORKSPACE_CONTENT_H
 #define MIRACLEWM_WORKSPACE_CONTENT_H
 
+#include "animator.h"
 #include "workspace_interface.h"
 
 #include <memory>
@@ -30,6 +31,7 @@ class WindowController;
 class Config;
 class CompositorState;
 class WorkspaceObserverRegistrar;
+class Animator;
 
 struct WorkspaceIdentifier
 {
@@ -48,7 +50,8 @@ public:
         std::shared_ptr<Config> const& config,
         std::shared_ptr<WindowController> const& window_controller,
         std::shared_ptr<CompositorState> const& state,
-        std::shared_ptr<WorkspaceObserverRegistrar> const& registry);
+        std::shared_ptr<WorkspaceObserverRegistrar> const& registry,
+        std::shared_ptr<Animator> const& animator);
 
     void set_area(mir::geometry::Rectangle const&) override;
     void recalculate_area() override;
@@ -62,19 +65,18 @@ public:
     void delete_container(std::shared_ptr<Container> const& container) override;
     bool move_container(Direction direction, Container&) override;
     bool add_to_root(Container& to_move) override;
-    void show() override;
-    void hide() override;
+    void show(mir::geometry::Point const& origin) override;
+    void hide(mir::geometry::Point const& end) override;
     void transfer_pinned_windows_to(std::shared_ptr<WorkspaceInterface> const& other) override;
     bool for_each_window(std::function<bool(std::shared_ptr<Container>)> const&) const override;
     std::shared_ptr<ParentContainer> create_floating_tree(mir::geometry::Rectangle const& area) override;
     void advise_focus_gained(std::shared_ptr<Container> const& container) override;
     [[nodiscard]] std::shared_ptr<OutputInterface> get_output() const override;
     void set_output(std::shared_ptr<OutputInterface> const&) override;
-    void workspace_transform_change_hack() override;
     [[nodiscard]] bool is_empty() const override;
     void graft(std::shared_ptr<Container> const&) override;
-    void on_animation_start() override;
-    void on_animation_end() override;
+    void on_animation_start(bool is_hiding) override;
+    void on_animation_end(bool is_hiding) override;
     [[nodiscard]] uint32_t id() const override { return id_; }
     [[nodiscard]] std::optional<int> num() const override { return num_; }
     [[nodiscard]] std::optional<std::string> const& name() const override { return name_; }
@@ -84,6 +86,7 @@ public:
     void outer_gaps(std::optional<Gaps> const& gaps) override;
     [[nodiscard]] std::optional<Gaps> inner_gaps() const override;
     void inner_gaps(std::optional<Gaps> const& gaps) override;
+    void transform(glm::mat4 const&) override;
     glm::mat4 transform() const override;
     [[nodiscard]] nlohmann::json get_workspaces_json(bool is_output_focused) const override;
     [[nodiscard]] nlohmann::json to_json(bool is_output_focused) const override;
@@ -116,12 +119,13 @@ private:
     std::shared_ptr<CompositorState> state;
     std::shared_ptr<WorkspaceObserverRegistrar> registry;
     std::shared_ptr<Config> config;
+    std::shared_ptr<Animator> animator;
+    AnimationHandle animation_handle;
     bool is_showing = false;
     std::weak_ptr<Container> last_selected_container;
     std::optional<Gaps> workspace_outer_gaps;
     std::optional<Gaps> workspace_inner_gaps;
-    mutable int workspace_index = -1;
-    mutable glm::mat4 cached_transform;
+    glm::mat4 transform_;
 
     /// Retrieves the container that is currently being used for layout
     std::shared_ptr<ParentContainer> get_layout_container();

--- a/src/workspace_interface.h
+++ b/src/workspace_interface.h
@@ -58,8 +58,16 @@ public:
     virtual void delete_container(std::shared_ptr<Container> const& container) = 0;
     virtual bool move_container(Direction direction, Container&) = 0;
     virtual bool add_to_root(Container& to_move) = 0;
-    virtual void show() = 0;
-    virtual void hide() = 0;
+
+    /// Show the workspace.
+    ///
+    /// \param origin the position that the animation should happen from.
+    virtual void show(mir::geometry::Point const& origin) = 0;
+
+    /// Hide the workspace.
+    ///
+    /// \param end the position that the workspace will end up at.
+    virtual void hide(mir::geometry::Point const& end) = 0;
 
     virtual void transfer_pinned_windows_to(std::shared_ptr<WorkspaceInterface> const& other) = 0;
 
@@ -78,13 +86,10 @@ public:
 
     virtual void set_output(std::shared_ptr<OutputInterface> const&) = 0;
 
-    virtual void workspace_transform_change_hack()
-        = 0;
-
     [[nodiscard]] virtual bool is_empty() const = 0;
     virtual void graft(std::shared_ptr<Container> const&) = 0;
-    virtual void on_animation_start() = 0;
-    virtual void on_animation_end() = 0;
+    virtual void on_animation_start(bool is_hiding) = 0;
+    virtual void on_animation_end(bool is_hiding) = 0;
 
     [[nodiscard]] virtual uint32_t id() const = 0;
     [[nodiscard]] virtual std::optional<int> num() const = 0;
@@ -98,6 +103,12 @@ public:
     [[nodiscard]] virtual std::optional<Gaps> inner_gaps() const = 0;
     virtual void inner_gaps(std::optional<Gaps> const& gaps) = 0;
 
+    /// Sets the transformation for this workspace.
+    virtual void transform(glm::mat4 const&) = 0;
+
+    /// Retrieve the transformation for this workspace.
+    ///
+    /// \returns the workspace transforms
     virtual glm::mat4 transform() const = 0;
 
     /// Json returned to IPC GET_WORKSPACES command.

--- a/tests/mock_output.h
+++ b/tests/mock_output.h
@@ -53,7 +53,6 @@ namespace test
         MOCK_METHOD(void, update_area, (geom::Rectangle const& area), (override));
         MOCK_METHOD(void, graft, (std::shared_ptr<Container> const& container), (override));
         MOCK_METHOD(void, set_transform, (glm::mat4 const& in), (override));
-        MOCK_METHOD(void, set_position, (glm::vec2 const&), (override));
         MOCK_METHOD(std::shared_ptr<WorkspaceInterface>, active, (), (const, override));
         MOCK_METHOD(std::vector<std::shared_ptr<WorkspaceInterface>> const&, get_workspaces, (), (const, override));
         MOCK_METHOD(geom::Rectangle const&, get_area, (), (const, override));
@@ -61,7 +60,6 @@ namespace test
         MOCK_METHOD(std::string const&, name, (), (const, override));
         MOCK_METHOD(int, id, (), (const, override));
         MOCK_METHOD(glm::mat4, get_transform, (), (const, override));
-        MOCK_METHOD(geom::Rectangle, get_workspace_rectangle, (size_t i), (const, override));
         MOCK_METHOD(WorkspaceInterface const*, workspace, (uint32_t id), (const, override));
         MOCK_METHOD(nlohmann::json, to_json, (bool), (const, override));
         MOCK_METHOD(nlohmann::json, get_outputs_json, (bool), (const, override));
@@ -69,7 +67,6 @@ namespace test
         MOCK_METHOD(void, set_defunct, (), (override));
         MOCK_METHOD(void, unset_defunct, (), (override));
         MOCK_METHOD(bool, is_defunct, (), (const, override));
-        MOCK_METHOD(void, handle_workspace_animation, (AnimationFrameResult const&, std::shared_ptr<WorkspaceInterface> const&, std::shared_ptr<WorkspaceInterface> const&), (override));
         MOCK_METHOD(bool, is_primary, (), (const, override));
     };
 

--- a/tests/mock_workspace.h
+++ b/tests/mock_workspace.h
@@ -46,8 +46,8 @@ namespace test
 
         MOCK_METHOD(void, delete_container, (std::shared_ptr<Container> const& container), (override));
         MOCK_METHOD(bool, move_container, (Direction direction, Container&), (override));
-        MOCK_METHOD(void, show, (), (override));
-        MOCK_METHOD(void, hide, (), (override));
+        MOCK_METHOD(void, show, (geom::Point const&), (override));
+        MOCK_METHOD(void, hide, (geom::Point const&), (override));
         MOCK_METHOD(bool, add_to_root, (Container&), (override));
         MOCK_METHOD(std::shared_ptr<ParentContainer>, create_floating_tree, (mir::geometry::Rectangle const&), (override));
 
@@ -62,8 +62,6 @@ namespace test
 
         MOCK_METHOD(void, set_output, (std::shared_ptr<OutputInterface> const&), (override));
 
-        MOCK_METHOD(void, workspace_transform_change_hack, (), (override));
-
         MOCK_METHOD(bool, is_empty, (), (const, override));
         MOCK_METHOD(void, graft, (std::shared_ptr<Container> const&), (override));
 
@@ -76,8 +74,8 @@ namespace test
         MOCK_METHOD(void, name, (std::optional<std::string> const&), (override));
         MOCK_METHOD(std::string, display_name, (), (const, override));
         MOCK_METHOD(std::shared_ptr<ParentContainer>, get_root, (), (const, override));
-        MOCK_METHOD(void, on_animation_start, (), (override));
-        MOCK_METHOD(void, on_animation_end, (), (override));
+        MOCK_METHOD(void, on_animation_start, (bool), (override));
+        MOCK_METHOD(void, on_animation_end, (bool), (override));
 
         MOCK_METHOD(std::optional<Gaps>, outer_gaps, (), (const, override));
         MOCK_METHOD(void, outer_gaps, (std::optional<Gaps> const&), (override));
@@ -85,6 +83,7 @@ namespace test
         MOCK_METHOD(std::optional<Gaps>, inner_gaps, (), (const, override));
         MOCK_METHOD(void, inner_gaps, (std::optional<Gaps> const&), (override));
 
+        MOCK_METHOD(void, transform, (glm::mat4 const&), (override));
         MOCK_METHOD(glm::mat4, transform, (), (const, override));
     };
 }

--- a/tests/test_policy.cpp
+++ b/tests/test_policy.cpp
@@ -271,6 +271,7 @@ TEST_F(SingleWindowPolicyTest, can_move_container_to_workspace_that_doesnt_have_
     auto const app = open_application("test");
     miral::WindowSpecification spec;
     auto const window1 = create_window(app, spec);
+    EXPECT_THAT(compositor_state->focused_container(), Eq(compositor_state->containers().front().lock()));
 
     {
         // Move to workspace 2

--- a/tests/test_workspace.cpp
+++ b/tests/test_workspace.cpp
@@ -79,7 +79,8 @@ public:
             std::make_shared<test::StubConfiguration>(),
             window_controller,
             state,
-            registry))
+            registry,
+            animator))
     {
     }
 
@@ -116,6 +117,7 @@ public:
     std::shared_ptr<test::MockOutput> output;
     std::shared_ptr<StubWindowController> window_controller;
     std::shared_ptr<WorkspaceObserverRegistrar> registry = std::make_shared<WorkspaceObserverRegistrar>();
+    std::shared_ptr<Animator> animator = std::make_shared<Animator>();
     std::shared_ptr<Workspace> workspace;
 };
 
@@ -232,7 +234,8 @@ TEST_F(WorkspaceTest, CanMoveContainerToContainerInOtherTree)
         std::make_shared<test::StubConfiguration>(),
         window_controller,
         state,
-        registry);
+        registry,
+        animator);
     auto leaf1 = create_leaf();
     auto leaf2 = create_leaf(std::nullopt, other.get());
 
@@ -255,7 +258,8 @@ TEST_F(WorkspaceTest, CanMoveContainerToTree)
         std::make_shared<test::StubConfiguration>(),
         window_controller,
         state,
-        registry);
+        registry,
+        animator);
     auto leaf1 = create_leaf();
 
     ASSERT_EQ(leaf1->get_workspace(), workspace);
@@ -313,7 +317,8 @@ TEST_F(WorkspaceTest, WorkspaceBoundsAreInitializedToFirstZoneSizeWhenAppZonesAr
         std::make_shared<test::StubConfiguration>(),
         window_controller,
         state,
-        registry);
+        registry,
+        animator);
 
     // Assert that the first tree (w/o app zones) is equal to the output size.
     ASSERT_EQ(other->get_root()->get_logical_area(), zone_bounds);


### PR DESCRIPTION
## Whats new?
- Workspace slide animations no longer rely on the workspace _literally_ being at a specific offset
- This will enable things like fade transformations and the like
- This also _greatly_ simplifies the leaf container transformation code so that it isn't so reliant on the workspace transform