### PR TITLE
feature: implementation of a background on floating containers

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="BackendCodeEditorMiscSettings">
-    <option name="/Default/RiderDebugger/RiderRestoreDecompile/RestoreDecompileSetting/@EntryValue" value="false" type="bool" />
-    <option name="/Default/Housekeeping/GlobalSettingsUpgraded/IsUpgraded/@EntryValue" value="true" type="bool" />
-    <option name="/Default/Housekeeping/FeatureSuggestion/FeatureSuggestionManager/DisabledSuggesters/=SwitchToGoToActionSuggester/@EntryIndexedValue" value="true" type="bool" />
-    <option name="/Default/Environment/Hierarchy/GeneratedFilesCacheKey/Timestamp/@EntryValue" value="3" type="long" />
-    <option name="/Default/Housekeeping/FeatureSuggestion/FeatureSuggestionManager/DisabledSuggesters/=SwitchToGoToActionSuggester/@EntryIndexRemoved" />
-  </component>
   <component name="CMakePythonSetting">
     <option name="pythonIntegrationState" value="YES" />
   </component>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,9 @@ add_library(miracle-wm-implementation STATIC
         src/magnifier_wrapper.cpp
         src/math_helpers.cpp
         src/plugin_manager.cpp
-        src/shell_application_manager.cpp
+        src/shell_application_manager.cpp src/shell_application_manager.h
+        src/shell_application_spawner.h
+        src/internal_shell_application_spawner.h src/internal_shell_application_spawner.cpp
 )
 
 target_compile_definitions(miracle-wm-implementation PRIVATE COMPILING_AGAINST_DEV=${COMPILING_AGAINST_DEV} ENABLE_PLUGIN_SYSTEM=${ENABLE_PLUGIN_SYSTEM})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ add_library(miracle-wm-implementation STATIC
         src/window_helpers.cpp
         src/config.cpp
         src/output.cpp
+        src/parent_background_internal_client.cpp
         src/workspace_manager.cpp
         src/ipc_message_handler.cpp
         src/ipc_connection_manager.cpp
@@ -162,6 +163,7 @@ add_library(miracle-wm-implementation STATIC
         src/magnifier_wrapper.cpp
         src/math_helpers.cpp
         src/plugin_manager.cpp
+        src/shell_application_manager.cpp
 )
 
 target_compile_definitions(miracle-wm-implementation PRIVATE COMPILING_AGAINST_DEV=${COMPILING_AGAINST_DEV} ENABLE_PLUGIN_SYSTEM=${ENABLE_PLUGIN_SYSTEM})
@@ -236,6 +238,7 @@ target_link_libraries(miracle-wm-implementation
         PkgConfig::GLESv2
         -lpcre2-8 -lpcre2-16 -lpcre2-32
         miracle-wm-config
+        xdg-shell-protocol
 )
 
 if (ENABLE_PLUGIN_SYSTEM)

--- a/protocols/CMakeLists.txt
+++ b/protocols/CMakeLists.txt
@@ -17,3 +17,35 @@ add_custom_target(wlr-output-management-unstable-v1
         ${GENERATE_FILE}.cpp
         ${GENERATE_FILE}.h
 )
+
+# XDG Shell protocol (for internal client)
+find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+
+set(XDG_SHELL_PROTOCOL_FILE "${CMAKE_CURRENT_SOURCE_DIR}/xdg-shell.xml")
+set(XDG_SHELL_CLIENT_HEADER "${CMAKE_BINARY_DIR}/xdg-shell-client-protocol.h")
+set(XDG_SHELL_PRIVATE_CODE "${CMAKE_BINARY_DIR}/xdg-shell-protocol.c")
+
+add_custom_command(
+        OUTPUT ${XDG_SHELL_CLIENT_HEADER}
+        COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header ${XDG_SHELL_PROTOCOL_FILE} ${XDG_SHELL_CLIENT_HEADER}
+        DEPENDS ${XDG_SHELL_PROTOCOL_FILE}
+        VERBATIM
+)
+
+add_custom_command(
+        OUTPUT ${XDG_SHELL_PRIVATE_CODE}
+        COMMAND ${WAYLAND_SCANNER_EXECUTABLE} private-code ${XDG_SHELL_PROTOCOL_FILE} ${XDG_SHELL_PRIVATE_CODE}
+        DEPENDS ${XDG_SHELL_PROTOCOL_FILE}
+        VERBATIM
+)
+
+add_library(xdg-shell-protocol STATIC
+        ${XDG_SHELL_PRIVATE_CODE}
+        ${XDG_SHELL_CLIENT_HEADER}
+)
+
+target_include_directories(xdg-shell-protocol PUBLIC ${CMAKE_BINARY_DIR})
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
+target_include_directories(xdg-shell-protocol PUBLIC ${WAYLAND_CLIENT_INCLUDE_DIRS})
+target_link_libraries(xdg-shell-protocol ${WAYLAND_CLIENT_LIBRARIES})

--- a/protocols/xdg-shell.xml
+++ b/protocols/xdg-shell.xml
@@ -1,0 +1,1415 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xdg_shell">
+
+  <copyright>
+    Copyright © 2008-2013 Kristian Høgsberg
+    Copyright © 2013      Rafael Antognolli
+    Copyright © 2013      Jasper St. Pierre
+    Copyright © 2010-2013 Intel Corporation
+    Copyright © 2015-2017 Samsung Electronics Co., Ltd
+    Copyright © 2015-2017 Red Hat Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="xdg_wm_base" version="7">
+    <description summary="create desktop-style surfaces">
+      The xdg_wm_base interface is exposed as a global object enabling clients
+      to turn their wl_surfaces into windows in a desktop environment. It
+      defines the basic functionality needed for clients and the compositor to
+      create windows that can be dragged, resized, maximized, etc, as well as
+      creating transient windows such as popup menus.
+    </description>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="given wl_surface has another role"/>
+      <entry name="defunct_surfaces" value="1"
+	     summary="xdg_wm_base was destroyed before children"/>
+      <entry name="not_the_topmost_popup" value="2"
+	     summary="the client tried to map or destroy a non-topmost popup"/>
+      <entry name="invalid_popup_parent" value="3"
+	     summary="the client specified an invalid popup parent surface"/>
+      <entry name="invalid_surface_state" value="4"
+	     summary="the client provided an invalid surface state"/>
+      <entry name="invalid_positioner" value="5"
+	     summary="the client provided an invalid positioner"/>
+      <entry name="unresponsive" value="6"
+	     summary="the client didn’t respond to a ping event in time"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy xdg_wm_base">
+	Destroy this xdg_wm_base object.
+
+	Destroying a bound xdg_wm_base object while there are surfaces
+	still alive created by this xdg_wm_base object instance is illegal
+	and will result in a defunct_surfaces error.
+      </description>
+    </request>
+
+    <request name="create_positioner">
+      <description summary="create a positioner object">
+	Create a positioner object. A positioner object is used to position
+	surfaces relative to some parent surface. See the interface description
+	and xdg_surface.get_popup for details.
+      </description>
+      <arg name="id" type="new_id" interface="xdg_positioner"/>
+    </request>
+
+    <request name="get_xdg_surface">
+      <description summary="create a shell surface from a surface">
+	This creates an xdg_surface for the given surface. While xdg_surface
+	itself is not a role, the corresponding surface may only be assigned
+	a role extending xdg_surface, such as xdg_toplevel or xdg_popup. It is
+	illegal to create an xdg_surface for a wl_surface which already has an
+	assigned role and this will result in a role error.
+
+	This creates an xdg_surface for the given surface. An xdg_surface is
+	used as basis to define a role to a given surface, such as xdg_toplevel
+	or xdg_popup. It also manages functionality shared between xdg_surface
+	based surface roles.
+
+	See the documentation of xdg_surface for more details about what an
+	xdg_surface is and how it is used.
+      </description>
+      <arg name="id" type="new_id" interface="xdg_surface"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+
+    <request name="pong">
+      <description summary="respond to a ping event">
+	A client must respond to a ping event with a pong request or
+	the client may be deemed unresponsive. See xdg_wm_base.ping
+	and xdg_wm_base.error.unresponsive.
+      </description>
+      <arg name="serial" type="uint" summary="serial of the ping event"/>
+    </request>
+
+    <event name="ping">
+      <description summary="check if the client is alive">
+	The ping event asks the client if it's still alive. Pass the
+	serial specified in the event back to the compositor by sending
+	a "pong" request back with the specified serial. See xdg_wm_base.pong.
+
+	Compositors can use this to determine if the client is still
+	alive. It's unspecified what will happen if the client doesn't
+	respond to the ping request, or in what timeframe. Clients should
+	try to respond in a reasonable amount of time. The “unresponsive”
+	error is provided for compositors that wish to disconnect unresponsive
+	clients.
+
+	A compositor is free to ping in any way it wants, but a client must
+	always respond to any xdg_wm_base object it created.
+      </description>
+      <arg name="serial" type="uint" summary="pass this to the pong request"/>
+    </event>
+  </interface>
+
+  <interface name="xdg_positioner" version="7">
+    <description summary="child surface positioner">
+      The xdg_positioner provides a collection of rules for the placement of a
+      child surface relative to a parent surface. Rules can be defined to ensure
+      the child surface remains within the visible area's borders, and to
+      specify how the child surface changes its position, such as sliding along
+      an axis, or flipping around a rectangle. These positioner-created rules are
+      constrained by the requirement that a child surface must intersect with or
+      be at least partially adjacent to its parent surface.
+
+      See the various requests for details about possible rules.
+
+      At the time of the request, the compositor makes a copy of the rules
+      specified by the xdg_positioner. Thus, after the request is complete the
+      xdg_positioner object can be destroyed or reused; further changes to the
+      object will have no effect on previous usages.
+
+      For an xdg_positioner object to be considered complete, it must have a
+      non-zero size set by set_size, and a non-zero anchor rectangle set by
+      set_anchor_rect. Passing an incomplete xdg_positioner object when
+      positioning a surface raises an invalid_positioner error.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_input" value="0" summary="invalid input provided"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_positioner object">
+	Notify the compositor that the xdg_positioner will no longer be used.
+      </description>
+    </request>
+
+    <request name="set_size">
+      <description summary="set the size of the to-be positioned rectangle">
+	Set the size of the surface that is to be positioned with the positioner
+	object. The size is in surface-local coordinates and corresponds to the
+	window geometry. See xdg_surface.set_window_geometry.
+
+	If a zero or negative size is set the invalid_input error is raised.
+      </description>
+      <arg name="width" type="int" summary="width of positioned rectangle"/>
+      <arg name="height" type="int" summary="height of positioned rectangle"/>
+    </request>
+
+    <request name="set_anchor_rect">
+      <description summary="set the anchor rectangle within the parent surface">
+	Specify the anchor rectangle within the parent surface that the child
+	surface will be placed relative to. The rectangle is relative to the
+	window geometry as defined by xdg_surface.set_window_geometry of the
+	parent surface.
+
+	When the xdg_positioner object is used to position a child surface, the
+	anchor rectangle may not extend outside the window geometry of the
+	positioned child's parent surface.
+
+	If a negative size is set the invalid_input error is raised.
+      </description>
+      <arg name="x" type="int" summary="x position of anchor rectangle"/>
+      <arg name="y" type="int" summary="y position of anchor rectangle"/>
+      <arg name="width" type="int" summary="width of anchor rectangle"/>
+      <arg name="height" type="int" summary="height of anchor rectangle"/>
+    </request>
+
+    <enum name="anchor">
+      <entry name="none" value="0"/>
+      <entry name="top" value="1"/>
+      <entry name="bottom" value="2"/>
+      <entry name="left" value="3"/>
+      <entry name="right" value="4"/>
+      <entry name="top_left" value="5"/>
+      <entry name="bottom_left" value="6"/>
+      <entry name="top_right" value="7"/>
+      <entry name="bottom_right" value="8"/>
+    </enum>
+
+    <request name="set_anchor">
+      <description summary="set anchor rectangle anchor">
+	Defines the anchor point for the anchor rectangle. The specified anchor
+	is used derive an anchor point that the child surface will be
+	positioned relative to. If a corner anchor is set (e.g. 'top_left' or
+	'bottom_right'), the anchor point will be at the specified corner;
+	otherwise, the derived anchor point will be centered on the specified
+	edge, or in the center of the anchor rectangle if no edge is specified.
+      </description>
+      <arg name="anchor" type="uint" enum="anchor"
+	   summary="anchor"/>
+    </request>
+
+    <enum name="gravity">
+      <entry name="none" value="0"/>
+      <entry name="top" value="1"/>
+      <entry name="bottom" value="2"/>
+      <entry name="left" value="3"/>
+      <entry name="right" value="4"/>
+      <entry name="top_left" value="5"/>
+      <entry name="bottom_left" value="6"/>
+      <entry name="top_right" value="7"/>
+      <entry name="bottom_right" value="8"/>
+    </enum>
+
+    <request name="set_gravity">
+      <description summary="set child surface gravity">
+	Defines in what direction a surface should be positioned, relative to
+	the anchor point of the parent surface. If a corner gravity is
+	specified (e.g. 'bottom_right' or 'top_left'), then the child surface
+	will be placed towards the specified gravity; otherwise, the child
+	surface will be centered over the anchor point on any axis that had no
+	gravity specified. If the gravity is not in the ‘gravity’ enum, an
+	invalid_input error is raised.
+      </description>
+      <arg name="gravity" type="uint" enum="gravity"
+	   summary="gravity direction"/>
+    </request>
+
+    <enum name="constraint_adjustment" bitfield="true">
+      <description summary="constraint adjustments">
+	The constraint adjustment value define ways the compositor will adjust
+	the position of the surface, if the unadjusted position would result
+	in the surface being partly constrained.
+
+	Whether a surface is considered 'constrained' is left to the compositor
+	to determine. For example, the surface may be partly outside the
+	compositor's defined 'work area', thus necessitating the child surface's
+	position be adjusted until it is entirely inside the work area.
+
+	The adjustments can be combined, according to a defined precedence: 1)
+	Flip, 2) Slide, 3) Resize.
+      </description>
+      <entry name="none" value="0">
+	<description summary="don't move the child surface when constrained">
+	  Don't alter the surface position even if it is constrained on some
+	  axis, for example partially outside the edge of an output.
+	</description>
+      </entry>
+      <entry name="slide_x" value="1">
+	<description summary="move along the x axis until unconstrained">
+	  Slide the surface along the x axis until it is no longer constrained.
+
+	  First try to slide towards the direction of the gravity on the x axis
+	  until either the edge in the opposite direction of the gravity is
+	  unconstrained or the edge in the direction of the gravity is
+	  constrained.
+
+	  Then try to slide towards the opposite direction of the gravity on the
+	  x axis until either the edge in the direction of the gravity is
+	  unconstrained or the edge in the opposite direction of the gravity is
+	  constrained.
+	</description>
+      </entry>
+      <entry name="slide_y" value="2">
+	<description summary="move along the y axis until unconstrained">
+	  Slide the surface along the y axis until it is no longer constrained.
+
+	  First try to slide towards the direction of the gravity on the y axis
+	  until either the edge in the opposite direction of the gravity is
+	  unconstrained or the edge in the direction of the gravity is
+	  constrained.
+
+	  Then try to slide towards the opposite direction of the gravity on the
+	  y axis until either the edge in the direction of the gravity is
+	  unconstrained or the edge in the opposite direction of the gravity is
+	  constrained.
+	</description>
+      </entry>
+      <entry name="flip_x" value="4">
+	<description summary="invert the anchor and gravity on the x axis">
+	  Invert the anchor and gravity on the x axis if the surface is
+	  constrained on the x axis. For example, if the left edge of the
+	  surface is constrained, the gravity is 'left' and the anchor is
+	  'left', change the gravity to 'right' and the anchor to 'right'.
+
+	  If the adjusted position also ends up being constrained, the resulting
+	  position of the flip_x adjustment will be the one before the
+	  adjustment.
+	</description>
+      </entry>
+      <entry name="flip_y" value="8">
+	<description summary="invert the anchor and gravity on the y axis">
+	  Invert the anchor and gravity on the y axis if the surface is
+	  constrained on the y axis. For example, if the bottom edge of the
+	  surface is constrained, the gravity is 'bottom' and the anchor is
+	  'bottom', change the gravity to 'top' and the anchor to 'top'.
+
+	  The adjusted position is calculated given the original anchor
+	  rectangle and offset, but with the new flipped anchor and gravity
+	  values.
+
+	  If the adjusted position also ends up being constrained, the resulting
+	  position of the flip_y adjustment will be the one before the
+	  adjustment.
+	</description>
+      </entry>
+      <entry name="resize_x" value="16">
+	<description summary="horizontally resize the surface">
+	  Resize the surface horizontally so that it is completely
+	  unconstrained.
+	</description>
+      </entry>
+      <entry name="resize_y" value="32">
+	<description summary="vertically resize the surface">
+	  Resize the surface vertically so that it is completely unconstrained.
+	</description>
+      </entry>
+    </enum>
+
+    <request name="set_constraint_adjustment">
+      <description summary="set the adjustment to be done when constrained">
+	Specify how the window should be positioned if the originally intended
+	position caused the surface to be constrained, meaning at least
+	partially outside positioning boundaries set by the compositor. The
+	adjustment is set by constructing a bitmask describing the adjustment to
+	be made when the surface is constrained on that axis.
+
+	If no bit for one axis is set, the compositor will assume that the child
+	surface should not change its position on that axis when constrained.
+
+	If more than one bit for one axis is set, the order of how adjustments
+	are applied is specified in the corresponding adjustment descriptions.
+
+	The default adjustment is none.
+      </description>
+      <arg name="constraint_adjustment" type="uint" enum="constraint_adjustment"
+	   summary="bit mask of constraint adjustments"/>
+    </request>
+
+    <request name="set_offset">
+      <description summary="set surface position offset">
+	Specify the surface position offset relative to the position of the
+	anchor on the anchor rectangle and the anchor on the surface. For
+	example if the anchor of the anchor rectangle is at (x, y), the surface
+	has the gravity bottom|right, and the offset is (ox, oy), the calculated
+	surface position will be (x + ox, y + oy). The offset position of the
+	surface is the one used for constraint testing. See
+	set_constraint_adjustment.
+
+	An example use case is placing a popup menu on top of a user interface
+	element, while aligning the user interface element of the parent surface
+	with some user interface element placed somewhere in the popup surface.
+      </description>
+      <arg name="x" type="int" summary="surface position x offset"/>
+      <arg name="y" type="int" summary="surface position y offset"/>
+    </request>
+
+    <!-- Version 3 additions -->
+
+    <request name="set_reactive" since="3">
+      <description summary="continuously reconstrain the surface">
+	When set reactive, the surface is reconstrained if the conditions used
+	for constraining changed, e.g. the parent window moved.
+
+	If the conditions changed and the popup was reconstrained, an
+	xdg_popup.configure event is sent with updated geometry, followed by an
+	xdg_surface.configure event.
+      </description>
+    </request>
+
+    <request name="set_parent_size" since="3">
+      <description summary="">
+	Set the parent window geometry the compositor should use when
+	positioning the popup. The compositor may use this information to
+	determine the future state the popup should be constrained using. If
+	this doesn't match the dimension of the parent the popup is eventually
+	positioned against, the behavior is undefined.
+
+	The arguments are given in the surface-local coordinate space.
+      </description>
+      <arg name="parent_width" type="int"
+	   summary="future window geometry width of parent"/>
+      <arg name="parent_height" type="int"
+	   summary="future window geometry height of parent"/>
+    </request>
+
+    <request name="set_parent_configure" since="3">
+      <description summary="set parent configure this is a response to">
+	Set the serial of an xdg_surface.configure event this positioner will be
+	used in response to. The compositor may use this information together
+	with set_parent_size to determine what future state the popup should be
+	constrained using.
+      </description>
+      <arg name="serial" type="uint"
+	   summary="serial of parent configure event"/>
+    </request>
+  </interface>
+
+  <interface name="xdg_surface" version="7">
+    <description summary="desktop user interface surface base interface">
+      An interface that may be implemented by a wl_surface, for
+      implementations that provide a desktop-style user interface.
+
+      It provides a base set of functionality required to construct user
+      interface elements requiring management by the compositor, such as
+      toplevel windows, menus, etc. The types of functionality are split into
+      xdg_surface roles.
+
+      Creating an xdg_surface does not set the role for a wl_surface. In order
+      to map an xdg_surface, the client must create a role-specific object
+      using, e.g., get_toplevel, get_popup. The wl_surface for any given
+      xdg_surface can have at most one role, and may not be assigned any role
+      not based on xdg_surface.
+
+      A role must be assigned before any other requests are made to the
+      xdg_surface object.
+
+      The client must call wl_surface.commit on the corresponding wl_surface
+      for the xdg_surface state to take effect.
+
+      Creating an xdg_surface from a wl_surface which has a buffer attached or
+      committed is a client error, and any attempts by a client to attach or
+      manipulate a buffer prior to the first xdg_surface.configure call must
+      also be treated as errors.
+
+      After creating a role-specific object and setting it up (e.g. by sending
+      the title, app ID, size constraints, parent, etc), the client must
+      perform an initial commit without any buffer attached. The compositor
+      will reply with initial wl_surface state such as
+      wl_surface.preferred_buffer_scale followed by an xdg_surface.configure
+      event. The client must acknowledge it and is then allowed to attach a
+      buffer to map the surface.
+
+      Mapping an xdg_surface-based role surface is defined as making it
+      possible for the surface to be shown by the compositor. Note that
+      a mapped surface is not guaranteed to be visible once it is mapped.
+
+      For an xdg_surface to be mapped by the compositor, the following
+      conditions must be met:
+      (1) the client has assigned an xdg_surface-based role to the surface
+      (2) the client has set and committed the xdg_surface state and the
+	  role-dependent state to the surface
+      (3) the client has committed a buffer to the surface
+
+      A newly-unmapped surface is considered to have met condition (1) out
+      of the 3 required conditions for mapping a surface if its role surface
+      has not been destroyed, i.e. the client must perform the initial commit
+      again before attaching a buffer.
+    </description>
+
+    <enum name="error">
+      <entry name="not_constructed" value="1"
+	     summary="Surface was not fully constructed"/>
+      <entry name="already_constructed" value="2"
+	     summary="Surface was already constructed"/>
+      <entry name="unconfigured_buffer" value="3"
+	     summary="Attaching a buffer to an unconfigured surface"/>
+      <entry name="invalid_serial" value="4"
+	     summary="Invalid serial number when acking a configure event"/>
+      <entry name="invalid_size" value="5"
+	     summary="Width or height was zero or negative"/>
+      <entry name="defunct_role_object" value="6"
+	     summary="Surface was destroyed before its role object"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_surface">
+	Destroy the xdg_surface object. An xdg_surface must only be destroyed
+	after its role object has been destroyed, otherwise
+	a defunct_role_object error is raised.
+      </description>
+    </request>
+
+    <request name="get_toplevel">
+      <description summary="assign the xdg_toplevel surface role">
+	This creates an xdg_toplevel object for the given xdg_surface and gives
+	the associated wl_surface the xdg_toplevel role.
+
+	See the documentation of xdg_toplevel for more details about what an
+	xdg_toplevel is and how it is used.
+      </description>
+      <arg name="id" type="new_id" interface="xdg_toplevel"/>
+    </request>
+
+    <request name="get_popup">
+      <description summary="assign the xdg_popup surface role">
+	This creates an xdg_popup object for the given xdg_surface and gives
+	the associated wl_surface the xdg_popup role.
+
+	If null is passed as a parent, a parent surface must be specified using
+	some other protocol, before committing the initial state.
+
+	See the documentation of xdg_popup for more details about what an
+	xdg_popup is and how it is used.
+      </description>
+      <arg name="id" type="new_id" interface="xdg_popup"/>
+      <arg name="parent" type="object" interface="xdg_surface" allow-null="true"/>
+      <arg name="positioner" type="object" interface="xdg_positioner"/>
+    </request>
+
+    <request name="set_window_geometry">
+      <description summary="set the new window geometry">
+	The window geometry of a surface is its "visible bounds" from the
+	user's perspective. Client-side decorations often have invisible
+	portions like drop-shadows which should be ignored for the
+	purposes of aligning, placing and constraining windows.
+
+	The window geometry is double-buffered state, see wl_surface.commit.
+
+	When maintaining a position, the compositor should treat the (x, y)
+	coordinate of the window geometry as the top left corner of the window.
+	A client changing the (x, y) window geometry coordinate should in
+	general not alter the position of the window.
+
+	Once the window geometry of the surface is set, it is not possible to
+	unset it, and it will remain the same until set_window_geometry is
+	called again, even if a new subsurface or buffer is attached.
+
+	If never set, the value is the full bounds of the surface,
+	including any subsurfaces. This updates dynamically on every
+	commit. This unset is meant for extremely simple clients.
+
+	The arguments are given in the surface-local coordinate space of
+	the wl_surface associated with this xdg_surface, and may extend outside
+	of the wl_surface itself to mark parts of the subsurface tree as part of
+	the window geometry.
+
+	When applied, the effective window geometry will be the set window
+	geometry clamped to the bounding rectangle of the combined
+	geometry of the surface of the xdg_surface and the associated
+	subsurfaces.
+
+	The effective geometry will not be recalculated unless a new call to
+	set_window_geometry is done and the new pending surface state is
+	subsequently applied.
+
+	The width and height of the effective window geometry must be
+	greater than zero. Setting an invalid size will raise an
+	invalid_size error.
+      </description>
+      <arg name="x" type="int"/>
+      <arg name="y" type="int"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <request name="ack_configure">
+      <description summary="ack a configure event">
+	When a configure event is received, if a client commits the
+	surface in response to the configure event, then the client
+	must make an ack_configure request sometime before the commit
+	request, passing along the serial of the configure event.
+
+	For instance, for toplevel surfaces the compositor might use this
+	information to move a surface to the top left only when the client has
+	drawn itself for the maximized or fullscreen state.
+
+	If the client receives multiple configure events before it
+	can respond to one, it only has to ack the last configure event.
+	Acking a configure event that was never sent raises an invalid_serial
+	error.
+
+	A client is not required to commit immediately after sending
+	an ack_configure request - it may even ack_configure several times
+	before its next surface commit.
+
+	A client may send multiple ack_configure requests before committing, but
+	only the last request sent before a commit indicates which configure
+	event the client really is responding to.
+
+	Sending an ack_configure request consumes the serial number sent with
+	the request, as well as serial numbers sent by all configure events
+	sent on this xdg_surface prior to the configure event referenced by
+	the committed serial.
+
+	It is an error to issue multiple ack_configure requests referencing a
+	serial from the same configure event, or to issue an ack_configure
+	request referencing a serial from a configure event issued before the
+	event identified by the last ack_configure request for the same
+	xdg_surface. Doing so will raise an invalid_serial error.
+      </description>
+      <arg name="serial" type="uint" summary="the serial from the configure event"/>
+    </request>
+
+    <event name="configure">
+      <description summary="suggest a surface change">
+	The configure event marks the end of a configure sequence. A configure
+	sequence is a set of one or more events configuring the state of the
+	xdg_surface, including the final xdg_surface.configure event.
+
+	Where applicable, xdg_surface surface roles will during a configure
+	sequence extend this event as a latched state sent as events before the
+	xdg_surface.configure event. Such events should be considered to make up
+	a set of atomically applied configuration states, where the
+	xdg_surface.configure commits the accumulated state.
+
+	Clients should arrange their surface for the new states, and then send
+	an ack_configure request with the serial sent in this configure event at
+	some point before committing the new surface.
+
+	If the client receives multiple configure events before it can respond
+	to one, it is free to discard all but the last event it received.
+      </description>
+      <arg name="serial" type="uint" summary="serial of the configure event"/>
+    </event>
+
+  </interface>
+
+  <interface name="xdg_toplevel" version="7">
+    <description summary="toplevel surface">
+      This interface defines an xdg_surface role which allows a surface to,
+      among other things, set window-like properties such as maximize,
+      fullscreen, and minimize, set application-specific metadata like title and
+      id, and well as trigger user interactive operations such as interactive
+      resize and move.
+
+      A xdg_toplevel by default is responsible for providing the full intended
+      visual representation of the toplevel, which depending on the window
+      state, may mean things like a title bar, window controls and drop shadow.
+
+      Unmapping an xdg_toplevel means that the surface cannot be shown
+      by the compositor until it is explicitly mapped again.
+      All active operations (e.g., move, resize) are canceled and all
+      attributes (e.g. title, state, stacking, ...) are discarded for
+      an xdg_toplevel surface when it is unmapped. The xdg_toplevel returns to
+      the state it had right after xdg_surface.get_toplevel. The client
+      can re-map the toplevel by performing a commit without any buffer
+      attached, waiting for a configure event and handling it as usual (see
+      xdg_surface description).
+
+      Attaching a null buffer to a toplevel unmaps the surface.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_toplevel">
+	This request destroys the role surface and unmaps the surface;
+	see "Unmapping" behavior in interface section for details.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="invalid_resize_edge" value="0" summary="provided value is
+        not a valid variant of the resize_edge enum"/>
+      <entry name="invalid_parent" value="1"
+        summary="invalid parent toplevel"/>
+      <entry name="invalid_size" value="2"
+	summary="client provided an invalid min or max size"/>
+    </enum>
+
+    <request name="set_parent">
+      <description summary="set the parent of this surface">
+	Set the "parent" of this surface. This surface should be stacked
+	above the parent surface and all other ancestor surfaces.
+
+	Parent surfaces should be set on dialogs, toolboxes, or other
+	"auxiliary" surfaces, so that the parent is raised when the dialog
+	is raised.
+
+	Setting a null parent for a child surface unsets its parent. Setting
+	a null parent for a surface which currently has no parent is a no-op.
+
+	Only mapped surfaces can have child surfaces. Setting a parent which
+	is not mapped is equivalent to setting a null parent. If a surface
+	becomes unmapped, its children's parent is set to the parent of
+	the now-unmapped surface. If the now-unmapped surface has no parent,
+	its children's parent is unset. If the now-unmapped surface becomes
+	mapped again, its parent-child relationship is not restored.
+
+	The parent toplevel must not be one of the child toplevel's
+	descendants, and the parent must be different from the child toplevel,
+	otherwise the invalid_parent protocol error is raised.
+      </description>
+      <arg name="parent" type="object" interface="xdg_toplevel" allow-null="true"/>
+    </request>
+
+    <request name="set_title">
+      <description summary="set surface title">
+	Set a short title for the surface.
+
+	This string may be used to identify the surface in a task bar,
+	window list, or other user interface elements provided by the
+	compositor.
+
+	The string must be encoded in UTF-8.
+      </description>
+      <arg name="title" type="string"/>
+    </request>
+
+    <request name="set_app_id">
+      <description summary="set application ID">
+	Set an application identifier for the surface.
+
+	The app ID identifies the general class of applications to which
+	the surface belongs. The compositor can use this to group multiple
+	surfaces together, or to determine how to launch a new application.
+
+	For D-Bus activatable applications, the app ID is used as the D-Bus
+	service name.
+
+	The compositor shell will try to group application surfaces together
+	by their app ID. As a best practice, it is suggested to select app
+	ID's that match the basename of the application's .desktop file.
+	For example, "org.freedesktop.FooViewer" where the .desktop file is
+	"org.freedesktop.FooViewer.desktop".
+
+	Like other properties, a set_app_id request can be sent after the
+	xdg_toplevel has been mapped to update the property.
+
+	See the desktop-entry specification [0] for more details on
+	application identifiers and how they relate to well-known D-Bus
+	names and .desktop files.
+
+	[0] https://standards.freedesktop.org/desktop-entry-spec/
+      </description>
+      <arg name="app_id" type="string"/>
+    </request>
+
+    <request name="show_window_menu">
+      <description summary="show the window menu">
+	Clients implementing client-side decorations might want to show
+	a context menu when right-clicking on the decorations, giving the
+	user a menu that they can use to maximize or minimize the window.
+
+	This request asks the compositor to pop up such a window menu at
+	the given position, relative to the local surface coordinates of
+	the parent surface. There are no guarantees as to what menu items
+	the window menu contains, or even if a window menu will be drawn
+	at all.
+
+	This request must be used in response to some sort of user action
+	like a button press, key press, or touch down event.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
+      <arg name="x" type="int" summary="the x position to pop up the window menu at"/>
+      <arg name="y" type="int" summary="the y position to pop up the window menu at"/>
+    </request>
+
+    <request name="move">
+      <description summary="start an interactive move">
+	Start an interactive, user-driven move of the surface.
+
+	This request must be used in response to some sort of user action
+	like a button press, key press, or touch down event. The passed
+	serial is used to determine the type of interactive move (touch,
+	pointer, etc).
+
+	The server may ignore move requests depending on the state of
+	the surface (e.g. fullscreen or maximized), or if the passed serial
+	is no longer valid.
+
+	If triggered, the surface will lose the focus of the device
+	(wl_pointer, wl_touch, etc) used for the move. It is up to the
+	compositor to visually indicate that the move is taking place, such as
+	updating a pointer cursor, during the move. There is no guarantee
+	that the device focus will return when the move is completed.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
+    </request>
+
+    <enum name="resize_edge">
+      <description summary="edge values for resizing">
+	These values are used to indicate which edge of a surface
+	is being dragged in a resize operation.
+      </description>
+      <entry name="none" value="0"/>
+      <entry name="top" value="1"/>
+      <entry name="bottom" value="2"/>
+      <entry name="left" value="4"/>
+      <entry name="top_left" value="5"/>
+      <entry name="bottom_left" value="6"/>
+      <entry name="right" value="8"/>
+      <entry name="top_right" value="9"/>
+      <entry name="bottom_right" value="10"/>
+    </enum>
+
+    <request name="resize">
+      <description summary="start an interactive resize">
+	Start a user-driven, interactive resize of the surface.
+
+	This request must be used in response to some sort of user action
+	like a button press, key press, or touch down event. The passed
+	serial is used to determine the type of interactive resize (touch,
+	pointer, etc).
+
+	The server may ignore resize requests depending on the state of
+	the surface (e.g. fullscreen or maximized).
+
+	If triggered, the client will receive configure events with the
+	"resize" state enum value and the expected sizes. See the "resize"
+	enum value for more details about what is required. The client
+	must also acknowledge configure events using "ack_configure". After
+	the resize is completed, the client will receive another "configure"
+	event without the resize state.
+
+	If triggered, the surface also will lose the focus of the device
+	(wl_pointer, wl_touch, etc) used for the resize. It is up to the
+	compositor to visually indicate that the resize is taking place,
+	such as updating a pointer cursor, during the resize. There is no
+	guarantee that the device focus will return when the resize is
+	completed.
+
+	The edges parameter specifies how the surface should be resized, and
+	is one of the values of the resize_edge enum. Values not matching
+	a variant of the enum will cause the invalid_resize_edge protocol error.
+	The compositor may use this information to update the surface position
+	for example when dragging the top left corner. The compositor may also
+	use this information to adapt its behavior, e.g. choose an appropriate
+	cursor image.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
+      <arg name="edges" type="uint" enum="resize_edge" summary="which edge or corner is being dragged"/>
+    </request>
+
+    <enum name="state">
+      <description summary="types of state on the surface">
+	The different state values used on the surface. This is designed for
+	state values like maximized, fullscreen. It is paired with the
+	configure event to ensure that both the client and the compositor
+	setting the state can be synchronized.
+
+	States set in this way are double-buffered, see wl_surface.commit.
+      </description>
+      <entry name="maximized" value="1" summary="the surface is maximized">
+	<description summary="the surface is maximized">
+	  The surface is maximized. The window geometry specified in the configure
+	  event must be obeyed by the client, or the xdg_wm_base.invalid_surface_state
+	  error is raised.
+
+	  The client should draw without shadow or other
+	  decoration outside of the window geometry.
+	</description>
+      </entry>
+      <entry name="fullscreen" value="2" summary="the surface is fullscreen">
+	<description summary="the surface is fullscreen">
+	  The surface is fullscreen. The window geometry specified in the
+	  configure event is a maximum; the client cannot resize beyond it. For
+	  a surface to cover the whole fullscreened area, the geometry
+	  dimensions must be obeyed by the client. For more details, see
+	  xdg_toplevel.set_fullscreen.
+	</description>
+      </entry>
+      <entry name="resizing" value="3" summary="the surface is being resized">
+	<description summary="the surface is being resized">
+	  The surface is being resized. The window geometry specified in the
+	  configure event is a maximum; the client cannot resize beyond it.
+	  Clients that have aspect ratio or cell sizing configuration can use
+	  a smaller size, however.
+	</description>
+      </entry>
+      <entry name="activated" value="4" summary="the surface is now activated">
+	<description summary="the surface is now activated">
+	  Client window decorations should be painted as if the window is
+	  active. Do not assume this means that the window actually has
+	  keyboard or pointer focus.
+	</description>
+      </entry>
+      <entry name="tiled_left" value="5" since="2">
+	<description summary="the surface’s left edge is tiled">
+	  The window is currently in a tiled layout and the left edge is
+	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the left edge.
+	</description>
+      </entry>
+      <entry name="tiled_right" value="6" since="2">
+	<description summary="the surface’s right edge is tiled">
+	  The window is currently in a tiled layout and the right edge is
+	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the right edge.
+	</description>
+      </entry>
+      <entry name="tiled_top" value="7" since="2">
+	<description summary="the surface’s top edge is tiled">
+	  The window is currently in a tiled layout and the top edge is
+	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the top edge.
+	</description>
+      </entry>
+      <entry name="tiled_bottom" value="8" since="2">
+	<description summary="the surface’s bottom edge is tiled">
+	  The window is currently in a tiled layout and the bottom edge is
+	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the bottom edge.
+	</description>
+      </entry>
+      <entry name="suspended" value="9" since="6">
+        <description summary="surface repaint is suspended">
+	  The surface is currently not ordinarily being repainted; for
+	  example because its content is occluded by another window, or its
+	  outputs are switched off due to screen locking.
+	</description>
+      </entry>
+      <entry name="constrained_left" value="10" since="7">
+	<description summary="the surface’s left edge is constrained">
+          The left edge of the window is currently constrained, meaning it
+          shouldn't attempt to resize from that edge. It can for example mean
+          it's tiled next to a monitor edge on the constrained side of the
+          window.
+	</description>
+      </entry>
+      <entry name="constrained_right" value="11" since="7">
+	<description summary="the surface’s right edge is constrained">
+          The right edge of the window is currently constrained, meaning it
+          shouldn't attempt to resize from that edge. It can for example mean
+          it's tiled next to a monitor edge on the constrained side of the
+          window.
+	</description>
+      </entry>
+      <entry name="constrained_top" value="12" since="7">
+	<description summary="the surface’s top edge is constrained">
+          The top edge of the window is currently constrained, meaning it
+          shouldn't attempt to resize from that edge. It can for example mean
+          it's tiled next to a monitor edge on the constrained side of the
+          window.
+	</description>
+      </entry>
+      <entry name="constrained_bottom" value="13" since="7">
+	<description summary="the surface’s bottom edge is tiled">
+          The bottom edge of the window is currently constrained, meaning it
+          shouldn't attempt to resize from that edge. It can for example mean
+          it's tiled next to a monitor edge on the constrained side of the
+          window.
+	</description>
+      </entry>
+    </enum>
+
+    <request name="set_max_size">
+      <description summary="set the maximum size">
+	Set a maximum size for the window.
+
+	The client can specify a maximum size so that the compositor does
+	not try to configure the window beyond this size.
+
+	The width and height arguments are in window geometry coordinates.
+	See xdg_surface.set_window_geometry.
+
+	Values set in this way are double-buffered, see wl_surface.commit.
+
+	The compositor can use this information to allow or disallow
+	different states like maximize or fullscreen and draw accurate
+	animations.
+
+	Similarly, a tiling window manager may use this information to
+	place and resize client windows in a more effective way.
+
+	The client should not rely on the compositor to obey the maximum
+	size. The compositor may decide to ignore the values set by the
+	client and request a larger size.
+
+	If never set, or a value of zero in the request, means that the
+	client has no expected maximum size in the given dimension.
+	As a result, a client wishing to reset the maximum size
+	to an unspecified state can use zero for width and height in the
+	request.
+
+	Requesting a maximum size to be smaller than the minimum size of
+	a surface is illegal and will result in an invalid_size error.
+
+	The width and height must be greater than or equal to zero. Using
+	strictly negative values for width or height will result in a
+	invalid_size error.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <request name="set_min_size">
+      <description summary="set the minimum size">
+	Set a minimum size for the window.
+
+	The client can specify a minimum size so that the compositor does
+	not try to configure the window below this size.
+
+	The width and height arguments are in window geometry coordinates.
+	See xdg_surface.set_window_geometry.
+
+	Values set in this way are double-buffered, see wl_surface.commit.
+
+	The compositor can use this information to allow or disallow
+	different states like maximize or fullscreen and draw accurate
+	animations.
+
+	Similarly, a tiling window manager may use this information to
+	place and resize client windows in a more effective way.
+
+	The client should not rely on the compositor to obey the minimum
+	size. The compositor may decide to ignore the values set by the
+	client and request a smaller size.
+
+	If never set, or a value of zero in the request, means that the
+	client has no expected minimum size in the given dimension.
+	As a result, a client wishing to reset the minimum size
+	to an unspecified state can use zero for width and height in the
+	request.
+
+	Requesting a minimum size to be larger than the maximum size of
+	a surface is illegal and will result in an invalid_size error.
+
+	The width and height must be greater than or equal to zero. Using
+	strictly negative values for width and height will result in a
+	invalid_size error.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <request name="set_maximized">
+      <description summary="maximize the window">
+	Maximize the surface.
+
+	After requesting that the surface should be maximized, the compositor
+	will respond by emitting a configure event. Whether this configure
+	actually sets the window maximized is subject to compositor policies.
+	The client must then update its content, drawing in the configured
+	state. The client must also acknowledge the configure when committing
+	the new content (see ack_configure).
+
+	It is up to the compositor to decide how and where to maximize the
+	surface, for example which output and what region of the screen should
+	be used.
+
+	If the surface was already maximized, the compositor will still emit
+	a configure event with the "maximized" state.
+
+	If the surface is in a fullscreen state, this request has no direct
+	effect. It may alter the state the surface is returned to when
+	unmaximized unless overridden by the compositor.
+      </description>
+    </request>
+
+    <request name="unset_maximized">
+      <description summary="unmaximize the window">
+	Unmaximize the surface.
+
+	After requesting that the surface should be unmaximized, the compositor
+	will respond by emitting a configure event. Whether this actually
+	un-maximizes the window is subject to compositor policies.
+	If available and applicable, the compositor will include the window
+	geometry dimensions the window had prior to being maximized in the
+	configure event. The client must then update its content, drawing it in
+	the configured state. The client must also acknowledge the configure
+	when committing the new content (see ack_configure).
+
+	It is up to the compositor to position the surface after it was
+	unmaximized; usually the position the surface had before maximizing, if
+	applicable.
+
+	If the surface was already not maximized, the compositor will still
+	emit a configure event without the "maximized" state.
+
+	If the surface is in a fullscreen state, this request has no direct
+	effect. It may alter the state the surface is returned to when
+	unmaximized unless overridden by the compositor.
+      </description>
+    </request>
+
+    <request name="set_fullscreen">
+      <description summary="set the window as fullscreen on an output">
+	Make the surface fullscreen.
+
+	After requesting that the surface should be fullscreened, the
+	compositor will respond by emitting a configure event. Whether the
+	client is actually put into a fullscreen state is subject to compositor
+	policies. The client must also acknowledge the configure when
+	committing the new content (see ack_configure).
+
+	The output passed by the request indicates the client's preference as
+	to which display it should be set fullscreen on. If this value is NULL,
+	it's up to the compositor to choose which display will be used to map
+	this surface.
+
+	If the surface doesn't cover the whole output, the compositor will
+	position the surface in the center of the output and compensate with
+	with border fill covering the rest of the output. The content of the
+	border fill is undefined, but should be assumed to be in some way that
+	attempts to blend into the surrounding area (e.g. solid black).
+
+	If the fullscreened surface is not opaque, the compositor must make
+	sure that other screen content not part of the same surface tree (made
+	up of subsurfaces, popups or similarly coupled surfaces) are not
+	visible below the fullscreened surface.
+      </description>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+    </request>
+
+    <request name="unset_fullscreen">
+      <description summary="unset the window as fullscreen">
+	Make the surface no longer fullscreen.
+
+	After requesting that the surface should be unfullscreened, the
+	compositor will respond by emitting a configure event.
+	Whether this actually removes the fullscreen state of the client is
+	subject to compositor policies.
+
+	Making a surface unfullscreen sets states for the surface based on the following:
+	* the state(s) it may have had before becoming fullscreen
+	* any state(s) decided by the compositor
+	* any state(s) requested by the client while the surface was fullscreen
+
+	The compositor may include the previous window geometry dimensions in
+	the configure event, if applicable.
+
+	The client must also acknowledge the configure when committing the new
+	content (see ack_configure).
+      </description>
+    </request>
+
+    <request name="set_minimized">
+      <description summary="set the window as minimized">
+	Request that the compositor minimize your surface. There is no
+	way to know if the surface is currently minimized, nor is there
+	any way to unset minimization on this surface.
+
+	If you are looking to throttle redrawing when minimized, please
+	instead use the wl_surface.frame event for this, as this will
+	also work with live previews on windows in Alt-Tab, Expose or
+	similar compositor features.
+      </description>
+    </request>
+
+    <event name="configure">
+      <description summary="suggest a surface change">
+	This configure event asks the client to resize its toplevel surface or
+	to change its state. The configured state should not be applied
+	immediately. See xdg_surface.configure for details.
+
+	The width and height arguments specify a hint to the window
+	about how its surface should be resized in window geometry
+	coordinates. See set_window_geometry.
+
+	If the width or height arguments are zero, it means the client
+	should decide its own window dimension. This may happen when the
+	compositor needs to configure the state of the surface but doesn't
+	have any information about any previous or expected dimension.
+
+	The states listed in the event specify how the width/height
+	arguments should be interpreted, and possibly how it should be
+	drawn.
+
+	Clients must send an ack_configure in response to this event. See
+	xdg_surface.configure and xdg_surface.ack_configure for details.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+      <arg name="states" type="array"/>
+    </event>
+
+    <event name="close">
+      <description summary="surface wants to be closed">
+	The close event is sent by the compositor when the user
+	wants the surface to be closed. This should be equivalent to
+	the user clicking the close button in client-side decorations,
+	if your application has any.
+
+	This is only a request that the user intends to close the
+	window. The client may choose to ignore this request, or show
+	a dialog to ask the user to save their data, etc.
+      </description>
+    </event>
+
+    <!-- Version 4 additions -->
+
+    <event name="configure_bounds" since="4">
+      <description summary="recommended window geometry bounds">
+	The configure_bounds event may be sent prior to a xdg_toplevel.configure
+	event to communicate the bounds a window geometry size is recommended
+	to constrain to.
+
+	The passed width and height are in surface coordinate space. If width
+	and height are 0, it means bounds is unknown and equivalent to as if no
+	configure_bounds event was ever sent for this surface.
+
+	The bounds can for example correspond to the size of a monitor excluding
+	any panels or other shell components, so that a surface isn't created in
+	a way that it cannot fit.
+
+	The bounds may change at any point, and in such a case, a new
+	xdg_toplevel.configure_bounds will be sent, followed by
+	xdg_toplevel.configure and xdg_surface.configure.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </event>
+
+    <!-- Version 5 additions -->
+
+    <enum name="wm_capabilities" since="5">
+      <entry name="window_menu" value="1" summary="show_window_menu is available"/>
+      <entry name="maximize" value="2" summary="set_maximized and unset_maximized are available"/>
+      <entry name="fullscreen" value="3" summary="set_fullscreen and unset_fullscreen are available"/>
+      <entry name="minimize" value="4" summary="set_minimized is available"/>
+    </enum>
+
+    <event name="wm_capabilities" since="5">
+      <description summary="compositor capabilities">
+	This event advertises the capabilities supported by the compositor. If
+	a capability isn't supported, clients should hide or disable the UI
+	elements that expose this functionality. For instance, if the
+	compositor doesn't advertise support for minimized toplevels, a button
+	triggering the set_minimized request should not be displayed.
+
+	The compositor will ignore requests it doesn't support. For instance,
+	a compositor which doesn't advertise support for minimized will ignore
+	set_minimized requests.
+
+	Compositors must send this event once before the first
+	xdg_surface.configure event. When the capabilities change, compositors
+	must send this event again and then send an xdg_surface.configure
+	event.
+
+	The configured state should not be applied immediately. See
+	xdg_surface.configure for details.
+
+	The capabilities are sent as an array of 32-bit unsigned integers in
+	native endianness.
+      </description>
+      <arg name="capabilities" type="array" summary="array of 32-bit capabilities"/>
+    </event>
+  </interface>
+
+  <interface name="xdg_popup" version="7">
+    <description summary="short-lived, popup surfaces for menus">
+      A popup surface is a short-lived, temporary surface. It can be used to
+      implement for example menus, popovers, tooltips and other similar user
+      interface concepts.
+
+      A popup can be made to take an explicit grab. See xdg_popup.grab for
+      details.
+
+      When the popup is dismissed, a popup_done event will be sent out, and at
+      the same time the surface will be unmapped. See the xdg_popup.popup_done
+      event for details.
+
+      Explicitly destroying the xdg_popup object will also dismiss the popup and
+      unmap the surface. Clients that want to dismiss the popup when another
+      surface of their own is clicked should dismiss the popup using the destroy
+      request.
+
+      A newly created xdg_popup will be stacked on top of all previously created
+      xdg_popup surfaces associated with the same xdg_toplevel.
+
+      The parent of an xdg_popup must be mapped (see the xdg_surface
+      description) before the xdg_popup itself.
+
+      The client must call wl_surface.commit on the corresponding wl_surface
+      for the xdg_popup state to take effect.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_grab" value="0"
+	     summary="tried to grab after being mapped"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="remove xdg_popup interface">
+	This destroys the popup. Explicitly destroying the xdg_popup
+	object will also dismiss the popup, and unmap the surface.
+
+	If this xdg_popup is not the "topmost" popup, the
+	xdg_wm_base.not_the_topmost_popup protocol error will be sent.
+      </description>
+    </request>
+
+    <request name="grab">
+      <description summary="make the popup take an explicit grab">
+	This request makes the created popup take an explicit grab. An explicit
+	grab will be dismissed when the user dismisses the popup, or when the
+	client destroys the xdg_popup. This can be done by the user clicking
+	outside the surface, using the keyboard, or even locking the screen
+	through closing the lid or a timeout.
+
+	If the compositor denies the grab, the popup will be immediately
+	dismissed.
+
+	This request must be used in response to some sort of user action like a
+	button press, key press, or touch down event. The serial number of the
+	event should be passed as 'serial'.
+
+	The parent of a grabbing popup must either be an xdg_toplevel surface or
+	another xdg_popup with an explicit grab. If the parent is another
+	xdg_popup it means that the popups are nested, with this popup now being
+	the topmost popup.
+
+	Nested popups must be destroyed in the reverse order they were created
+	in, e.g. the only popup you are allowed to destroy at all times is the
+	topmost one.
+
+	When compositors choose to dismiss a popup, they may dismiss every
+	nested grabbing popup as well. When a compositor dismisses popups, it
+	will follow the same dismissing order as required from the client.
+
+	If the topmost grabbing popup is destroyed, the grab will be returned to
+	the parent of the popup, if that parent previously had an explicit grab.
+
+	If the parent is a grabbing popup which has already been dismissed, this
+	popup will be immediately dismissed. If the parent is a popup that did
+	not take an explicit grab, an error will be raised.
+
+	During a popup grab, the client owning the grab will receive pointer
+	and touch events for all their surfaces as normal (similar to an
+	"owner-events" grab in X11 parlance), while the top most grabbing popup
+	will always have keyboard focus.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat"
+	   summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
+    </request>
+
+    <event name="configure">
+      <description summary="configure the popup surface">
+	This event asks the popup surface to configure itself given the
+	configuration. The configured state should not be applied immediately.
+	See xdg_surface.configure for details.
+
+	The x and y arguments represent the position the popup was placed at
+	given the xdg_positioner rule, relative to the upper left corner of the
+	window geometry of the parent surface.
+
+	For version 2 or older, the configure event for an xdg_popup is only
+	ever sent once for the initial configuration. Starting with version 3,
+	it may be sent again if the popup is setup with an xdg_positioner with
+	set_reactive requested, or in response to xdg_popup.reposition requests.
+      </description>
+      <arg name="x" type="int"
+	   summary="x position relative to parent surface window geometry"/>
+      <arg name="y" type="int"
+	   summary="y position relative to parent surface window geometry"/>
+      <arg name="width" type="int" summary="window geometry width"/>
+      <arg name="height" type="int" summary="window geometry height"/>
+    </event>
+
+    <event name="popup_done">
+      <description summary="popup interaction is done">
+	The popup_done event is sent out when a popup is dismissed by the
+	compositor. The client should destroy the xdg_popup object at this
+	point.
+      </description>
+    </event>
+
+    <!-- Version 3 additions -->
+
+    <request name="reposition" since="3">
+      <description summary="recalculate the popup's location">
+	Reposition an already-mapped popup. The popup will be placed given the
+	details in the passed xdg_positioner object, and a
+	xdg_popup.repositioned followed by xdg_popup.configure and
+	xdg_surface.configure will be emitted in response. Any parameters set
+	by the previous positioner will be discarded.
+
+	The passed token will be sent in the corresponding
+	xdg_popup.repositioned event. The new popup position will not take
+	effect until the corresponding configure event is acknowledged by the
+	client. See xdg_popup.repositioned for details. The token itself is
+	opaque, and has no other special meaning.
+
+	If multiple reposition requests are sent, the compositor may skip all
+	but the last one.
+
+	If the popup is repositioned in response to a configure event for its
+	parent, the client should send an xdg_positioner.set_parent_configure
+	and possibly an xdg_positioner.set_parent_size request to allow the
+	compositor to properly constrain the popup.
+
+	If the popup is repositioned together with a parent that is being
+	resized, but not in response to a configure event, the client should
+	send an xdg_positioner.set_parent_size request.
+      </description>
+      <arg name="positioner" type="object" interface="xdg_positioner"/>
+      <arg name="token" type="uint" summary="reposition request token"/>
+    </request>
+
+    <event name="repositioned" since="3">
+      <description summary="signal the completion of a repositioned request">
+	The repositioned event is sent as part of a popup configuration
+	sequence, together with xdg_popup.configure and lastly
+	xdg_surface.configure to notify the completion of a reposition request.
+
+	The repositioned event is to notify about the completion of a
+	xdg_popup.reposition request. The token argument is the token passed
+	in the xdg_popup.reposition request.
+
+	Immediately after this event is emitted, xdg_popup.configure and
+	xdg_surface.configure will be sent with the updated size and position,
+	as well as a new configure serial.
+
+	The client should optionally update the content of the popup, but must
+	acknowledge the new popup configuration for the new position to take
+	effect. See xdg_surface.ack_configure for details.
+      </description>
+      <arg name="token" type="uint" summary="reposition request token"/>
+    </event>
+
+  </interface>
+</protocol>

--- a/src/feature_flags.h
+++ b/src/feature_flags.h
@@ -20,5 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define MIRACLE_FEATURE_FLAG_MULTI_SELECT false
 #define MIRACLE_FEATURE_FLAG_DRAG_AND_DROP true
+namespace miracle::feature
+{
+    constexpr bool parent_container_wallpapers = false;
+}
 
 #endif // MIRACLE_WM_FEATURE_FLAGS_H

--- a/src/feature_flags.h
+++ b/src/feature_flags.h
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MIRACLE_FEATURE_FLAG_DRAG_AND_DROP true
 namespace miracle::feature
 {
-    constexpr bool parent_container_wallpapers = false;
+constexpr bool parent_container_wallpapers = false;
 }
 
 #endif // MIRACLE_WM_FEATURE_FLAGS_H

--- a/src/internal_shell_application_spawner.cpp
+++ b/src/internal_shell_application_spawner.cpp
@@ -1,0 +1,45 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#define MIR_LOG_COMPONENT "internal_shell_application_spawner"
+
+#include "internal_shell_application_spawner.h"
+#include "parent_background_internal_client.h"
+#include <mir/log.h>
+
+using namespace miracle;
+
+InternalShellApplicationSpawner::InternalShellApplicationSpawner(miral::InternalClientLauncher const& launcher) :
+    launcher(launcher)
+{
+}
+
+std::unique_ptr<ShellApplication> InternalShellApplicationSpawner::spawn(ShellApplicationRole role)
+{
+    switch (role)
+    {
+    case ShellApplicationRole::parent_container_background:
+    {
+        auto background_client = std::make_unique<ParentBackgroundInternalClient>();
+        launcher.launch(*background_client);
+        return background_client;
+    }
+    }
+
+    mir::log_error("Cannot spawn a shell application with an unknown role");
+    return nullptr;
+}

--- a/src/internal_shell_application_spawner.cpp
+++ b/src/internal_shell_application_spawner.cpp
@@ -23,8 +23,37 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using namespace miracle;
 
-InternalShellApplicationSpawner::InternalShellApplicationSpawner(miral::InternalClientLauncher const& launcher) :
-    launcher(launcher)
+namespace
+{
+class NotifyingInternalApplication : public ShellApplication
+{
+public:
+    NotifyingInternalApplication(
+        std::unique_ptr<ShellApplication> application,
+        std::function<void()>&& on_destroyed) :
+        app(std::move(application)),
+        on_destroyed(std::move(on_destroyed))
+    {
+    }
+
+    void stop() override
+    {
+        app->stop();
+    }
+
+    miral::Application application() override
+    {
+        return app->application();
+    }
+
+private:
+    std::unique_ptr<ShellApplication> app;
+    std::function<void()> on_destroyed;
+};
+}
+
+InternalShellApplicationSpawner::InternalShellApplicationSpawner(mir::Server& server) :
+    server(server)
 {
 }
 
@@ -34,9 +63,31 @@ std::unique_ptr<ShellApplication> InternalShellApplicationSpawner::spawn(ShellAp
     {
     case ShellApplicationRole::parent_container_background:
     {
+        size_t i = 0;
+        for (i = 0; i < client_pool.size(); ++i)
+        {
+            if (!client_pool[i].is_taken)
+                break;
+        }
+
+        if (i == client_pool.size())
+        {
+            miral::InternalClientLauncher launcher;
+            launcher(server);
+            client_pool.push_back({ launcher, true });
+        }
+
         auto background_client = std::make_unique<ParentBackgroundInternalClient>();
-        launcher.launch(*background_client);
-        return background_client;
+        client_pool[i].launcher(server);
+        client_pool[i].launcher.launch(*background_client);
+
+        auto wrapper_client = std::make_unique<NotifyingInternalApplication>(
+            std::move(background_client),
+            [this, i]
+        {
+            client_pool[i].is_taken = false;
+        });
+        return wrapper_client;
     }
     }
 

--- a/src/internal_shell_application_spawner.h
+++ b/src/internal_shell_application_spawner.h
@@ -1,0 +1,38 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef MIRACLE_WM_INTERNAL_SHELL_APPLICATION_SPAWNER_H
+#define MIRACLE_WM_INTERNAL_SHELL_APPLICATION_SPAWNER_H
+
+#include "shell_application_spawner.h"
+#include <miral/internal_client.h>
+
+namespace miracle
+{
+class InternalShellApplicationSpawner : public ShellApplicationSpawner
+{
+public:
+    explicit InternalShellApplicationSpawner(miral::InternalClientLauncher const& launcher);
+    std::unique_ptr<ShellApplication> spawn(ShellApplicationRole role) override;
+
+private:
+    miral::InternalClientLauncher launcher;
+};
+
+}
+
+#endif // MIRACLE_WM_INTERNAL_SHELL_APPLICATION_SPAWNER_H

--- a/src/internal_shell_application_spawner.h
+++ b/src/internal_shell_application_spawner.h
@@ -20,17 +20,30 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "shell_application_spawner.h"
 #include <miral/internal_client.h>
+#include <vector>
+
+namespace mir
+{
+class Server;
+}
 
 namespace miracle
 {
 class InternalShellApplicationSpawner : public ShellApplicationSpawner
 {
 public:
-    explicit InternalShellApplicationSpawner(miral::InternalClientLauncher const& launcher);
+    explicit InternalShellApplicationSpawner(mir::Server& server);
     std::unique_ptr<ShellApplication> spawn(ShellApplicationRole role) override;
 
 private:
-    miral::InternalClientLauncher launcher;
+    mir::Server& server;
+
+    struct ClientPoolItem
+    {
+        miral::InternalClientLauncher launcher;
+        bool is_taken = false;
+    };
+    std::vector<ClientPoolItem> client_pool;
 };
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "config_observer.h"
 #include "display_config.h"
 #include "output_listener.h"
+#include "parent_background_internal_client.h"
 #include "policy.h"
 #include "renderer.h"
 #include "version.h"
@@ -35,6 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <miral/decorations.h>
 #include <miral/external_client.h>
 #include <miral/hover_click.h>
+#include <miral/internal_client.h>
 #include <miral/keymap.h>
 #include <miral/magnifier.h>
 #include <miral/runner.h>
@@ -53,6 +55,7 @@ class PolicyLoader
 {
 public:
     PolicyLoader(ExternalClientLauncher& launcher,
+        InternalClientLauncher& internal_client_launcher,
         std::shared_ptr<miracle::Config> const& config,
         std::shared_ptr<miracle::CompositorState> const& compositor_state,
         std::shared_ptr<miracle::OutputListenerMultiplexer> const& output_listener,
@@ -60,6 +63,7 @@ public:
         std::shared_ptr<miracle::ConfigObserverRegistrar> const& config_observer_registrar,
         Magnifier const& magnifier) :
         launcher(launcher),
+        internal_client_launcher(internal_client_launcher),
         config(config),
         compositor_state(compositor_state),
         output_listener(output_listener),
@@ -73,13 +77,14 @@ public:
     {
         config->operator()(server);
         auto policy = add_window_manager_policy<miracle::Policy>(
-            "tiling", server, launcher, config, compositor_state, output_listener, display_config, config_observer_registrar, magnifier);
+            "tiling", server, launcher, internal_client_launcher, config, compositor_state, output_listener, display_config, config_observer_registrar, magnifier);
         options = std::make_shared<WindowManagerOptions>(std::initializer_list<WindowManagerOption> { policy });
         options->operator()(server);
     }
 
 private:
     ExternalClientLauncher& launcher;
+    InternalClientLauncher& internal_client_launcher;
     std::shared_ptr<miracle::Config> config;
     std::shared_ptr<miracle::CompositorState> compositor_state;
     std::shared_ptr<WindowManagerOptions> options;
@@ -98,6 +103,7 @@ int main(int argc, char const* argv[])
     auto display_config = std::make_shared<miracle::DisplayConfig>();
 
     ExternalClientLauncher external_client_launcher;
+    InternalClientLauncher internal_client_launcher;
     InputConfiguration input_configuration;
     Magnifier magnifier;
     HoverClick hover_click = HoverClick::disabled();
@@ -243,8 +249,9 @@ int main(int argc, char const* argv[])
     wayland_extensions.enable(mir::wayland::OutputManagerV1::interface_name);
 
     return runner.run_with(
-        { PolicyLoader(external_client_launcher, config, compositor_state, output_listener, display_config, config_observer_registrar, magnifier),
+        { PolicyLoader(external_client_launcher, internal_client_launcher, config, compositor_state, output_listener, display_config, config_observer_registrar, magnifier),
             wayland_extensions,
+            internal_client_launcher,
             X11Support {}.default_to_enabled(),
             keymap,
             *display_config,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,7 +55,6 @@ class PolicyLoader
 {
 public:
     PolicyLoader(ExternalClientLauncher& launcher,
-        InternalClientLauncher& internal_client_launcher,
         std::shared_ptr<miracle::Config> const& config,
         std::shared_ptr<miracle::CompositorState> const& compositor_state,
         std::shared_ptr<miracle::OutputListenerMultiplexer> const& output_listener,
@@ -63,7 +62,6 @@ public:
         std::shared_ptr<miracle::ConfigObserverRegistrar> const& config_observer_registrar,
         Magnifier const& magnifier) :
         launcher(launcher),
-        internal_client_launcher(internal_client_launcher),
         config(config),
         compositor_state(compositor_state),
         output_listener(output_listener),
@@ -77,14 +75,13 @@ public:
     {
         config->operator()(server);
         auto policy = add_window_manager_policy<miracle::Policy>(
-            "tiling", server, launcher, internal_client_launcher, config, compositor_state, output_listener, display_config, config_observer_registrar, magnifier);
+            "tiling", server, launcher, config, compositor_state, output_listener, display_config, config_observer_registrar, magnifier);
         options = std::make_shared<WindowManagerOptions>(std::initializer_list<WindowManagerOption> { policy });
         options->operator()(server);
     }
 
 private:
     ExternalClientLauncher& launcher;
-    InternalClientLauncher& internal_client_launcher;
     std::shared_ptr<miracle::Config> config;
     std::shared_ptr<miracle::CompositorState> compositor_state;
     std::shared_ptr<WindowManagerOptions> options;
@@ -103,7 +100,6 @@ int main(int argc, char const* argv[])
     auto display_config = std::make_shared<miracle::DisplayConfig>();
 
     ExternalClientLauncher external_client_launcher;
-    InternalClientLauncher internal_client_launcher;
     InputConfiguration input_configuration;
     Magnifier magnifier;
     HoverClick hover_click = HoverClick::disabled();
@@ -249,9 +245,8 @@ int main(int argc, char const* argv[])
     wayland_extensions.enable(mir::wayland::OutputManagerV1::interface_name);
 
     return runner.run_with(
-        { PolicyLoader(external_client_launcher, internal_client_launcher, config, compositor_state, output_listener, display_config, config_observer_registrar, magnifier),
+        { PolicyLoader(external_client_launcher, config, compositor_state, output_listener, display_config, config_observer_registrar, magnifier),
             wayland_extensions,
-            internal_client_launcher,
             X11Support {}.default_to_enabled(),
             keymap,
             *display_config,

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -30,6 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <glm/gtx/transform.hpp>
 #include <memory>
 #include <mir/log.h>
+#include <miral/application_info.h>
 #include <miral/window_info.h>
 #include <miral/zone.h>
 
@@ -37,6 +38,8 @@ using namespace miracle;
 namespace mg = mir::graphics;
 
 Output::Output(
+    miral::InternalClientLauncher& internal_client_launcher,
+    std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
     std::string name,
     int id,
     geom::Rectangle const& area,
@@ -47,6 +50,8 @@ Output::Output(
     std::shared_ptr<Animator> const& animator,
     std::shared_ptr<mir::ServerActionQueue> const& server_action_queue,
     std::shared_ptr<PluginManager> const& plugin_manager) :
+    internal_client_launcher { internal_client_launcher },
+    shell_application_manager { shell_application_manager },
     name_ { std::move(name) },
     id_ { id },
     area { area },
@@ -182,7 +187,19 @@ void Output::advise_new_workspace(WorkspaceCreationData const&& data)
 {
     // Workspaces are always kept in sorted order with numbered workspaces in front followed by all other workspaces
     auto const new_workspace = std::make_shared<Workspace>(
-        shared_from_this(), data.id, data.num, data.name, config, window_controller, state, data.registrar, animator, server_action_queue, plugin_manager);
+        internal_client_launcher,
+        shell_application_manager,
+        shared_from_this(),
+        data.id,
+        data.num,
+        data.name,
+        config,
+        window_controller,
+        state,
+        data.registrar,
+        animator,
+        server_action_queue,
+        plugin_manager);
     insert_workspace_sorted(new_workspace);
 }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -34,6 +34,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <miral/window_info.h>
 #include <miral/zone.h>
 
+#include "shell_application_manager.h"
+
 using namespace miracle;
 namespace mg = mir::graphics;
 
@@ -132,6 +134,12 @@ AllocationHint Output::allocate_position(
     miral::WindowSpecification& requested_specification,
     AllocationHint hint)
 {
+    if (shell_application_manager->is_registered(app_info.application()))
+    {
+        hint.container_type = ContainerType::shell;
+        return hint;
+    }
+
     auto const has_exclusive_rect = requested_specification.exclusive_rect().is_set();
     auto const is_attached = requested_specification.attached_edges().is_set();
     auto const wrong_leaf_state = requested_specification.state() == mir_window_state_hidden

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -40,7 +40,6 @@ using namespace miracle;
 namespace mg = mir::graphics;
 
 Output::Output(
-    miral::InternalClientLauncher& internal_client_launcher,
     std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
     std::string name,
     int id,
@@ -52,7 +51,6 @@ Output::Output(
     std::shared_ptr<Animator> const& animator,
     std::shared_ptr<mir::ServerActionQueue> const& server_action_queue,
     std::shared_ptr<PluginManager> const& plugin_manager) :
-    internal_client_launcher { internal_client_launcher },
     shell_application_manager { shell_application_manager },
     name_ { std::move(name) },
     id_ { id },
@@ -195,7 +193,6 @@ void Output::advise_new_workspace(WorkspaceCreationData const&& data)
 {
     // Workspaces are always kept in sorted order with numbered workspaces in front followed by all other workspaces
     auto const new_workspace = std::make_shared<Workspace>(
-        internal_client_launcher,
         shell_application_manager,
         shared_from_this(),
         data.id,

--- a/src/output.h
+++ b/src/output.h
@@ -20,7 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "display_config.h"
 #include "output_interface.h"
-#include <miral/internal_client.h>
 
 namespace miracle
 {
@@ -31,7 +30,6 @@ class Output final : public OutputInterface, public std::enable_shared_from_this
 {
 public:
     explicit Output(
-        miral::InternalClientLauncher& internal_client_launcher,
         std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
         std::string name,
         int id,
@@ -85,7 +83,6 @@ public:
 private:
     void insert_workspace_sorted(std::shared_ptr<WorkspaceInterface> const& new_workspace);
 
-    miral::InternalClientLauncher internal_client_launcher;
     std::shared_ptr<ShellApplicationManager> shell_application_manager;
     std::string name_;
     int id_;

--- a/src/output.h
+++ b/src/output.h
@@ -20,15 +20,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "display_config.h"
 #include "output_interface.h"
+#include <miral/internal_client.h>
 
 namespace miracle
 {
 class PluginManager;
+class ShellApplicationManager;
 
 class Output final : public OutputInterface, public std::enable_shared_from_this<Output>
 {
 public:
     explicit Output(
+        miral::InternalClientLauncher& internal_client_launcher,
+        std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
         std::string name,
         int id,
         geom::Rectangle const& area,
@@ -81,6 +85,8 @@ public:
 private:
     void insert_workspace_sorted(std::shared_ptr<WorkspaceInterface> const& new_workspace);
 
+    miral::InternalClientLauncher internal_client_launcher;
+    std::shared_ptr<ShellApplicationManager> shell_application_manager;
     std::string name_;
     int id_;
     geom::Rectangle area;

--- a/src/output_factory.cpp
+++ b/src/output_factory.cpp
@@ -26,6 +26,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 using namespace miracle;
 
 MiralOutputFactory::MiralOutputFactory(
+    miral::InternalClientLauncher& internal_client_launcher,
+    std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
     std::shared_ptr<CompositorState> const& state,
     std::shared_ptr<Config> const& config,
     std::shared_ptr<WindowController> const& window_controller,
@@ -33,6 +35,8 @@ MiralOutputFactory::MiralOutputFactory(
     std::shared_ptr<DisplayConfig> const& display_config,
     std::shared_ptr<mir::ServerActionQueue> const& server_action_queue,
     std::shared_ptr<PluginManager> const& plugin_manager) :
+    internal_client_launcher { internal_client_launcher },
+    shell_application_manager { shell_application_manager },
     state { state },
     config { config },
     window_controller { window_controller },
@@ -54,6 +58,8 @@ std::shared_ptr<OutputInterface> MiralOutputFactory::create(
     }
 
     return std::make_shared<Output>(
+        internal_client_launcher,
+        shell_application_manager,
         std::move(name),
         id,
         area,

--- a/src/output_factory.cpp
+++ b/src/output_factory.cpp
@@ -26,7 +26,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 using namespace miracle;
 
 MiralOutputFactory::MiralOutputFactory(
-    miral::InternalClientLauncher& internal_client_launcher,
     std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
     std::shared_ptr<CompositorState> const& state,
     std::shared_ptr<Config> const& config,
@@ -35,7 +34,6 @@ MiralOutputFactory::MiralOutputFactory(
     std::shared_ptr<DisplayConfig> const& display_config,
     std::shared_ptr<mir::ServerActionQueue> const& server_action_queue,
     std::shared_ptr<PluginManager> const& plugin_manager) :
-    internal_client_launcher { internal_client_launcher },
     shell_application_manager { shell_application_manager },
     state { state },
     config { config },
@@ -58,7 +56,6 @@ std::shared_ptr<OutputInterface> MiralOutputFactory::create(
     }
 
     return std::make_shared<Output>(
-        internal_client_launcher,
         shell_application_manager,
         std::move(name),
         id,

--- a/src/output_factory.h
+++ b/src/output_factory.h
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MIRACLE_WM_OUTPUT_FACTORY_H
 
 #include "output_factory_interface.h"
+#include <miral/internal_client.h>
 
 namespace mir
 {
@@ -34,11 +35,14 @@ class WindowController;
 class Animator;
 class DisplayConfig;
 class PluginManager;
+class ShellApplicationManager;
 
 class MiralOutputFactory : public OutputFactoryInterface
 {
 public:
     MiralOutputFactory(
+        miral::InternalClientLauncher& internal_client_launcher,
+        std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
         std::shared_ptr<CompositorState> const& state,
         std::shared_ptr<Config> const& options,
         std::shared_ptr<WindowController> const&,
@@ -52,6 +56,8 @@ public:
         mir::geometry::Rectangle area) override;
 
 private:
+    miral::InternalClientLauncher internal_client_launcher;
+    std::shared_ptr<ShellApplicationManager> shell_application_manager;
     std::shared_ptr<CompositorState> state;
     std::shared_ptr<Config> config;
     std::shared_ptr<WindowController> window_controller;

--- a/src/output_factory.h
+++ b/src/output_factory.h
@@ -19,7 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MIRACLE_WM_OUTPUT_FACTORY_H
 
 #include "output_factory_interface.h"
-#include <miral/internal_client.h>
 
 namespace mir
 {
@@ -41,7 +40,6 @@ class MiralOutputFactory : public OutputFactoryInterface
 {
 public:
     MiralOutputFactory(
-        miral::InternalClientLauncher& internal_client_launcher,
         std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
         std::shared_ptr<CompositorState> const& state,
         std::shared_ptr<Config> const& options,
@@ -56,7 +54,6 @@ public:
         mir::geometry::Rectangle area) override;
 
 private:
-    miral::InternalClientLauncher internal_client_launcher;
     std::shared_ptr<ShellApplicationManager> shell_application_manager;
     std::shared_ptr<CompositorState> state;
     std::shared_ptr<Config> config;

--- a/src/parent_background_internal_client.cpp
+++ b/src/parent_background_internal_client.cpp
@@ -31,6 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <poll.h>
 #include <sys/eventfd.h>
 #include <sys/mman.h>
+#include <thread>
 #include <unistd.h>
 
 namespace miracle
@@ -38,6 +39,8 @@ namespace miracle
 
 struct ParentBackgroundInternalClient::Impl
 {
+    std::mutex mutex;
+
     wl_display* display = nullptr;
     wl_registry* registry = nullptr;
     wl_compositor* compositor = nullptr;
@@ -120,46 +123,31 @@ ParentBackgroundInternalClient::ParentBackgroundInternalClient() :
 
 ParentBackgroundInternalClient::~ParentBackgroundInternalClient()
 {
-    if (impl->buffer)
-        wl_buffer_destroy(impl->buffer);
-
+    // Cleanup is now done in stop() before the display becomes invalid
+    // The destructor only handles munmap which doesn't require a valid display
+    std::lock_guard<std::mutex> lock(impl->mutex);
     if (impl->shm_data)
+    {
         munmap(impl->shm_data, impl->shm_size);
-
-    if (impl->xdg_toplevel)
-        xdg_toplevel_destroy(impl->xdg_toplevel);
-
-    if (impl->xdg_surface)
-        xdg_surface_destroy(impl->xdg_surface);
-
-    if (impl->surface)
-        wl_surface_destroy(impl->surface);
-
-    if (impl->xdg_wm_base)
-        xdg_wm_base_destroy(impl->xdg_wm_base);
-
-    if (impl->compositor)
-        wl_compositor_destroy(impl->compositor);
-
-    if (impl->shm)
-        wl_shm_destroy(impl->shm);
-
-    if (impl->registry)
-        wl_registry_destroy(impl->registry);
+        impl->shm_data = nullptr;
+    }
 }
 
 void ParentBackgroundInternalClient::operator()(wl_display* display)
 {
     mir::log_info("ParentBackgroundInternalClient: Starting internal client");
 
-    impl->display = display;
-
-    // Get the registry
-    impl->registry = wl_display_get_registry(display);
-    if (!impl->registry)
     {
-        mir::log_error("Failed to get Wayland registry");
-        return;
+        std::lock_guard<std::mutex> lock(impl->mutex);
+        impl->display = display;
+
+        // Get the registry
+        impl->registry = wl_display_get_registry(display);
+        if (!impl->registry)
+        {
+            mir::log_error("Failed to get Wayland registry");
+            return;
+        }
     }
 
     static const struct wl_registry_listener registry_listener = {
@@ -167,45 +155,54 @@ void ParentBackgroundInternalClient::operator()(wl_display* display)
         registry_handle_global_remove
     };
 
-    wl_registry_add_listener(impl->registry, &registry_listener, this);
+    {
+        std::lock_guard<std::mutex> lock(impl->mutex);
+        wl_registry_add_listener(impl->registry, &registry_listener, this);
+    }
 
     // Roundtrip to get globals
     wl_display_roundtrip(display);
 
-    if (!impl->compositor || !impl->shm || !impl->xdg_wm_base)
     {
-        mir::log_error("Required Wayland globals not available");
-        return;
-    }
+        std::lock_guard<std::mutex> lock(impl->mutex);
+        if (!impl->compositor || !impl->shm || !impl->xdg_wm_base)
+        {
+            mir::log_error("Required Wayland globals not available");
+            return;
+        }
 
-    // Create surface
-    impl->surface = wl_compositor_create_surface(impl->compositor);
-    if (!impl->surface)
-    {
-        mir::log_error("Failed to create Wayland surface");
-        return;
-    }
+        // Create surface
+        impl->surface = wl_compositor_create_surface(impl->compositor);
+        if (!impl->surface)
+        {
+            mir::log_error("Failed to create Wayland surface");
+            return;
+        }
 
-    // Create XDG surface
-    impl->xdg_surface = xdg_wm_base_get_xdg_surface(impl->xdg_wm_base, impl->surface);
-    if (!impl->xdg_surface)
-    {
-        mir::log_error("Failed to create XDG surface");
-        return;
+        // Create XDG surface
+        impl->xdg_surface = xdg_wm_base_get_xdg_surface(impl->xdg_wm_base, impl->surface);
+        if (!impl->xdg_surface)
+        {
+            mir::log_error("Failed to create XDG surface");
+            return;
+        }
     }
 
     static const struct xdg_surface_listener xdg_surface_listener = {
         xdg_surface_configure
     };
 
-    xdg_surface_add_listener(impl->xdg_surface, &xdg_surface_listener, this);
-
-    // Create XDG toplevel
-    impl->xdg_toplevel = xdg_surface_get_toplevel(impl->xdg_surface);
-    if (!impl->xdg_toplevel)
     {
-        mir::log_error("Failed to create XDG toplevel");
-        return;
+        std::lock_guard<std::mutex> lock(impl->mutex);
+        xdg_surface_add_listener(impl->xdg_surface, &xdg_surface_listener, this);
+
+        // Create XDG toplevel
+        impl->xdg_toplevel = xdg_surface_get_toplevel(impl->xdg_surface);
+        if (!impl->xdg_toplevel)
+        {
+            mir::log_error("Failed to create XDG toplevel");
+            return;
+        }
     }
 
     static const struct xdg_toplevel_listener xdg_toplevel_listener = {
@@ -213,52 +210,46 @@ void ParentBackgroundInternalClient::operator()(wl_display* display)
         xdg_toplevel_close
     };
 
-    xdg_toplevel_add_listener(impl->xdg_toplevel, &xdg_toplevel_listener, this);
-
-    xdg_toplevel_set_title(impl->xdg_toplevel, "Parent Background");
-    xdg_toplevel_set_app_id(impl->xdg_toplevel, "miracle.parent_background");
-
-    // Commit to trigger configure
-    wl_surface_commit(impl->surface);
-
-    // Run event loop with poll() to allow interruption via eventfd
-    int wl_fd = wl_display_get_fd(display);
-    struct pollfd fds[2];
-    fds[0].fd = wl_fd;
-    fds[0].events = POLLIN;
-    fds[1].fd = impl->quit_eventfd;
-    fds[1].events = POLLIN;
-
-    while (!should_quit)
     {
-        // Flush outgoing requests
+        std::lock_guard<std::mutex> lock(impl->mutex);
+        xdg_toplevel_add_listener(impl->xdg_toplevel, &xdg_toplevel_listener, this);
+
+        xdg_toplevel_set_title(impl->xdg_toplevel, "Parent Background");
+        xdg_toplevel_set_app_id(impl->xdg_toplevel, "miracle.parent_background");
+
+        // Commit to trigger configure
+        wl_surface_commit(impl->surface);
+    }
+
+    // Standard Mir internal client event loop pattern
+    enum FdIndices
+    {
+        display_fd = 0,
+        shutdown,
+        indices
+    };
+
+    pollfd fds[indices];
+    fds[display_fd] = { wl_display_get_fd(display), POLLIN, 0 };
+    fds[shutdown] = { impl->quit_eventfd, POLLIN, 0 };
+
+    while (!(fds[shutdown].revents & (POLLIN | POLLERR)))
+    {
         while (wl_display_prepare_read(display) != 0)
-            wl_display_dispatch_pending(display);
+        {
+            if (wl_display_dispatch_pending(display) == -1)
+                mir::log_error("Failed to dispatch Wayland events");
+        }
 
         wl_display_flush(display);
 
-        // Wait for events on either Wayland or quit eventfd
-        int ret = poll(fds, 2, -1);
-        if (ret < 0)
-        {
-            wl_display_cancel_read(display);
-            mir::log_error("poll failed");
-            break;
-        }
+        if (poll(fds, indices, -1) == -1)
+            mir::log_error("Failed to wait for Wayland events");
 
-        // Check if quit was signaled
-        if (fds[1].revents & POLLIN)
+        if (fds[display_fd].revents & (POLLIN | POLLERR))
         {
-            wl_display_cancel_read(display);
-            mir::log_info("Quit signal received");
-            break;
-        }
-
-        // Read and dispatch Wayland events
-        if (fds[0].revents & POLLIN)
-        {
-            wl_display_read_events(display);
-            wl_display_dispatch_pending(display);
+            if (wl_display_read_events(display))
+                mir::log_error("Failed to read Wayland events");
         }
         else
         {
@@ -271,15 +262,17 @@ void ParentBackgroundInternalClient::operator()(wl_display* display)
 
 void ParentBackgroundInternalClient::operator()(std::weak_ptr<mir::scene::Session> const& session)
 {
+    std::lock_guard<std::mutex> lock(impl->mutex);
     impl->session = session;
     mir::log_info("ParentBackgroundInternalClient: Session connected");
 }
 
 void ParentBackgroundInternalClient::stop()
 {
-    should_quit = true;
+    cleanup_wayland_objects();
 
     // Signal the eventfd to wake up the event loop
+    // The event loop will handle cleanup before exiting
     if (impl->quit_eventfd >= 0)
     {
         uint64_t value = 1;
@@ -290,8 +283,70 @@ void ParentBackgroundInternalClient::stop()
     }
 }
 
+void ParentBackgroundInternalClient::cleanup_wayland_objects()
+{
+    mir::log_info("ParentBackgroundInternalClient: Cleaning up Wayland objects");
+    std::lock_guard<std::mutex> lock(impl->mutex);
+
+    // Clean up Wayland objects while the display is still valid
+    if (impl->buffer)
+    {
+        wl_buffer_destroy(impl->buffer);
+        impl->buffer = nullptr;
+    }
+
+    if (impl->xdg_toplevel)
+    {
+        xdg_toplevel_destroy(impl->xdg_toplevel);
+        impl->xdg_toplevel = nullptr;
+    }
+
+    if (impl->xdg_surface)
+    {
+        xdg_surface_destroy(impl->xdg_surface);
+        impl->xdg_surface = nullptr;
+    }
+
+    if (impl->surface)
+    {
+        wl_surface_destroy(impl->surface);
+        impl->surface = nullptr;
+    }
+
+    if (impl->xdg_wm_base)
+    {
+        xdg_wm_base_destroy(impl->xdg_wm_base);
+        impl->xdg_wm_base = nullptr;
+    }
+
+    if (impl->compositor)
+    {
+        wl_compositor_destroy(impl->compositor);
+        impl->compositor = nullptr;
+    }
+
+    if (impl->shm)
+    {
+        wl_shm_destroy(impl->shm);
+        impl->shm = nullptr;
+    }
+
+    if (impl->registry)
+    {
+        wl_registry_destroy(impl->registry);
+        impl->registry = nullptr;
+    }
+
+    // Flush the display to ensure destroy requests are sent
+    if (impl->display)
+    {
+        wl_display_flush(impl->display);
+    }
+}
+
 miral::Application ParentBackgroundInternalClient::application()
 {
+    std::lock_guard<std::mutex> lock(impl->mutex);
     return impl->session.lock();
 }
 
@@ -303,6 +358,7 @@ void ParentBackgroundInternalClient::registry_handle_global(
     uint32_t version)
 {
     auto* client = static_cast<ParentBackgroundInternalClient*>(data);
+    std::lock_guard<std::mutex> lock(client->impl->mutex);
 
     if (strcmp(interface, wl_compositor_interface.name) == 0)
     {
@@ -342,20 +398,23 @@ void ParentBackgroundInternalClient::xdg_surface_configure(
 
     xdg_surface_ack_configure(xdg_surface, serial);
 
-    if (!client->impl->configured)
     {
-        client->impl->configured = true;
+        std::lock_guard<std::mutex> lock(client->impl->mutex);
+        if (!client->impl->configured)
+        {
+            client->impl->configured = true;
 
-        // Create and draw the buffer
-        client->create_shm_buffer(client->impl->width, client->impl->height);
-        client->draw_gradient();
-        client->apply_rounded_corners();
+            // Create and draw the buffer
+            client->create_shm_buffer(client->impl->width, client->impl->height);
+            client->draw_gradient();
+            client->apply_rounded_corners();
 
-        // Attach and commit
-        wl_surface_attach(client->impl->surface, client->impl->buffer, 0, 0);
-        wl_surface_commit(client->impl->surface);
+            // Attach and commit
+            wl_surface_attach(client->impl->surface, client->impl->buffer, 0, 0);
+            wl_surface_commit(client->impl->surface);
 
-        mir::log_info("Surface configured and drawn");
+            mir::log_info("Surface configured and drawn");
+        }
     }
 }
 
@@ -367,6 +426,7 @@ void ParentBackgroundInternalClient::xdg_toplevel_configure(
     wl_array* /*states*/)
 {
     auto* client = static_cast<ParentBackgroundInternalClient*>(data);
+    std::lock_guard<std::mutex> lock(client->impl->mutex);
 
     if (width > 0 && height > 0 && client->impl->configured)
     {
@@ -413,7 +473,6 @@ void ParentBackgroundInternalClient::xdg_toplevel_close(
     xdg_toplevel* /*xdg_toplevel*/)
 {
     auto* client = static_cast<ParentBackgroundInternalClient*>(data);
-    client->should_quit = true;
     mir::log_info("Toplevel close requested");
 }
 

--- a/src/parent_background_internal_client.cpp
+++ b/src/parent_background_internal_client.cpp
@@ -50,6 +50,7 @@ struct ParentBackgroundInternalClient::Impl
     void* shm_data = nullptr;
     size_t shm_size = 0;
 
+    mir::geometry::Rectangle rectangle;
     int width = 800;
     int height = 600;
 
@@ -59,6 +60,8 @@ struct ParentBackgroundInternalClient::Impl
 
     bool configured = false;
     std::weak_ptr<mir::scene::Session> session;
+
+    Impl(mir::geometry::Rectangle const& rect) : rectangle(rect), width(rect.size.width.as_int()), height(rect.size.height.as_int()) {}
 };
 
 namespace
@@ -94,9 +97,12 @@ namespace
     }
 }
 
-ParentBackgroundInternalClient::ParentBackgroundInternalClient() :
-    impl(std::make_unique<Impl>())
+ParentBackgroundInternalClient::ParentBackgroundInternalClient(mir::geometry::Rectangle const& rectangle) :
+    impl(std::make_unique<Impl>(rectangle))
 {
+    mir::log_info("ParentBackgroundInternalClient: Created with rectangle pos=(%d,%d) size=%dx%d",
+        rectangle.top_left.x.as_int(), rectangle.top_left.y.as_int(),
+        rectangle.size.width.as_int(), rectangle.size.height.as_int());
 }
 
 ParentBackgroundInternalClient::~ParentBackgroundInternalClient()

--- a/src/parent_background_internal_client.cpp
+++ b/src/parent_background_internal_client.cpp
@@ -30,6 +30,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <sys/eventfd.h>
+#include <poll.h>
 
 namespace miracle
 {
@@ -61,7 +63,22 @@ struct ParentBackgroundInternalClient::Impl
     bool configured = false;
     std::weak_ptr<mir::scene::Session> session;
 
-    Impl(mir::geometry::Rectangle const& rect) : rectangle(rect), width(rect.size.width.as_int()), height(rect.size.height.as_int()) {}
+    int quit_eventfd = -1;
+
+    Impl(mir::geometry::Rectangle const& rect) : rectangle(rect), width(rect.size.width.as_int()), height(rect.size.height.as_int())
+    {
+        quit_eventfd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+        if (quit_eventfd < 0)
+        {
+            mir::log_error("Failed to create eventfd");
+        }
+    }
+
+    ~Impl()
+    {
+        if (quit_eventfd >= 0)
+            close(quit_eventfd);
+    }
 };
 
 namespace
@@ -208,10 +225,49 @@ void ParentBackgroundInternalClient::operator()(wl_display* display)
     // Commit to trigger configure
     wl_surface_commit(impl->surface);
 
-    // Run event loop
-    while (!should_quit && wl_display_dispatch(display) != -1)
+    // Run event loop with poll() to allow interruption via eventfd
+    int wl_fd = wl_display_get_fd(display);
+    struct pollfd fds[2];
+    fds[0].fd = wl_fd;
+    fds[0].events = POLLIN;
+    fds[1].fd = impl->quit_eventfd;
+    fds[1].events = POLLIN;
+
+    while (!should_quit)
     {
-        // Event loop continues until should_quit is set
+        // Flush outgoing requests
+        while (wl_display_prepare_read(display) != 0)
+            wl_display_dispatch_pending(display);
+
+        wl_display_flush(display);
+
+        // Wait for events on either Wayland or quit eventfd
+        int ret = poll(fds, 2, -1);
+        if (ret < 0)
+        {
+            wl_display_cancel_read(display);
+            mir::log_error("poll failed");
+            break;
+        }
+
+        // Check if quit was signaled
+        if (fds[1].revents & POLLIN)
+        {
+            wl_display_cancel_read(display);
+            mir::log_info("Quit signal received");
+            break;
+        }
+
+        // Read and dispatch Wayland events
+        if (fds[0].revents & POLLIN)
+        {
+            wl_display_read_events(display);
+            wl_display_dispatch_pending(display);
+        }
+        else
+        {
+            wl_display_cancel_read(display);
+        }
     }
 
     mir::log_info("ParentBackgroundInternalClient: Exiting event loop");
@@ -232,6 +288,21 @@ void ParentBackgroundInternalClient::set_gradient_colors(float top_color[4], flo
 void ParentBackgroundInternalClient::set_border_radius(float radius)
 {
     impl->border_radius = radius;
+}
+
+void ParentBackgroundInternalClient::stop()
+{
+    should_quit = true;
+
+    // Signal the eventfd to wake up the event loop
+    if (impl->quit_eventfd >= 0)
+    {
+        uint64_t value = 1;
+        if (write(impl->quit_eventfd, &value, sizeof(value)) != sizeof(value))
+        {
+            mir::log_error("Failed to write to quit_eventfd");
+        }
+    }
 }
 
 void ParentBackgroundInternalClient::registry_handle_global(
@@ -307,7 +378,39 @@ void ParentBackgroundInternalClient::xdg_toplevel_configure(
 {
     auto* client = static_cast<ParentBackgroundInternalClient*>(data);
 
-    if (width > 0 && height > 0)
+    if (width > 0 && height > 0 && client->impl->configured)
+    {
+        // Only resize if dimensions actually changed
+        if (client->impl->width != width || client->impl->height != height)
+        {
+            client->impl->width = width;
+            client->impl->height = height;
+            mir::log_info("Toplevel resizing to %dx%d", width, height);
+
+            // Clean up old buffer
+            if (client->impl->buffer)
+            {
+                wl_buffer_destroy(client->impl->buffer);
+                client->impl->buffer = nullptr;
+            }
+
+            if (client->impl->shm_data)
+            {
+                munmap(client->impl->shm_data, client->impl->shm_size);
+                client->impl->shm_data = nullptr;
+            }
+
+            // Create new buffer with new size
+            client->create_shm_buffer(width, height);
+            client->draw_gradient();
+            client->apply_rounded_corners();
+
+            // Attach and commit the new buffer
+            wl_surface_attach(client->impl->surface, client->impl->buffer, 0, 0);
+            wl_surface_commit(client->impl->surface);
+        }
+    }
+    else if (width > 0 && height > 0)
     {
         client->impl->width = width;
         client->impl->height = height;
@@ -396,22 +499,29 @@ void ParentBackgroundInternalClient::apply_rounded_corners()
     float radius = impl->border_radius;
 
     // Apply rounded corners to all four corners
-    auto apply_corner = [&](int cx, int cy, int x_start, int y_start, int x_dir, int y_dir)
+    // Only process pixels in the corner squares (radius x radius)
+    auto apply_corner = [&](int corner_x, int corner_y, bool is_left, bool is_top)
     {
         int radius_ceil = static_cast<int>(std::ceil(radius));
 
-        for (int dy = 0; dy < radius_ceil; ++dy)
+        // Define the corner square boundaries
+        int x_start = is_left ? 0 : impl->width - radius_ceil;
+        int x_end = is_left ? radius_ceil : impl->width;
+        int y_start = is_top ? 0 : impl->height - radius_ceil;
+        int y_end = is_top ? radius_ceil : impl->height;
+
+        // Center of the arc circle
+        float center_x = is_left ? radius : static_cast<float>(impl->width) - radius;
+        float center_y = is_top ? radius : static_cast<float>(impl->height) - radius;
+
+        for (int y = y_start; y < y_end; ++y)
         {
-            for (int dx = 0; dx < radius_ceil; ++dx)
+            for (int x = x_start; x < x_end; ++x)
             {
-                int x = x_start + dx * x_dir;
-                int y = y_start + dy * y_dir;
-
-                if (x < 0 || x >= impl->width || y < 0 || y >= impl->height)
-                    continue;
-
                 // Calculate distance from corner center
-                float dist = std::sqrt(static_cast<float>(dx * dx + dy * dy));
+                float dx = static_cast<float>(x) + 0.5f - center_x;
+                float dy = static_cast<float>(y) + 0.5f - center_y;
+                float dist = std::sqrt(dx * dx + dy * dy);
 
                 // If outside the radius, make transparent
                 if (dist > radius)
@@ -432,16 +542,16 @@ void ParentBackgroundInternalClient::apply_rounded_corners()
     };
 
     // Top-left corner
-    apply_corner(0, 0, 0, 0, 1, 1);
+    apply_corner(0, 0, true, true);
 
     // Top-right corner
-    apply_corner(impl->width - 1, 0, impl->width - 1, 0, -1, 1);
+    apply_corner(impl->width - 1, 0, false, true);
 
     // Bottom-left corner
-    apply_corner(0, impl->height - 1, 0, impl->height - 1, 1, -1);
+    apply_corner(0, impl->height - 1, true, false);
 
     // Bottom-right corner
-    apply_corner(impl->width - 1, impl->height - 1, impl->width - 1, impl->height - 1, -1, -1);
+    apply_corner(impl->width - 1, impl->height - 1, false, false);
 }
 
 } // namespace miracle

--- a/src/parent_background_internal_client.cpp
+++ b/src/parent_background_internal_client.cpp
@@ -28,10 +28,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <cmath>
 #include <cstring>
 #include <fcntl.h>
+#include <poll.h>
+#include <sys/eventfd.h>
 #include <sys/mman.h>
 #include <unistd.h>
-#include <sys/eventfd.h>
-#include <poll.h>
 
 namespace miracle
 {
@@ -52,12 +52,11 @@ struct ParentBackgroundInternalClient::Impl
     void* shm_data = nullptr;
     size_t shm_size = 0;
 
-    mir::geometry::Rectangle rectangle;
     int width = 800;
     int height = 600;
 
-    float top_color[4] = { 0.2f, 0.3f, 0.5f, 1.0f }; // Bluish top
-    float bottom_color[4] = { 0.1f, 0.15f, 0.25f, 1.0f }; // Darker blue bottom
+    float top_color[4] = { 0.2f, 0.3f, 0.5f, 0.5f }; // Bluish top
+    float bottom_color[4] = { 0.1f, 0.15f, 0.25f, 0.5f }; // Darker blue bottom
     float border_radius = 8.0f;
 
     bool configured = false;
@@ -65,7 +64,7 @@ struct ParentBackgroundInternalClient::Impl
 
     int quit_eventfd = -1;
 
-    Impl(mir::geometry::Rectangle const& rect) : rectangle(rect), width(rect.size.width.as_int()), height(rect.size.height.as_int())
+    Impl()
     {
         quit_eventfd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
         if (quit_eventfd < 0)
@@ -114,12 +113,9 @@ namespace
     }
 }
 
-ParentBackgroundInternalClient::ParentBackgroundInternalClient(mir::geometry::Rectangle const& rectangle) :
-    impl(std::make_unique<Impl>(rectangle))
+ParentBackgroundInternalClient::ParentBackgroundInternalClient() :
+    impl(std::make_unique<Impl>())
 {
-    mir::log_info("ParentBackgroundInternalClient: Created with rectangle pos=(%d,%d) size=%dx%d",
-        rectangle.top_left.x.as_int(), rectangle.top_left.y.as_int(),
-        rectangle.size.width.as_int(), rectangle.size.height.as_int());
 }
 
 ParentBackgroundInternalClient::~ParentBackgroundInternalClient()
@@ -279,17 +275,6 @@ void ParentBackgroundInternalClient::operator()(std::weak_ptr<mir::scene::Sessio
     mir::log_info("ParentBackgroundInternalClient: Session connected");
 }
 
-void ParentBackgroundInternalClient::set_gradient_colors(float top_color[4], float bottom_color[4])
-{
-    std::memcpy(impl->top_color, top_color, sizeof(float) * 4);
-    std::memcpy(impl->bottom_color, bottom_color, sizeof(float) * 4);
-}
-
-void ParentBackgroundInternalClient::set_border_radius(float radius)
-{
-    impl->border_radius = radius;
-}
-
 void ParentBackgroundInternalClient::stop()
 {
     should_quit = true;
@@ -303,6 +288,11 @@ void ParentBackgroundInternalClient::stop()
             mir::log_error("Failed to write to quit_eventfd");
         }
     }
+}
+
+miral::Application ParentBackgroundInternalClient::application()
+{
+    return impl->session.lock();
 }
 
 void ParentBackgroundInternalClient::registry_handle_global(

--- a/src/parent_background_internal_client.cpp
+++ b/src/parent_background_internal_client.cpp
@@ -1,0 +1,441 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#define MIR_LOG_COMPONENT "ParentBackgroundInternalClient"
+
+#include "parent_background_internal_client.h"
+
+#include <mir/log.h>
+#include <mir/scene/session.h>
+
+#include "xdg-shell-client-protocol.h"
+#include <wayland-client.h>
+
+#include <cmath>
+#include <cstring>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+namespace miracle
+{
+
+struct ParentBackgroundInternalClient::Impl
+{
+    wl_display* display = nullptr;
+    wl_registry* registry = nullptr;
+    wl_compositor* compositor = nullptr;
+    wl_shm* shm = nullptr;
+    xdg_wm_base* xdg_wm_base = nullptr;
+
+    wl_surface* surface = nullptr;
+    xdg_surface* xdg_surface = nullptr;
+    xdg_toplevel* xdg_toplevel = nullptr;
+
+    wl_buffer* buffer = nullptr;
+    void* shm_data = nullptr;
+    size_t shm_size = 0;
+
+    int width = 800;
+    int height = 600;
+
+    float top_color[4] = { 0.2f, 0.3f, 0.5f, 1.0f }; // Bluish top
+    float bottom_color[4] = { 0.1f, 0.15f, 0.25f, 1.0f }; // Darker blue bottom
+    float border_radius = 8.0f;
+
+    bool configured = false;
+    std::weak_ptr<mir::scene::Session> session;
+};
+
+namespace
+{
+    // XDG WM Base listener
+    void xdg_wm_base_ping(void* /*data*/, xdg_wm_base* xdg_wm_base, uint32_t serial)
+    {
+        xdg_wm_base_pong(xdg_wm_base, serial);
+    }
+
+    const struct xdg_wm_base_listener xdg_wm_base_listener = {
+        xdg_wm_base_ping
+    };
+
+    // Shared memory pool creation
+    int create_shm_file(size_t size)
+    {
+        int fd = memfd_create("miracle-wm-shm", MFD_CLOEXEC);
+        if (fd < 0)
+        {
+            mir::log_error("memfd_create failed");
+            return -1;
+        }
+
+        if (ftruncate(fd, static_cast<off_t>(size)) < 0)
+        {
+            mir::log_error("ftruncate failed");
+            close(fd);
+            return -1;
+        }
+
+        return fd;
+    }
+}
+
+ParentBackgroundInternalClient::ParentBackgroundInternalClient() :
+    impl(std::make_unique<Impl>())
+{
+}
+
+ParentBackgroundInternalClient::~ParentBackgroundInternalClient()
+{
+    if (impl->buffer)
+        wl_buffer_destroy(impl->buffer);
+
+    if (impl->shm_data)
+        munmap(impl->shm_data, impl->shm_size);
+
+    if (impl->xdg_toplevel)
+        xdg_toplevel_destroy(impl->xdg_toplevel);
+
+    if (impl->xdg_surface)
+        xdg_surface_destroy(impl->xdg_surface);
+
+    if (impl->surface)
+        wl_surface_destroy(impl->surface);
+
+    if (impl->xdg_wm_base)
+        xdg_wm_base_destroy(impl->xdg_wm_base);
+
+    if (impl->compositor)
+        wl_compositor_destroy(impl->compositor);
+
+    if (impl->shm)
+        wl_shm_destroy(impl->shm);
+
+    if (impl->registry)
+        wl_registry_destroy(impl->registry);
+}
+
+void ParentBackgroundInternalClient::operator()(wl_display* display)
+{
+    mir::log_info("ParentBackgroundInternalClient: Starting internal client");
+
+    impl->display = display;
+
+    // Get the registry
+    impl->registry = wl_display_get_registry(display);
+    if (!impl->registry)
+    {
+        mir::log_error("Failed to get Wayland registry");
+        return;
+    }
+
+    static const struct wl_registry_listener registry_listener = {
+        registry_handle_global,
+        registry_handle_global_remove
+    };
+
+    wl_registry_add_listener(impl->registry, &registry_listener, this);
+
+    // Roundtrip to get globals
+    wl_display_roundtrip(display);
+
+    if (!impl->compositor || !impl->shm || !impl->xdg_wm_base)
+    {
+        mir::log_error("Required Wayland globals not available");
+        return;
+    }
+
+    // Create surface
+    impl->surface = wl_compositor_create_surface(impl->compositor);
+    if (!impl->surface)
+    {
+        mir::log_error("Failed to create Wayland surface");
+        return;
+    }
+
+    // Create XDG surface
+    impl->xdg_surface = xdg_wm_base_get_xdg_surface(impl->xdg_wm_base, impl->surface);
+    if (!impl->xdg_surface)
+    {
+        mir::log_error("Failed to create XDG surface");
+        return;
+    }
+
+    static const struct xdg_surface_listener xdg_surface_listener = {
+        xdg_surface_configure
+    };
+
+    xdg_surface_add_listener(impl->xdg_surface, &xdg_surface_listener, this);
+
+    // Create XDG toplevel
+    impl->xdg_toplevel = xdg_surface_get_toplevel(impl->xdg_surface);
+    if (!impl->xdg_toplevel)
+    {
+        mir::log_error("Failed to create XDG toplevel");
+        return;
+    }
+
+    static const struct xdg_toplevel_listener xdg_toplevel_listener = {
+        xdg_toplevel_configure,
+        xdg_toplevel_close
+    };
+
+    xdg_toplevel_add_listener(impl->xdg_toplevel, &xdg_toplevel_listener, this);
+
+    xdg_toplevel_set_title(impl->xdg_toplevel, "Parent Background");
+    xdg_toplevel_set_app_id(impl->xdg_toplevel, "miracle.parent_background");
+
+    // Commit to trigger configure
+    wl_surface_commit(impl->surface);
+
+    // Run event loop
+    while (!should_quit && wl_display_dispatch(display) != -1)
+    {
+        // Event loop continues until should_quit is set
+    }
+
+    mir::log_info("ParentBackgroundInternalClient: Exiting event loop");
+}
+
+void ParentBackgroundInternalClient::operator()(std::weak_ptr<mir::scene::Session> const& session)
+{
+    impl->session = session;
+    mir::log_info("ParentBackgroundInternalClient: Session connected");
+}
+
+void ParentBackgroundInternalClient::set_gradient_colors(float top_color[4], float bottom_color[4])
+{
+    std::memcpy(impl->top_color, top_color, sizeof(float) * 4);
+    std::memcpy(impl->bottom_color, bottom_color, sizeof(float) * 4);
+}
+
+void ParentBackgroundInternalClient::set_border_radius(float radius)
+{
+    impl->border_radius = radius;
+}
+
+void ParentBackgroundInternalClient::registry_handle_global(
+    void* data,
+    wl_registry* registry,
+    uint32_t name,
+    char const* interface,
+    uint32_t version)
+{
+    auto* client = static_cast<ParentBackgroundInternalClient*>(data);
+
+    if (strcmp(interface, wl_compositor_interface.name) == 0)
+    {
+        client->impl->compositor = static_cast<wl_compositor*>(
+            wl_registry_bind(registry, name, &wl_compositor_interface, std::min(version, 4u)));
+        mir::log_info("Bound to wl_compositor");
+    }
+    else if (strcmp(interface, wl_shm_interface.name) == 0)
+    {
+        client->impl->shm = static_cast<wl_shm*>(
+            wl_registry_bind(registry, name, &wl_shm_interface, std::min(version, 1u)));
+        mir::log_info("Bound to wl_shm");
+    }
+    else if (strcmp(interface, xdg_wm_base_interface.name) == 0)
+    {
+        client->impl->xdg_wm_base = static_cast<xdg_wm_base*>(
+            wl_registry_bind(registry, name, &xdg_wm_base_interface, std::min(version, 2u)));
+        xdg_wm_base_add_listener(client->impl->xdg_wm_base, &xdg_wm_base_listener, client);
+        mir::log_info("Bound to xdg_wm_base");
+    }
+}
+
+void ParentBackgroundInternalClient::registry_handle_global_remove(
+    void* /*data*/,
+    wl_registry* /*registry*/,
+    uint32_t /*name*/)
+{
+    // Handle global removal if needed
+}
+
+void ParentBackgroundInternalClient::xdg_surface_configure(
+    void* data,
+    xdg_surface* xdg_surface,
+    uint32_t serial)
+{
+    auto* client = static_cast<ParentBackgroundInternalClient*>(data);
+
+    xdg_surface_ack_configure(xdg_surface, serial);
+
+    if (!client->impl->configured)
+    {
+        client->impl->configured = true;
+
+        // Create and draw the buffer
+        client->create_shm_buffer(client->impl->width, client->impl->height);
+        client->draw_gradient();
+        client->apply_rounded_corners();
+
+        // Attach and commit
+        wl_surface_attach(client->impl->surface, client->impl->buffer, 0, 0);
+        wl_surface_commit(client->impl->surface);
+
+        mir::log_info("Surface configured and drawn");
+    }
+}
+
+void ParentBackgroundInternalClient::xdg_toplevel_configure(
+    void* data,
+    xdg_toplevel* /*xdg_toplevel*/,
+    int32_t width,
+    int32_t height,
+    wl_array* /*states*/)
+{
+    auto* client = static_cast<ParentBackgroundInternalClient*>(data);
+
+    if (width > 0 && height > 0)
+    {
+        client->impl->width = width;
+        client->impl->height = height;
+        mir::log_info("Toplevel configured to %dx%d", width, height);
+    }
+}
+
+void ParentBackgroundInternalClient::xdg_toplevel_close(
+    void* data,
+    xdg_toplevel* /*xdg_toplevel*/)
+{
+    auto* client = static_cast<ParentBackgroundInternalClient*>(data);
+    client->should_quit = true;
+    mir::log_info("Toplevel close requested");
+}
+
+void ParentBackgroundInternalClient::create_shm_buffer(int width, int height)
+{
+    int stride = width * 4; // 4 bytes per pixel (ARGB8888)
+    impl->shm_size = static_cast<size_t>(stride * height);
+
+    int fd = create_shm_file(impl->shm_size);
+    if (fd < 0)
+    {
+        mir::log_error("Failed to create shared memory file");
+        return;
+    }
+
+    impl->shm_data = mmap(nullptr, impl->shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (impl->shm_data == MAP_FAILED)
+    {
+        mir::log_error("mmap failed");
+        close(fd);
+        return;
+    }
+
+    wl_shm_pool* pool = wl_shm_create_pool(impl->shm, fd, static_cast<int32_t>(impl->shm_size));
+    impl->buffer = wl_shm_pool_create_buffer(
+        pool,
+        0,
+        width,
+        height,
+        stride,
+        WL_SHM_FORMAT_ARGB8888);
+
+    wl_shm_pool_destroy(pool);
+    close(fd);
+
+    mir::log_info("Created shared memory buffer %dx%d", width, height);
+}
+
+void ParentBackgroundInternalClient::draw_gradient()
+{
+    if (!impl->shm_data)
+        return;
+
+    auto* pixels = static_cast<uint32_t*>(impl->shm_data);
+
+    for (int y = 0; y < impl->height; ++y)
+    {
+        // Calculate interpolation factor (0.0 at top, 1.0 at bottom)
+        float t = static_cast<float>(y) / static_cast<float>(impl->height - 1);
+
+        // Interpolate colors
+        float r = impl->top_color[0] * (1.0f - t) + impl->bottom_color[0] * t;
+        float g = impl->top_color[1] * (1.0f - t) + impl->bottom_color[1] * t;
+        float b = impl->top_color[2] * (1.0f - t) + impl->bottom_color[2] * t;
+        float a = impl->top_color[3] * (1.0f - t) + impl->bottom_color[3] * t;
+
+        // Convert to ARGB8888
+        uint32_t pixel = (static_cast<uint32_t>(a * 255) << 24) | (static_cast<uint32_t>(r * 255) << 16) | (static_cast<uint32_t>(g * 255) << 8) | (static_cast<uint32_t>(b * 255));
+
+        for (int x = 0; x < impl->width; ++x)
+        {
+            pixels[y * impl->width + x] = pixel;
+        }
+    }
+}
+
+void ParentBackgroundInternalClient::apply_rounded_corners()
+{
+    if (!impl->shm_data || impl->border_radius <= 0.0f)
+        return;
+
+    auto* pixels = static_cast<uint32_t*>(impl->shm_data);
+    float radius = impl->border_radius;
+
+    // Apply rounded corners to all four corners
+    auto apply_corner = [&](int cx, int cy, int x_start, int y_start, int x_dir, int y_dir)
+    {
+        int radius_ceil = static_cast<int>(std::ceil(radius));
+
+        for (int dy = 0; dy < radius_ceil; ++dy)
+        {
+            for (int dx = 0; dx < radius_ceil; ++dx)
+            {
+                int x = x_start + dx * x_dir;
+                int y = y_start + dy * y_dir;
+
+                if (x < 0 || x >= impl->width || y < 0 || y >= impl->height)
+                    continue;
+
+                // Calculate distance from corner center
+                float dist = std::sqrt(static_cast<float>(dx * dx + dy * dy));
+
+                // If outside the radius, make transparent
+                if (dist > radius)
+                {
+                    pixels[y * impl->width + x] = 0x00000000; // Fully transparent
+                }
+                else if (dist > radius - 1.0f)
+                {
+                    // Anti-aliasing for smooth edges
+                    float alpha = radius - dist;
+                    uint32_t current = pixels[y * impl->width + x];
+                    uint32_t current_alpha = (current >> 24) & 0xFF;
+                    uint32_t new_alpha = static_cast<uint32_t>(current_alpha * alpha);
+                    pixels[y * impl->width + x] = (current & 0x00FFFFFF) | (new_alpha << 24);
+                }
+            }
+        }
+    };
+
+    // Top-left corner
+    apply_corner(0, 0, 0, 0, 1, 1);
+
+    // Top-right corner
+    apply_corner(impl->width - 1, 0, impl->width - 1, 0, -1, 1);
+
+    // Bottom-left corner
+    apply_corner(0, impl->height - 1, 0, impl->height - 1, 1, -1);
+
+    // Bottom-right corner
+    apply_corner(impl->width - 1, impl->height - 1, impl->width - 1, impl->height - 1, -1, -1);
+}
+
+} // namespace miracle

--- a/src/parent_background_internal_client.h
+++ b/src/parent_background_internal_client.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef MIRACLE_WM_PARENT_BACKGROUND_INTERNAL_CLIENT_H
 #define MIRACLE_WM_PARENT_BACKGROUND_INTERNAL_CLIENT_H
 
+#include "shell_application_spawner.h"
 #include <memory>
 #include <wayland-client.h>
 
@@ -33,11 +34,11 @@ namespace miracle
 ///
 /// This client is designed to be used as a visual background for parent containers
 /// in the tiling window manager, providing a decorative element with smooth gradients.
-class ParentBackgroundInternalClient
+class ParentBackgroundInternalClient : public ShellApplication
 {
 public:
-    ParentBackgroundInternalClient(mir::geometry::Rectangle const& rectangle);
-    ~ParentBackgroundInternalClient();
+    ParentBackgroundInternalClient();
+    ~ParentBackgroundInternalClient() override;
 
     /// Called when the Wayland display connection is established.
     /// This is the main entry point that sets up the client and runs the event loop.
@@ -48,16 +49,9 @@ public:
     /// \param session The Mir session (weak pointer)
     void operator()(std::weak_ptr<mir::scene::Session> const& session);
 
-    /// Set the gradient colors
-    /// \param top_color Top color of the gradient (RGBA, values 0.0-1.0)
-    /// \param bottom_color Bottom color of the gradient (RGBA, values 0.0-1.0)
-    void set_gradient_colors(float top_color[4], float bottom_color[4]);
+    void stop() override;
 
-    /// Set the border radius
-    /// \param radius Border radius in pixels
-    void set_border_radius(float radius);
-
-    void stop();
+    miral::Application application() override;
 
 private:
     struct Impl;

--- a/src/parent_background_internal_client.h
+++ b/src/parent_background_internal_client.h
@@ -1,0 +1,105 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef MIRACLE_WM_PARENT_BACKGROUND_INTERNAL_CLIENT_H
+#define MIRACLE_WM_PARENT_BACKGROUND_INTERNAL_CLIENT_H
+
+#include <memory>
+#include <wayland-client.h>
+
+struct xdg_wm_base;
+struct xdg_surface;
+struct xdg_toplevel;
+
+namespace miracle
+{
+
+/// Internal Wayland client that creates a surface with a gradient background
+/// and rounded corners (8px border radius by default).
+///
+/// This client is designed to be used as a visual background for parent containers
+/// in the tiling window manager, providing a decorative element with smooth gradients.
+class ParentBackgroundInternalClient
+{
+public:
+    ParentBackgroundInternalClient();
+    ~ParentBackgroundInternalClient();
+
+    /// Called when the Wayland display connection is established.
+    /// This is the main entry point that sets up the client and runs the event loop.
+    /// \param display The Wayland display connection
+    void operator()(wl_display* display);
+
+    /// Called when the Mir session is established.
+    /// \param session The Mir session (weak pointer)
+    void operator()(std::weak_ptr<mir::scene::Session> const& session);
+
+    /// Set the gradient colors
+    /// \param top_color Top color of the gradient (RGBA, values 0.0-1.0)
+    /// \param bottom_color Bottom color of the gradient (RGBA, values 0.0-1.0)
+    void set_gradient_colors(float top_color[4], float bottom_color[4]);
+
+    /// Set the border radius
+    /// \param radius Border radius in pixels
+    void set_border_radius(float radius);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+
+    // Wayland registry callbacks
+    static void registry_handle_global(
+        void* data,
+        wl_registry* registry,
+        uint32_t name,
+        char const* interface,
+        uint32_t version);
+
+    static void registry_handle_global_remove(
+        void* data,
+        wl_registry* registry,
+        uint32_t name);
+
+    // XDG surface callbacks
+    static void xdg_surface_configure(
+        void* data,
+        xdg_surface* xdg_surface,
+        uint32_t serial);
+
+    static void xdg_toplevel_configure(
+        void* data,
+        xdg_toplevel* xdg_toplevel,
+        int32_t width,
+        int32_t height,
+        wl_array* states);
+
+    static void xdg_toplevel_close(
+        void* data,
+        xdg_toplevel* xdg_toplevel);
+
+    // Shared memory buffer management
+    void create_shm_buffer(int width, int height);
+    void draw_gradient();
+    void apply_rounded_corners();
+
+    // Event loop control
+    bool should_quit = false;
+};
+
+} // namespace miracle
+
+#endif // MIRACLE_WM_PARENT_BACKGROUND_INTERNAL_CLIENT_H

--- a/src/parent_background_internal_client.h
+++ b/src/parent_background_internal_client.h
@@ -36,7 +36,7 @@ namespace miracle
 class ParentBackgroundInternalClient
 {
 public:
-    ParentBackgroundInternalClient();
+    ParentBackgroundInternalClient(mir::geometry::Rectangle const& rectangle);
     ~ParentBackgroundInternalClient();
 
     /// Called when the Wayland display connection is established.

--- a/src/parent_background_internal_client.h
+++ b/src/parent_background_internal_client.h
@@ -57,6 +57,8 @@ public:
     /// \param radius Border radius in pixels
     void set_border_radius(float radius);
 
+    void stop();
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl;

--- a/src/parent_background_internal_client.h
+++ b/src/parent_background_internal_client.h
@@ -87,13 +87,10 @@ private:
         void* data,
         xdg_toplevel* xdg_toplevel);
 
-    // Shared memory buffer management
     void create_shm_buffer(int width, int height);
     void draw_gradient();
     void apply_rounded_corners();
-
-    // Event loop control
-    bool should_quit = false;
+    void cleanup_wayland_objects();
 };
 
 } // namespace miracle

--- a/src/parent_container.cpp
+++ b/src/parent_container.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "shell_application_manager.h"
 #include "tiling_algorithms.h"
 #include "workspace_interface.h"
+#include "feature_flags.h"
 #include <cmath>
 #include <mir/log.h>
 
@@ -120,7 +121,7 @@ void ParentContainer::try_remove_background_client()
 void ParentContainer::update_background_client_area()
 {
     try_remove_background_client();
-    if (parent.expired() && !is_anchored)
+    if (parent.expired() && !is_anchored && feature::parent_container_wallpapers)
     {
         // Start up the internal client that will display the background for this floating parent
         mir::log_info("Spawning ParentBackgroundInternalClient for unanchored root parent");

--- a/src/parent_container.cpp
+++ b/src/parent_container.cpp
@@ -22,13 +22,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "container.h"
 #include "leaf_container.h"
 #include "output_interface.h"
-#include "parent_background_internal_client.h"
 #include "shell_application_manager.h"
 #include "tiling_algorithms.h"
 #include "workspace_interface.h"
 #include <cmath>
 #include <mir/log.h>
-#include <miral/internal_client.h>
 
 #include "auto_restarting_launcher.h"
 
@@ -36,20 +34,23 @@ using namespace miracle;
 
 namespace
 {
-    geom::Rectangle get_background_area(geom::Rectangle const& area)
-    {
-        const int padding = 8;
-        return geom::Rectangle(
-            geom::Point(
-                area.top_left.x.as_int() - padding,
-                area.top_left.y.as_int() - padding),
-            geom::Size(
-                area.size.width.as_int() + 2 * padding,
-                area.size.height.as_int() + 2 * padding));
-    }
+geom::Rectangle get_background_area(geom::Rectangle const& area)
+{
+    const int padding = 8;
+    return geom::Rectangle(
+        geom::Point(
+            area.top_left.x.as_int() - padding,
+            area.top_left.y.as_int() - padding),
+        geom::Size(
+            area.size.width.as_int() + 2 * padding,
+            area.size.height.as_int() + 2 * padding));
+}
 };
 
-ParentContainer::ParentContainerBackgroundPositioner::ParentContainerBackgroundPositioner(ParentContainer* parent) : parent { parent } {}
+ParentContainer::ParentContainerBackgroundPositioner::ParentContainerBackgroundPositioner(ParentContainer* parent) :
+    parent { parent }
+{
+}
 void ParentContainer::ParentContainerBackgroundPositioner::handle_ready(std::shared_ptr<Container> const& in)
 {
     container = in;
@@ -65,7 +66,6 @@ void ParentContainer::ParentContainerBackgroundPositioner::set_area(mir::geometr
 }
 
 ParentContainer::ParentContainer(
-    miral::InternalClientLauncher& internal_client_launcher,
     std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
     std::shared_ptr<CompositorState> const& state,
     std::shared_ptr<WindowController> const& window_controller,
@@ -74,7 +74,6 @@ ParentContainer::ParentContainer(
     std::shared_ptr<WorkspaceInterface> const& workspace,
     std::shared_ptr<ParentContainer> const& parent,
     bool is_anchored) :
-    internal_client_launcher { internal_client_launcher },
     shell_application_manager { shell_application_manager },
     state { state },
     window_controller { window_controller },
@@ -104,19 +103,9 @@ geom::Rectangle ParentContainer::get_area() const
 
 void ParentContainer::try_remove_background_client()
 {
-    if (background_client)
-    {
-        background_client->stop();
-        background_client = nullptr;
-    }
-
-    if (background_app.has_value())
-    {
-        shell_application_manager->unregister_app(*background_app);
-        background_app.reset();
-    }
-
-    background_positioner.reset();
+    if (shell_application_id)
+        shell_application_manager->stop(shell_application_id.value());
+    shell_application_positioner.reset();
 }
 
 void ParentContainer::update_background_client_area()
@@ -126,28 +115,9 @@ void ParentContainer::update_background_client_area()
     {
         // Start up the internal client that will display the background for this floating parent
         mir::log_info("Spawning ParentBackgroundInternalClient for unanchored root parent");
-
-        background_client = std::make_shared<ParentBackgroundInternalClient>(logical_area);
-
-        internal_client_launcher.launch(
-            [this](wl_display* display)
-        {
-            (*background_client)(display);
-        },
-            [this](std::weak_ptr<mir::scene::Session> const& session)
-        {
-            // Register the application with the shell application manager
-            if (auto app = session.lock())
-            {
-                background_app = app;
-                auto const positioner = std::make_shared<ParentContainerBackgroundPositioner>(this);
-                background_positioner = positioner;
-                shell_application_manager->register_app(app, ShellApplicationType::parent_container_background, positioner);
-                mir::log_info("Registered parent background application with ShellApplicationManager");
-            }
-
-            (*background_client)(session);
-        });
+        auto const positioner = std::make_shared<ParentContainerBackgroundPositioner>(this);
+        shell_application_id = shell_application_manager->spawn(ShellApplicationRole::parent_container_background, positioner);
+        shell_application_positioner = positioner;
     }
 }
 
@@ -306,7 +276,6 @@ std::shared_ptr<ParentContainer> ParentContainer::convert_to_parent(std::shared_
     }
 
     auto new_parent_node = std::make_shared<ParentContainer>(
-        internal_client_launcher,
         shell_application_manager,
         state,
         window_controller,
@@ -332,7 +301,7 @@ void ParentContainer::set_logical_area(const geom::Rectangle& target_rect, bool 
     logical_area = target_rect;
     auto target_placement_area = get_logical_area();
 
-    if (auto const background_positioner_sh = background_positioner.lock())
+    if (auto const background_positioner_sh = shell_application_positioner.lock())
     {
         background_positioner_sh->set_area(target_placement_area);
     }

--- a/src/parent_container.cpp
+++ b/src/parent_container.cpp
@@ -110,7 +110,10 @@ geom::Rectangle ParentContainer::get_area() const
 void ParentContainer::try_remove_background_client()
 {
     if (shell_application_id)
+    {
         shell_application_manager->stop(shell_application_id.value());
+        shell_application_id.reset();
+    }
     shell_application_positioner.reset();
 }
 

--- a/src/parent_container.cpp
+++ b/src/parent_container.cpp
@@ -22,14 +22,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "container.h"
 #include "leaf_container.h"
 #include "output_interface.h"
+#include "parent_background_internal_client.h"
+#include "shell_application_manager.h"
 #include "tiling_algorithms.h"
 #include "workspace_interface.h"
 #include <cmath>
 #include <mir/log.h>
+#include <miral/internal_client.h>
 
 using namespace miracle;
 
 ParentContainer::ParentContainer(
+    miral::InternalClientLauncher& internal_client_launcher,
+    std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
     std::shared_ptr<CompositorState> const& state,
     std::shared_ptr<WindowController> const& window_controller,
     std::shared_ptr<Config> const& config,
@@ -37,6 +42,8 @@ ParentContainer::ParentContainer(
     std::shared_ptr<WorkspaceInterface> const& workspace,
     std::shared_ptr<ParentContainer> const& parent,
     bool is_anchored) :
+    internal_client_launcher { internal_client_launcher },
+    shell_application_manager { shell_application_manager },
     state { state },
     window_controller { window_controller },
     config { config },
@@ -50,6 +57,32 @@ ParentContainer::ParentContainer(
     // of them. Reserving at least 4 spots is a relatively safe
     // optimization.
     container_list.reserve(4);
+
+    if (!parent && !is_anchored)
+    {
+        // Start up the internal client that will display the background for this floating parent
+        mir::log_info("Spawning ParentBackgroundInternalClient for unanchored root parent");
+
+        auto background_client = std::make_shared<ParentBackgroundInternalClient>();
+
+        internal_client_launcher.launch(
+            [background_client](wl_display* display)
+        {
+            (*background_client)(display);
+        },
+            [this, background_client, shell_application_manager](std::weak_ptr<mir::scene::Session> const& session)
+        {
+            (*background_client)(session);
+
+            // Register the application with the shell application manager
+            if (auto app = session.lock())
+            {
+                background_app = app;
+                shell_application_manager->register_app(app, ShellApplicationType::parent_container_background);
+                mir::log_info("Registered parent background application with ShellApplicationManager");
+            }
+        });
+    }
 }
 
 geom::Rectangle ParentContainer::get_area() const
@@ -212,6 +245,8 @@ std::shared_ptr<ParentContainer> ParentContainer::convert_to_parent(std::shared_
     }
 
     auto new_parent_node = std::make_shared<ParentContainer>(
+        internal_client_launcher,
+        shell_application_manager,
         state,
         window_controller,
         config,

--- a/src/parent_container.cpp
+++ b/src/parent_container.cpp
@@ -51,6 +51,12 @@ ParentContainer::ParentContainerBackgroundPositioner::ParentContainerBackgroundP
     parent { parent }
 {
 }
+
+void ParentContainer::ParentContainerBackgroundPositioner::place_window(miral::WindowSpecification& specification)
+{
+    specification.focus_mode() = mir_focus_mode_disabled;
+}
+
 void ParentContainer::ParentContainerBackgroundPositioner::handle_ready(std::shared_ptr<Container> const& in)
 {
     container = in;

--- a/src/parent_container.cpp
+++ b/src/parent_container.cpp
@@ -34,18 +34,33 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using namespace miracle;
 
+namespace
+{
+    geom::Rectangle get_background_area(geom::Rectangle const& area)
+    {
+        const int padding = 8;
+        return geom::Rectangle(
+            geom::Point(
+                area.top_left.x.as_int() - padding,
+                area.top_left.y.as_int() - padding),
+            geom::Size(
+                area.size.width.as_int() + 2 * padding,
+                area.size.height.as_int() + 2 * padding));
+    }
+};
+
 ParentContainer::ParentContainerBackgroundPositioner::ParentContainerBackgroundPositioner(ParentContainer* parent) : parent { parent } {}
 void ParentContainer::ParentContainerBackgroundPositioner::handle_ready(std::shared_ptr<Container> const& in)
 {
     container = in;
-    in->set_logical_area(parent->get_logical_area(), false);
+    in->set_logical_area(get_background_area(parent->get_logical_area()), false);
 }
 
 void ParentContainer::ParentContainerBackgroundPositioner::set_area(mir::geometry::Rectangle const& area)
 {
-    if (auto sh_container = container.lock())
+    if (auto const sh_container = container.lock())
     {
-        sh_container->set_logical_area(area, false);
+        sh_container->set_logical_area(get_background_area(area), false);
     }
 }
 
@@ -74,20 +89,52 @@ ParentContainer::ParentContainer(
     // of them. Reserving at least 4 spots is a relatively safe
     // optimization.
     container_list.reserve(4);
+    update_background_client_area();
+}
 
-    if (!parent && !is_anchored)
+ParentContainer::~ParentContainer()
+{
+    try_remove_background_client();
+}
+
+geom::Rectangle ParentContainer::get_area() const
+{
+    return logical_area;
+}
+
+void ParentContainer::try_remove_background_client()
+{
+    if (background_client)
+    {
+        background_client->stop();
+        background_client = nullptr;
+    }
+
+    if (background_app.has_value())
+    {
+        shell_application_manager->unregister_app(*background_app);
+        background_app.reset();
+    }
+
+    background_positioner.reset();
+}
+
+void ParentContainer::update_background_client_area()
+{
+    try_remove_background_client();
+    if (parent.expired() && !is_anchored)
     {
         // Start up the internal client that will display the background for this floating parent
         mir::log_info("Spawning ParentBackgroundInternalClient for unanchored root parent");
 
-        auto background_client = std::make_shared<ParentBackgroundInternalClient>(logical_area);
+        background_client = std::make_shared<ParentBackgroundInternalClient>(logical_area);
 
         internal_client_launcher.launch(
-            [background_client](wl_display* display)
+            [this](wl_display* display)
         {
             (*background_client)(display);
         },
-            [this, background_client, shell_application_manager](std::weak_ptr<mir::scene::Session> const& session)
+            [this](std::weak_ptr<mir::scene::Session> const& session)
         {
             // Register the application with the shell application manager
             if (auto app = session.lock())
@@ -102,11 +149,6 @@ ParentContainer::ParentContainer(
             (*background_client)(session);
         });
     }
-}
-
-geom::Rectangle ParentContainer::get_area() const
-{
-    return logical_area;
 }
 
 geom::Rectangle ParentContainer::get_logical_area() const
@@ -934,6 +976,7 @@ bool ParentContainer::matches(ContainerScope const&) const
 bool ParentContainer::set_anchored(bool anchor)
 {
     is_anchored = anchor;
+    update_background_client_area();
     return true;
 }
 

--- a/src/parent_container.cpp
+++ b/src/parent_container.cpp
@@ -30,7 +30,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <mir/log.h>
 #include <miral/internal_client.h>
 
+#include "auto_restarting_launcher.h"
+
 using namespace miracle;
+
+ParentContainer::ParentContainerBackgroundPositioner::ParentContainerBackgroundPositioner(ParentContainer* parent) : parent { parent } {}
+void ParentContainer::ParentContainerBackgroundPositioner::handle_ready(std::shared_ptr<Container> const& in)
+{
+    container = in;
+    in->set_logical_area(parent->get_logical_area(), false);
+}
+
+void ParentContainer::ParentContainerBackgroundPositioner::set_area(mir::geometry::Rectangle const& area)
+{
+    if (auto sh_container = container.lock())
+    {
+        sh_container->set_logical_area(area, false);
+    }
+}
 
 ParentContainer::ParentContainer(
     miral::InternalClientLauncher& internal_client_launcher,
@@ -63,7 +80,7 @@ ParentContainer::ParentContainer(
         // Start up the internal client that will display the background for this floating parent
         mir::log_info("Spawning ParentBackgroundInternalClient for unanchored root parent");
 
-        auto background_client = std::make_shared<ParentBackgroundInternalClient>();
+        auto background_client = std::make_shared<ParentBackgroundInternalClient>(logical_area);
 
         internal_client_launcher.launch(
             [background_client](wl_display* display)
@@ -72,15 +89,17 @@ ParentContainer::ParentContainer(
         },
             [this, background_client, shell_application_manager](std::weak_ptr<mir::scene::Session> const& session)
         {
-            (*background_client)(session);
-
             // Register the application with the shell application manager
             if (auto app = session.lock())
             {
                 background_app = app;
-                shell_application_manager->register_app(app, ShellApplicationType::parent_container_background);
+                auto const positioner = std::make_shared<ParentContainerBackgroundPositioner>(this);
+                background_positioner = positioner;
+                shell_application_manager->register_app(app, ShellApplicationType::parent_container_background, positioner);
                 mir::log_info("Registered parent background application with ShellApplicationManager");
             }
+
+            (*background_client)(session);
         });
     }
 }
@@ -270,6 +289,12 @@ void ParentContainer::set_logical_area(const geom::Rectangle& target_rect, bool 
     auto current_logical_area = get_logical_area();
     logical_area = target_rect;
     auto target_placement_area = get_logical_area();
+
+    if (auto const background_positioner_sh = background_positioner.lock())
+    {
+        background_positioner_sh->set_area(target_placement_area);
+    }
+
     std::vector<geom::Rectangle> pending_size_updates;
     pending_size_updates.reserve(container_list.size());
     if (scheme == LayoutScheme::horizontal)

--- a/src/parent_container.cpp
+++ b/src/parent_container.cpp
@@ -20,12 +20,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "compositor_state.h"
 #include "config.h"
 #include "container.h"
+#include "feature_flags.h"
 #include "leaf_container.h"
 #include "output_interface.h"
 #include "shell_application_manager.h"
 #include "tiling_algorithms.h"
 #include "workspace_interface.h"
-#include "feature_flags.h"
 #include <cmath>
 #include <mir/log.h>
 

--- a/src/parent_container.h
+++ b/src/parent_container.h
@@ -20,20 +20,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "container.h"
 #include "layout_scheme.h"
-#include "shell_application_manager.h"
 #include "mir/geometry/forward.h"
+#include "shell_application_manager.h"
 #include "window_controller.h"
 #include <mir/geometry/rectangle.h>
-#include <miral/internal_client.h>
 #include <miral/window_specification.h>
 
 namespace geom = mir::geometry;
 
 namespace miracle
 {
-    class ParentBackgroundInternalClient;
+class ParentBackgroundInternalClient;
 
-    class LeafContainer;
+class LeafContainer;
 class Config;
 class CompositorState;
 class OutputManager;
@@ -43,7 +42,6 @@ class ParentContainer : public Container
 {
 public:
     ParentContainer(
-        miral::InternalClientLauncher& internal_client_launcher,
         std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
         std::shared_ptr<CompositorState> const& state,
         std::shared_ptr<WindowController> const& window_controller,
@@ -148,7 +146,7 @@ public:
         size_t second_index);
 
 private:
-    class ParentContainerBackgroundPositioner : public ShellComponentDelegate
+    class ParentContainerBackgroundPositioner : public ShellApplicationDelegate
     {
     public:
         explicit ParentContainerBackgroundPositioner(ParentContainer* parent);
@@ -162,7 +160,6 @@ private:
 
     std::vector<std::shared_ptr<Container>> container_list;
     std::weak_ptr<ParentContainer> parent;
-    miral::InternalClientLauncher internal_client_launcher;
     std::shared_ptr<ShellApplicationManager> shell_application_manager;
     std::shared_ptr<CompositorState> state;
     std::shared_ptr<WindowController> window_controller;
@@ -179,10 +176,8 @@ private:
     bool is_shown = false;
     std::shared_ptr<LeafContainer> pending_node;
 
-    /// The background internal client application, if spawned
-    std::shared_ptr<ParentBackgroundInternalClient> background_client;
-    std::optional<miral::Application> background_app;
-    std::weak_ptr<ParentContainerBackgroundPositioner> background_positioner;
+    std::optional<ShellApplicationId> shell_application_id;
+    std::weak_ptr<ParentContainerBackgroundPositioner> shell_application_positioner;
 
     geom::Rectangle create_space(std::optional<size_t> index);
     void relayout();

--- a/src/parent_container.h
+++ b/src/parent_container.h
@@ -31,8 +31,9 @@ namespace geom = mir::geometry;
 
 namespace miracle
 {
+    class ParentBackgroundInternalClient;
 
-class LeafContainer;
+    class LeafContainer;
 class Config;
 class CompositorState;
 class OutputManager;
@@ -51,7 +52,7 @@ public:
         std::shared_ptr<WorkspaceInterface> const& workspace,
         std::shared_ptr<ParentContainer> const& parent,
         bool is_anchored);
-    ~ParentContainer() override = default;
+    ~ParentContainer() override;
     virtual geom::Rectangle get_area() const;
     geom::Rectangle get_logical_area() const override;
     geom::Rectangle get_visible_area() const override;
@@ -179,12 +180,15 @@ private:
     std::shared_ptr<LeafContainer> pending_node;
 
     /// The background internal client application, if spawned
+    std::shared_ptr<ParentBackgroundInternalClient> background_client;
     std::optional<miral::Application> background_app;
     std::weak_ptr<ParentContainerBackgroundPositioner> background_positioner;
 
     geom::Rectangle create_space(std::optional<size_t> index);
     void relayout();
     void raise_children();
+    void update_background_client_area();
+    void try_remove_background_client();
 };
 
 } // miracle

--- a/src/parent_container.h
+++ b/src/parent_container.h
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "container.h"
 #include "layout_scheme.h"
+#include "shell_application_manager.h"
 #include "mir/geometry/forward.h"
 #include "window_controller.h"
 #include <mir/geometry/rectangle.h>
@@ -35,7 +36,6 @@ class LeafContainer;
 class Config;
 class CompositorState;
 class OutputManager;
-class ShellApplicationManager;
 
 /// A parent container used to define the layout of containers beneath it.
 class ParentContainer : public Container
@@ -147,6 +147,18 @@ public:
         size_t second_index);
 
 private:
+    class ParentContainerBackgroundPositioner : public ShellComponentDelegate
+    {
+    public:
+        explicit ParentContainerBackgroundPositioner(ParentContainer* parent);
+        void handle_ready(std::shared_ptr<Container> const& in) override;
+        void set_area(mir::geometry::Rectangle const& area);
+
+    private:
+        ParentContainer* parent;
+        std::weak_ptr<Container> container;
+    };
+
     std::vector<std::shared_ptr<Container>> container_list;
     std::weak_ptr<ParentContainer> parent;
     miral::InternalClientLauncher internal_client_launcher;
@@ -168,6 +180,7 @@ private:
 
     /// The background internal client application, if spawned
     std::optional<miral::Application> background_app;
+    std::weak_ptr<ParentContainerBackgroundPositioner> background_positioner;
 
     geom::Rectangle create_space(std::optional<size_t> index);
     void relayout();

--- a/src/parent_container.h
+++ b/src/parent_container.h
@@ -21,9 +21,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "container.h"
 #include "layout_scheme.h"
 #include "mir/geometry/forward.h"
-#include "miral/window_specification.h"
 #include "window_controller.h"
 #include <mir/geometry/rectangle.h>
+#include <miral/internal_client.h>
+#include <miral/window_specification.h>
 
 namespace geom = mir::geometry;
 
@@ -34,12 +35,15 @@ class LeafContainer;
 class Config;
 class CompositorState;
 class OutputManager;
+class ShellApplicationManager;
 
 /// A parent container used to define the layout of containers beneath it.
 class ParentContainer : public Container
 {
 public:
     ParentContainer(
+        miral::InternalClientLauncher& internal_client_launcher,
+        std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
         std::shared_ptr<CompositorState> const& state,
         std::shared_ptr<WindowController> const& window_controller,
         std::shared_ptr<Config> const& config,
@@ -145,6 +149,8 @@ public:
 private:
     std::vector<std::shared_ptr<Container>> container_list;
     std::weak_ptr<ParentContainer> parent;
+    miral::InternalClientLauncher internal_client_launcher;
+    std::shared_ptr<ShellApplicationManager> shell_application_manager;
     std::shared_ptr<CompositorState> state;
     std::shared_ptr<WindowController> window_controller;
     std::shared_ptr<Config> config;
@@ -159,6 +165,9 @@ private:
     ScratchpadState scratchpad_state_ = ScratchpadState::none;
     bool is_shown = false;
     std::shared_ptr<LeafContainer> pending_node;
+
+    /// The background internal client application, if spawned
+    std::optional<miral::Application> background_app;
 
     geom::Rectangle create_space(std::optional<size_t> index);
     void relayout();

--- a/src/parent_container.h
+++ b/src/parent_container.h
@@ -150,6 +150,7 @@ private:
     {
     public:
         explicit ParentContainerBackgroundPositioner(ParentContainer* parent);
+        void place_window(miral::WindowSpecification& specification) override;
         void handle_ready(std::shared_ptr<Container> const& in) override;
         void set_area(mir::geometry::Rectangle const& area);
 

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -182,7 +182,7 @@ Policy::Policy(
     launcher { std::make_shared<AutoRestartingLauncher>(server, external_client_launcher) },
     workspace_observer_registrar(std::make_shared<WorkspaceObserverRegistrar>()),
     mode_observer_registrar(std::make_shared<ModeObserverRegistrar>()),
-    shell_application_manager(std::make_shared<ShellApplicationManager>(std::make_unique<InternalShellApplicationSpawner>(internal_client_launcher))),
+    shell_application_manager(std::make_shared<ShellApplicationManager>(std::make_unique<InternalShellApplicationSpawner>(server))),
     output_manager(std::make_shared<OutputManager>(
         std::make_unique<MiralOutputFactory>(
             shell_application_manager,
@@ -511,6 +511,9 @@ auto Policy::place_new_window(
     }
 
     auto new_spec = requested_specification;
+    if (auto const delegate = shell_application_manager->delegate(app_info.application()))
+        delegate->place_window(new_spec);
+
     pending_allocation = output_manager->focused()->allocate_position(app_info, new_spec, {});
     return new_spec;
 }

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -27,6 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "container_listener.h"
 #include "dying_surface_manager.h"
 #include "feature_flags.h"
+#include "internal_shell_application_spawner.h"
 #include "magnifier_wrapper.h"
 #include "output_factory.h"
 #include "output_listener.h"
@@ -42,8 +43,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <mir/log.h>
 #include <mir/server.h>
 #include <mir_toolkit/events/enums.h>
-#include <miral/application_info.h>
-#include <miral/runner.h>
 #include <miral/toolkit_event.h>
 #include <miral/window_specification.h>
 #include <mutex>
@@ -183,10 +182,9 @@ Policy::Policy(
     launcher { std::make_shared<AutoRestartingLauncher>(server, external_client_launcher) },
     workspace_observer_registrar(std::make_shared<WorkspaceObserverRegistrar>()),
     mode_observer_registrar(std::make_shared<ModeObserverRegistrar>()),
-    shell_application_manager(std::make_shared<ShellApplicationManager>()),
+    shell_application_manager(std::make_shared<ShellApplicationManager>(std::make_unique<InternalShellApplicationSpawner>(internal_client_launcher))),
     output_manager(std::make_shared<OutputManager>(
         std::make_unique<MiralOutputFactory>(
-            internal_client_launcher,
             shell_application_manager,
             state,
             config,

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -33,6 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "output_manager.h"
 #include "parent_container.h"
 #include "plugin_manager.h"
+#include "shell_application_manager.h"
 #include "window_observer.h"
 #include "workspace_manager.h"
 
@@ -163,6 +164,7 @@ Policy::Policy(
     miral::WindowManagerTools const& tools,
     mir::Server& server,
     miral::ExternalClientLauncher& external_client_launcher,
+    miral::InternalClientLauncher& internal_client_launcher,
     std::shared_ptr<Config> const& config,
     std::shared_ptr<CompositorState> const& state,
     std::shared_ptr<OutputListenerMultiplexer> const& output_listener,
@@ -181,8 +183,11 @@ Policy::Policy(
     launcher { std::make_shared<AutoRestartingLauncher>(server, external_client_launcher) },
     workspace_observer_registrar(std::make_shared<WorkspaceObserverRegistrar>()),
     mode_observer_registrar(std::make_shared<ModeObserverRegistrar>()),
+    shell_application_manager(std::make_shared<ShellApplicationManager>()),
     output_manager(std::make_shared<OutputManager>(
         std::make_unique<MiralOutputFactory>(
+            internal_client_launcher,
+            shell_application_manager,
             state,
             config,
             window_controller,

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -163,7 +163,6 @@ Policy::Policy(
     miral::WindowManagerTools const& tools,
     mir::Server& server,
     miral::ExternalClientLauncher& external_client_launcher,
-    miral::InternalClientLauncher& internal_client_launcher,
     std::shared_ptr<Config> const& config,
     std::shared_ptr<CompositorState> const& state,
     std::shared_ptr<OutputListenerMultiplexer> const& output_listener,

--- a/src/policy.h
+++ b/src/policy.h
@@ -60,6 +60,7 @@ class DisplayConfig;
 class WindowObserverRegistrar;
 class MagnifierWrapper;
 class PluginManager;
+class ShellApplicationManager;
 
 class Policy : public miral::WindowManagementPolicy
 {
@@ -68,6 +69,7 @@ public:
         miral::WindowManagerTools const&,
         mir::Server&,
         miral::ExternalClientLauncher& external_client_launcher,
+        miral::InternalClientLauncher& internal_client_launcher,
         std::shared_ptr<Config> const&,
         std::shared_ptr<CompositorState> const& state,
         std::shared_ptr<OutputListenerMultiplexer> const& output_listener,
@@ -127,6 +129,7 @@ private:
     std::shared_ptr<AutoRestartingLauncher> launcher;
     std::shared_ptr<WorkspaceObserverRegistrar> workspace_observer_registrar;
     std::shared_ptr<ModeObserverRegistrar> mode_observer_registrar;
+    std::shared_ptr<ShellApplicationManager> shell_application_manager;
     std::shared_ptr<OutputManager> output_manager;
     std::shared_ptr<WorkspaceManager> workspace_manager;
     std::shared_ptr<Self> self;

--- a/src/policy.h
+++ b/src/policy.h
@@ -44,7 +44,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace miral
 {
 class ExternalClientLauncher;
-class InternalClientLauncher;
 }
 
 namespace miracle
@@ -70,7 +69,6 @@ public:
         miral::WindowManagerTools const&,
         mir::Server&,
         miral::ExternalClientLauncher& external_client_launcher,
-        miral::InternalClientLauncher& internal_client_launcher,
         std::shared_ptr<Config> const&,
         std::shared_ptr<CompositorState> const& state,
         std::shared_ptr<OutputListenerMultiplexer> const& output_listener,

--- a/src/policy.h
+++ b/src/policy.h
@@ -44,6 +44,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace miral
 {
 class ExternalClientLauncher;
+class InternalClientLauncher;
 }
 
 namespace miracle

--- a/src/render_data_manager.h
+++ b/src/render_data_manager.h
@@ -32,7 +32,7 @@ typedef int RenderDataManagerId;
 struct RenderData
 {
     RenderDataManagerId id = 0;
-    mir::scene::Surface const* surface;
+    mir::scene::Surface const* surface = nullptr;
     bool needs_outline = false;
     bool is_focused = false;
     glm::mat4 transform = glm::mat4(1.f);

--- a/src/shell_application_manager.cpp
+++ b/src/shell_application_manager.cpp
@@ -18,42 +18,46 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "shell_application_manager.h"
 #include <algorithm>
 
-void miracle::ShellApplicationManager::register_app(miral::Application const& application, ShellApplicationType type)
+void miracle::ShellApplicationManager::register_app(miral::Application const& application, ShellApplicationType type, std::shared_ptr<ShellComponentDelegate> const& delegate)
 {
     switch (type)
     {
     case ShellApplicationType::parent_container_background:
-        parent_container_background_apps.push_back(application);
-        break;
-    }
-}
-
-void miracle::ShellApplicationManager::unregister_app(miral::Application const& application, ShellApplicationType type)
-{
-    switch (type)
-    {
-    case ShellApplicationType::parent_container_background:
-        std::erase_if(
-            parent_container_background_apps,
-            [&application](miral::Application const& app)
-        {
-            return app == application;
+        registered_apps.push_back({
+            .type = type,
+            .application = application,
+            .delegate = std::move(delegate)
         });
         break;
     }
 }
 
-bool miracle::ShellApplicationManager::is_registered(miral::Application const& application, ShellApplicationType type) const
+void miracle::ShellApplicationManager::unregister_app(miral::Application const& application)
 {
-    switch (type)
+    std::erase_if(
+        registered_apps,
+        [&application](auto const& app)
     {
-    case ShellApplicationType::parent_container_background:
-        return std::ranges::any_of(parent_container_background_apps,
-            [&application](miral::Application const& app)
-        {
-            return app == application;
-        });
-    default:
-        return false;
+        return app.application == application;
+    });
+}
+
+bool miracle::ShellApplicationManager::is_registered(miral::Application const& application) const
+{
+    return std::ranges::any_of(registered_apps,
+        [&application](auto const& app)
+    {
+        return app.application == application;
+    });
+}
+
+std::shared_ptr<miracle::ShellComponentDelegate> miracle::ShellApplicationManager::delegate(miral::Application const& application) const
+{
+    for (auto const& app : registered_apps)
+    {
+        if (app.application == application)
+            return app.delegate;
     }
+
+    return nullptr;
 }

--- a/src/shell_application_manager.cpp
+++ b/src/shell_application_manager.cpp
@@ -40,7 +40,8 @@ void miracle::ShellApplicationManager::stop(ShellApplicationId app_id)
     {
         if (app.id == app_id)
         {
-            app.application->stop();
+            if (app.application)
+                app.application->stop();
             return true;
         }
 

--- a/src/shell_application_manager.cpp
+++ b/src/shell_application_manager.cpp
@@ -18,27 +18,33 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "shell_application_manager.h"
 #include <algorithm>
 
-void miracle::ShellApplicationManager::register_app(miral::Application const& application, ShellApplicationType type, std::shared_ptr<ShellComponentDelegate> const& delegate)
+miracle::ShellApplicationManager::ShellApplicationManager(std::unique_ptr<ShellApplicationSpawner> spawner) :
+    spawner(std::move(spawner))
 {
-    switch (type)
-    {
-    case ShellApplicationType::parent_container_background:
-        registered_apps.push_back({
-            .type = type,
-            .application = application,
-            .delegate = std::move(delegate)
-        });
-        break;
-    }
 }
 
-void miracle::ShellApplicationManager::unregister_app(miral::Application const& application)
+miracle::ShellApplicationId miracle::ShellApplicationManager::spawn(ShellApplicationRole type, std::shared_ptr<ShellApplicationDelegate> const& delegate)
+{
+    registered_apps.push_back({ .role = type,
+        .id = next_id++,
+        .application = spawner->spawn(type),
+        .delegate = std::move(delegate) });
+    return registered_apps.back().id;
+}
+
+void miracle::ShellApplicationManager::stop(ShellApplicationId app_id)
 {
     std::erase_if(
         registered_apps,
-        [&application](auto const& app)
+        [&app_id](auto const& app)
     {
-        return app.application == application;
+        if (app.id == app_id)
+        {
+            app.application->stop();
+            return true;
+        }
+
+        return false;
     });
 }
 
@@ -47,15 +53,15 @@ bool miracle::ShellApplicationManager::is_registered(miral::Application const& a
     return std::ranges::any_of(registered_apps,
         [&application](auto const& app)
     {
-        return app.application == application;
+        return app.application->application() == application;
     });
 }
 
-std::shared_ptr<miracle::ShellComponentDelegate> miracle::ShellApplicationManager::delegate(miral::Application const& application) const
+std::shared_ptr<miracle::ShellApplicationDelegate> miracle::ShellApplicationManager::delegate(miral::Application const& application) const
 {
     for (auto const& app : registered_apps)
     {
-        if (app.application == application)
+        if (app.application->application() == application)
             return app.delegate;
     }
 

--- a/src/shell_application_manager.cpp
+++ b/src/shell_application_manager.cpp
@@ -1,0 +1,59 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#include "shell_application_manager.h"
+#include <algorithm>
+
+void miracle::ShellApplicationManager::register_app(miral::Application const& application, ShellApplicationType type)
+{
+    switch (type)
+    {
+    case ShellApplicationType::parent_container_background:
+        parent_container_background_apps.push_back(application);
+        break;
+    }
+}
+
+void miracle::ShellApplicationManager::unregister_app(miral::Application const& application, ShellApplicationType type)
+{
+    switch (type)
+    {
+    case ShellApplicationType::parent_container_background:
+        std::erase_if(
+            parent_container_background_apps,
+            [&application](miral::Application const& app)
+        {
+            return app == application;
+        });
+        break;
+    }
+}
+
+bool miracle::ShellApplicationManager::is_registered(miral::Application const& application, ShellApplicationType type) const
+{
+    switch (type)
+    {
+    case ShellApplicationType::parent_container_background:
+        return std::ranges::any_of(parent_container_background_apps,
+            [&application](miral::Application const& app)
+        {
+            return app == application;
+        });
+    default:
+        return false;
+    }
+}

--- a/src/shell_application_manager.h
+++ b/src/shell_application_manager.h
@@ -1,0 +1,31 @@
+
+#ifndef MIRACLE_WM_SHELL_APPLICATION_MANAGER_H
+#define MIRACLE_WM_SHELL_APPLICATION_MANAGER_H
+
+#include <miral/application.h>
+#include <vector>
+
+namespace miracle
+{
+enum class ShellApplicationType
+{
+    parent_container_background
+};
+
+/// Manages applications that have special shell roles, such as being
+/// rendered in the background of parent containers.
+///
+/// Miracle will use this to specially position such applications.
+class ShellApplicationManager
+{
+public:
+    void register_app(miral::Application const& application, ShellApplicationType type);
+    void unregister_app(miral::Application const& application, ShellApplicationType type);
+    bool is_registered(miral::Application const& application, ShellApplicationType type) const;
+
+private:
+    std::vector<miral::Application> parent_container_background_apps;
+};
+}
+
+#endif // MIRACLE_WM_SHELL_APPLICATION_MANAGER_H

--- a/src/shell_application_manager.h
+++ b/src/shell_application_manager.h
@@ -7,9 +7,19 @@
 
 namespace miracle
 {
+class Container;
+
 enum class ShellApplicationType
 {
     parent_container_background
+};
+
+/// Used to notify delegates about shell component events.
+class ShellComponentDelegate
+{
+public:
+    ~ShellComponentDelegate() = default;
+    virtual void handle_ready(std::shared_ptr<Container> const&) = 0;
 };
 
 /// Manages applications that have special shell roles, such as being
@@ -19,13 +29,29 @@ enum class ShellApplicationType
 class ShellApplicationManager
 {
 public:
-    void register_app(miral::Application const& application, ShellApplicationType type);
-    void unregister_app(miral::Application const& application, ShellApplicationType type);
-    bool is_registered(miral::Application const& application, ShellApplicationType type) const;
+    /// Register an application with a specific shell role.
+    void register_app(miral::Application const& application, ShellApplicationType type, std::shared_ptr<ShellComponentDelegate> const& delegate);
+
+    /// Unregister an applicationn.
+    void unregister_app(miral::Application const& application);
+
+    /// Check if an application is registered.
+    bool is_registered(miral::Application const& application) const;
+
+    /// Get a delegate for the given application, or `nullptr` if none exists.
+    std::shared_ptr<ShellComponentDelegate> delegate(miral::Application const& application) const;
 
 private:
-    std::vector<miral::Application> parent_container_background_apps;
+    struct ApplicationData
+    {
+        ShellApplicationType type;
+        miral::Application application;
+        std::shared_ptr<ShellComponentDelegate> delegate;
+    };
+
+    std::vector<ApplicationData> registered_apps;
 };
 }
+
 
 #endif // MIRACLE_WM_SHELL_APPLICATION_MANAGER_H

--- a/src/shell_application_manager.h
+++ b/src/shell_application_manager.h
@@ -1,57 +1,72 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
 
 #ifndef MIRACLE_WM_SHELL_APPLICATION_MANAGER_H
 #define MIRACLE_WM_SHELL_APPLICATION_MANAGER_H
 
-#include <miral/application.h>
+#include "shell_application_spawner.h"
 #include <vector>
 
 namespace miracle
 {
-class Container;
+typedef uint32_t ShellApplicationId;
 
-enum class ShellApplicationType
-{
-    parent_container_background
-};
-
-/// Used to notify delegates about shell component events.
-class ShellComponentDelegate
-{
-public:
-    ~ShellComponentDelegate() = default;
-    virtual void handle_ready(std::shared_ptr<Container> const&) = 0;
-};
-
-/// Manages applications that have special shell roles, such as being
-/// rendered in the background of parent containers.
+/// Manages applications that have special shell roles.
 ///
-/// Miracle will use this to specially position such applications.
+///
 class ShellApplicationManager
 {
 public:
-    /// Register an application with a specific shell role.
-    void register_app(miral::Application const& application, ShellApplicationType type, std::shared_ptr<ShellComponentDelegate> const& delegate);
+    explicit ShellApplicationManager(std::unique_ptr<ShellApplicationSpawner> spawner);
 
-    /// Unregister an applicationn.
-    void unregister_app(miral::Application const& application);
+    /// Spawn application with a specific \p role.
+    ///
+    /// The behavior of the application will be provided by the \p delegate.
+    ///
+    /// \param role the shell application role
+    /// \param delegate controls the behavior of the application
+    /// \returns a unique id
+    ShellApplicationId spawn(ShellApplicationRole role, std::shared_ptr<ShellApplicationDelegate> const& delegate);
 
-    /// Check if an application is registered.
+    /// Stops the application with the provided id.
+    void stop(ShellApplicationId app_id);
+
+    /// Check if an application is registered as a shell application.
+    ///
+    /// \param application the application
+    /// \returns `true` if it is a shell application, otherwise `false`.
     bool is_registered(miral::Application const& application) const;
 
     /// Get a delegate for the given application, or `nullptr` if none exists.
-    std::shared_ptr<ShellComponentDelegate> delegate(miral::Application const& application) const;
+    std::shared_ptr<ShellApplicationDelegate> delegate(miral::Application const& application) const;
 
 private:
     struct ApplicationData
     {
-        ShellApplicationType type;
-        miral::Application application;
-        std::shared_ptr<ShellComponentDelegate> delegate;
+        ShellApplicationRole role;
+        ShellApplicationId id;
+        std::unique_ptr<ShellApplication> application;
+        std::shared_ptr<ShellApplicationDelegate> delegate;
     };
 
+    std::unique_ptr<ShellApplicationSpawner> spawner;
+    ShellApplicationId next_id = 0;
     std::vector<ApplicationData> registered_apps;
 };
 }
-
 
 #endif // MIRACLE_WM_SHELL_APPLICATION_MANAGER_H

--- a/src/shell_application_spawner.h
+++ b/src/shell_application_spawner.h
@@ -1,0 +1,62 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef MIRACLE_WM_SHELL_APPLICATION_SPAWNER_H
+#define MIRACLE_WM_SHELL_APPLICATION_SPAWNER_H
+
+#include <miral/application.h>
+
+namespace miracle
+{
+class Container;
+
+enum class ShellApplicationRole
+{
+    parent_container_background
+};
+
+/// Used to notify delegates about shell component events.
+class ShellApplicationDelegate
+{
+public:
+    virtual ~ShellApplicationDelegate() = default;
+    virtual void handle_ready(std::shared_ptr<Container> const&) = 0;
+};
+
+class ShellApplication
+{
+public:
+    virtual ~ShellApplication() = default;
+    virtual void stop() = 0;
+    virtual miral::Application application() = 0;
+};
+
+/// Spawns shell applications.
+class ShellApplicationSpawner
+{
+public:
+    virtual ~ShellApplicationSpawner() = default;
+
+    /// Spawns a shell application with the given \p type.
+    ///
+    /// \param role the application that should be spawned
+    /// \returns the spawned shell application
+    virtual std::unique_ptr<ShellApplication> spawn(ShellApplicationRole role) = 0;
+};
+}
+
+#endif

--- a/src/shell_application_spawner.h
+++ b/src/shell_application_spawner.h
@@ -34,6 +34,7 @@ class ShellApplicationDelegate
 {
 public:
     virtual ~ShellApplicationDelegate() = default;
+    virtual void place_window(miral::WindowSpecification& specification) = 0;
     virtual void handle_ready(std::shared_ptr<Container> const&) = 0;
 };
 

--- a/src/shell_component_container.cpp
+++ b/src/shell_component_container.cpp
@@ -90,9 +90,10 @@ size_t ShellComponentContainer::get_min_width() const
 
 void ShellComponentContainer::handle_ready()
 {
-    window_controller->select_active_window(window_);
     if (delegate)
         delegate->handle_ready(shared_from_this());
+    else
+        window_controller->select_active_window(window_);
 }
 
 void ShellComponentContainer::handle_modify(miral::WindowSpecification const& specification)

--- a/src/shell_component_container.cpp
+++ b/src/shell_component_container.cpp
@@ -20,14 +20,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <mir/scene/session.h>
 #include <mir/scene/surface.h>
 
+#include "shell_application_manager.h"
+
 namespace miracle
 {
 
 ShellComponentContainer::ShellComponentContainer(
     miral::Window const& window_,
-    std::shared_ptr<WindowController> const& window_controller) :
+    std::shared_ptr<WindowController> const& window_controller,
+    std::shared_ptr<ShellComponentDelegate>&& delegate) :
     window_ { window_ },
-    window_controller { window_controller }
+    window_controller { window_controller },
+    delegate { std::move(delegate) }
 {
 }
 
@@ -53,7 +57,7 @@ mir::geometry::Rectangle ShellComponentContainer::get_logical_area() const
 
 void ShellComponentContainer::set_logical_area(mir::geometry::Rectangle const& rectangle, bool with_animations)
 {
-    window_controller->set_rectangle(window_, get_visible_area(), rectangle);
+    window_controller->set_rectangle(window_, get_visible_area(), rectangle, with_animations);
 }
 
 mir::geometry::Rectangle ShellComponentContainer::get_visible_area() const
@@ -87,6 +91,8 @@ size_t ShellComponentContainer::get_min_width() const
 void ShellComponentContainer::handle_ready()
 {
     window_controller->select_active_window(window_);
+    if (delegate)
+        delegate->handle_ready(shared_from_this());
 }
 
 void ShellComponentContainer::handle_modify(miral::WindowSpecification const& specification)

--- a/src/shell_component_container.cpp
+++ b/src/shell_component_container.cpp
@@ -28,7 +28,7 @@ namespace miracle
 ShellComponentContainer::ShellComponentContainer(
     miral::Window const& window_,
     std::shared_ptr<WindowController> const& window_controller,
-    std::shared_ptr<ShellComponentDelegate>&& delegate) :
+    std::shared_ptr<ShellApplicationDelegate>&& delegate) :
     window_ { window_ },
     window_controller { window_controller },
     delegate { std::move(delegate) }

--- a/src/shell_component_container.h
+++ b/src/shell_component_container.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace miracle
 {
 class WindowController;
-class ShellComponentDelegate;
+class ShellApplicationDelegate;
 
 class ShellComponentContainer : public Container
 {
@@ -31,7 +31,7 @@ public:
     ShellComponentContainer(
         miral::Window const&,
         std::shared_ptr<WindowController> const& window_controller,
-        std::shared_ptr<ShellComponentDelegate>&& delegate);
+        std::shared_ptr<ShellApplicationDelegate>&& delegate);
 
     std::weak_ptr<ParentContainer> get_parent() const override;
 
@@ -103,7 +103,7 @@ public:
 private:
     miral::Window window_;
     std::shared_ptr<WindowController> window_controller;
-    std::shared_ptr<ShellComponentDelegate> delegate;
+    std::shared_ptr<ShellApplicationDelegate> delegate;
     uint32_t handle_ = 0;
     glm::mat4 transform_ = glm::mat4(1.f);
 };

--- a/src/shell_component_container.h
+++ b/src/shell_component_container.h
@@ -23,13 +23,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace miracle
 {
 class WindowController;
+class ShellComponentDelegate;
 
 class ShellComponentContainer : public Container
 {
 public:
     ShellComponentContainer(
         miral::Window const&,
-        std::shared_ptr<WindowController> const& window_controller);
+        std::shared_ptr<WindowController> const& window_controller,
+        std::shared_ptr<ShellComponentDelegate>&& delegate);
 
     std::weak_ptr<ParentContainer> get_parent() const override;
 
@@ -101,6 +103,7 @@ public:
 private:
     miral::Window window_;
     std::shared_ptr<WindowController> window_controller;
+    std::shared_ptr<ShellComponentDelegate> delegate;
     uint32_t handle_ = 0;
     glm::mat4 transform_ = glm::mat4(1.f);
 };

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -35,6 +35,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <mir/server_action_queue.h>
 #include <miral/zone.h>
 
+#include "shell_application_manager.h"
+
 using namespace miracle;
 
 namespace
@@ -243,7 +245,7 @@ std::shared_ptr<Container> Workspace::create_container(
         break;
     }
     case ContainerType::shell:
-        container = std::make_shared<ShellComponentContainer>(window_info.window(), window_controller);
+        container = std::make_shared<ShellComponentContainer>(window_info.window(), window_controller, shell_application_manager->delegate(window_info.window().application()));
         break;
     default:
         mir::log_error("Unsupported window type: %d", (int)hint.container_type);

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -107,6 +107,8 @@ geom::Rectangle get_output_area(std::shared_ptr<OutputInterface> const& output)
 }
 
 Workspace::Workspace(
+    miral::InternalClientLauncher& internal_client_launcher,
+    std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
     std::shared_ptr<OutputInterface> const& output,
     uint32_t id,
     std::optional<int> num,
@@ -118,6 +120,8 @@ Workspace::Workspace(
     std::shared_ptr<Animator> const& animator,
     std::shared_ptr<mir::ServerActionQueue> const& action_queue,
     std::shared_ptr<PluginManager> const& plugin_manager) :
+    internal_client_launcher { internal_client_launcher },
+    shell_application_manager { shell_application_manager },
     output { output },
     id_ { id },
     num_ { num },
@@ -144,7 +148,15 @@ std::shared_ptr<ParentContainer> Workspace::root() const
     {
         auto mutable_ws = std::const_pointer_cast<Workspace>(shared_from_this());
         root_ = std::make_shared<ParentContainer>(
-            state, window_controller, config, get_output_area(output.lock()), mutable_ws, nullptr, true);
+            internal_client_launcher,
+            shell_application_manager,
+            state,
+            window_controller,
+            config,
+            get_output_area(output.lock()),
+            mutable_ws,
+            nullptr,
+            true);
     }
 
     return root_;
@@ -420,7 +432,15 @@ void Workspace::transfer_pinned_windows_to(std::shared_ptr<WorkspaceInterface> c
 std::shared_ptr<ParentContainer> Workspace::create_floating_tree(mir::geometry::Rectangle const& area)
 {
     auto floating = std::make_shared<ParentContainer>(
-        state, window_controller, config, area, shared_from_this(), nullptr, false);
+        internal_client_launcher,
+        shell_application_manager,
+        state,
+        window_controller,
+        config,
+        area,
+        shared_from_this(),
+        nullptr,
+        false);
     floating_trees.push_back(floating);
     return floating;
 }
@@ -493,6 +513,8 @@ Workspace::MoveResult Workspace::handle_move(Container& from, Direction directio
             return {};
 
         auto after_root_lane = std::make_shared<ParentContainer>(
+            internal_client_launcher,
+            shell_application_manager,
             state,
             window_controller,
             config,

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -109,7 +109,6 @@ geom::Rectangle get_output_area(std::shared_ptr<OutputInterface> const& output)
 }
 
 Workspace::Workspace(
-    miral::InternalClientLauncher& internal_client_launcher,
     std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
     std::shared_ptr<OutputInterface> const& output,
     uint32_t id,
@@ -122,7 +121,6 @@ Workspace::Workspace(
     std::shared_ptr<Animator> const& animator,
     std::shared_ptr<mir::ServerActionQueue> const& action_queue,
     std::shared_ptr<PluginManager> const& plugin_manager) :
-    internal_client_launcher { internal_client_launcher },
     shell_application_manager { shell_application_manager },
     output { output },
     id_ { id },
@@ -150,7 +148,6 @@ std::shared_ptr<ParentContainer> Workspace::root() const
     {
         auto mutable_ws = std::const_pointer_cast<Workspace>(shared_from_this());
         root_ = std::make_shared<ParentContainer>(
-            internal_client_launcher,
             shell_application_manager,
             state,
             window_controller,
@@ -434,7 +431,6 @@ void Workspace::transfer_pinned_windows_to(std::shared_ptr<WorkspaceInterface> c
 std::shared_ptr<ParentContainer> Workspace::create_floating_tree(mir::geometry::Rectangle const& area)
 {
     auto floating = std::make_shared<ParentContainer>(
-        internal_client_launcher,
         shell_application_manager,
         state,
         window_controller,
@@ -515,7 +511,6 @@ Workspace::MoveResult Workspace::handle_move(Container& from, Direction directio
             return {};
 
         auto after_root_lane = std::make_shared<ParentContainer>(
-            internal_client_launcher,
             shell_application_manager,
             state,
             window_controller,

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -22,7 +22,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "workspace_interface.h"
 
 #include <memory>
-#include <miral/internal_client.h>
 #include <miral/window_manager_tools.h>
 
 namespace miracle
@@ -46,7 +45,6 @@ class Workspace : public WorkspaceInterface, public std::enable_shared_from_this
 {
 public:
     Workspace(
-        miral::InternalClientLauncher& internal_client_launcher,
         std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
         std::shared_ptr<OutputInterface> const& output,
         uint32_t id,
@@ -118,7 +116,6 @@ private:
 
     std::shared_ptr<ParentContainer> root() const;
 
-    mutable miral::InternalClientLauncher internal_client_launcher;
     std::shared_ptr<ShellApplicationManager> shell_application_manager;
     std::weak_ptr<OutputInterface> output;
     uint32_t id_;

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "workspace_interface.h"
 
 #include <memory>
+#include <miral/internal_client.h>
 #include <miral/window_manager_tools.h>
 
 namespace miracle
@@ -33,6 +34,7 @@ class CompositorState;
 class WorkspaceObserverRegistrar;
 class Animator;
 class PluginManager;
+class ShellApplicationManager;
 
 struct WorkspaceIdentifier
 {
@@ -44,6 +46,8 @@ class Workspace : public WorkspaceInterface, public std::enable_shared_from_this
 {
 public:
     Workspace(
+        miral::InternalClientLauncher& internal_client_launcher,
+        std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
         std::shared_ptr<OutputInterface> const& output,
         uint32_t id,
         std::optional<int> num,
@@ -114,6 +118,8 @@ private:
 
     std::shared_ptr<ParentContainer> root() const;
 
+    mutable miral::InternalClientLauncher internal_client_launcher;
+    std::shared_ptr<ShellApplicationManager> shell_application_manager;
     std::weak_ptr<OutputInterface> output;
     uint32_t id_;
     std::optional<int> num_;

--- a/tests/mock_parent_container.h
+++ b/tests/mock_parent_container.h
@@ -14,6 +14,7 @@ namespace test
     {
     public:
         MockParentContainer(
+            std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
             std::shared_ptr<CompositorState> const& state,
             std::shared_ptr<WindowController> const& window_controller,
             std::shared_ptr<Config> const& config,
@@ -21,7 +22,7 @@ namespace test
             std::shared_ptr<WorkspaceInterface> const& workspace,
             std::shared_ptr<ParentContainer> const& parent,
             bool is_anchored) :
-            ParentContainer(state, window_controller, config, area, workspace, parent, is_anchored)
+            ParentContainer(shell_application_manager, state, window_controller, config, area, workspace, parent, is_anchored)
         {
         }
 

--- a/tests/mock_shell_application_spawner.h
+++ b/tests/mock_shell_application_spawner.h
@@ -1,0 +1,40 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef MIRACLE_WM_MOCK_SHELL_APPLICATION_SPAWNER_H
+#define MIRACLE_WM_MOCK_SHELL_APPLICATION_SPAWNER_H
+
+#include "shell_application_spawner.h"
+#include <gmock/gmock.h>
+
+namespace miracle::test
+{
+class MockShellApplication : public ShellApplication
+{
+public:
+    MOCK_METHOD(void, stop, (), (override));
+    MOCK_METHOD(miral::Application, application, (), (override));
+};
+
+class MockShellApplicationSpawner : public ShellApplicationSpawner
+{
+public:
+    MOCK_METHOD(std::unique_ptr<ShellApplication>, spawn, (ShellApplicationRole role), (override));
+};
+}
+
+#endif // MIRACLE_WM_MOCK_SHELL_APPLICATION_SPAWNER_H

--- a/tests/test_leaf_container.cpp
+++ b/tests/test_leaf_container.cpp
@@ -29,9 +29,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "mock_output_factory.h"
 #include "mock_parent_container.h"
 #include "mock_session.h"
+#include "mock_shell_application_spawner.h"
 #include "mock_surface.h"
 #include "mock_window_controller.h"
 #include "mock_workspace.h"
+#include "shell_application_manager.h"
 #include "stub_configuration.h"
 #include "gmock/gmock.h"
 #include <gtest/gtest.h>
@@ -52,7 +54,10 @@ class LeafContainerTest : public ::testing::Test
 public:
     LeafContainerTest() :
         workspace(std::make_shared<testing::NiceMock<test::MockWorkspace>>()),
+        shell_application_manager(std::make_shared<ShellApplicationManager>(
+            std::make_unique<testing::NiceMock<test::MockShellApplicationSpawner>>())),
         parent(std::make_shared<testing::NiceMock<test::MockParentContainer>>(
+            shell_application_manager,
             state,
             window_controller,
             config,
@@ -93,6 +98,7 @@ protected:
     std::shared_ptr<test::MockWindowController> window_controller = std::make_shared<testing::NiceMock<test::MockWindowController>>();
     std::shared_ptr<Config> config = std::make_shared<test::StubConfiguration>();
     std::shared_ptr<test::MockWorkspace> workspace;
+    std::shared_ptr<ShellApplicationManager> shell_application_manager;
     std::vector<std::shared_ptr<WorkspaceInterface>> workspaces;
     std::shared_ptr<test::MockOutput> output = std::make_shared<testing::NiceMock<test::MockOutput>>();
     std::shared_ptr<test::MockParentContainer> parent;

--- a/tests/test_output.cpp
+++ b/tests/test_output.cpp
@@ -18,10 +18,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "animator.h"
 #include "compositor_state.h"
 #include "mock_container.h"
+#include "mock_shell_application_spawner.h"
 #include "mock_window_controller.h"
 #include "mock_workspace.h"
 #include "output.h"
 #include "passthrough_server_action_queue.h"
+#include "shell_application_manager.h"
 #include "stub_configuration.h"
 #include "workspace_observer.h"
 #include <gmock/gmock.h>
@@ -43,9 +45,12 @@ protected:
         animator = std::make_shared<Animator>();
         state = std::make_shared<CompositorState>();
         config = std::make_shared<test::StubConfiguration>();
+        shell_application_manager = std::make_shared<ShellApplicationManager>(
+            std::make_unique<NiceMock<test::MockShellApplicationSpawner>>());
 
         // Create the Output
         output = std::make_shared<Output>(
+            shell_application_manager,
             "TestOutput",
             1, // id
             geom::Rectangle {
@@ -77,6 +82,7 @@ protected:
     std::shared_ptr<Animator> animator;
     std::shared_ptr<CompositorState> state;
     std::shared_ptr<test::StubConfiguration> config;
+    std::shared_ptr<ShellApplicationManager> shell_application_manager;
     std::shared_ptr<WorkspaceInterface> actual_workspace;
 };
 

--- a/tests/test_parent_container.cpp
+++ b/tests/test_parent_container.cpp
@@ -22,11 +22,13 @@
 #include "mock_container.h"
 #include "mock_output_factory.h"
 #include "mock_session.h"
+#include "mock_shell_application_spawner.h"
 #include "mock_surface.h"
 #include "mock_window_controller.h"
 #include "mock_workspace.h"
 #include "output_manager.h"
 #include "parent_container.h"
+#include "shell_application_manager.h"
 #include "stub_configuration.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -42,12 +44,13 @@ class ParentContainerData
 {
 public:
     ParentContainerData(
+        std::shared_ptr<ShellApplicationManager> const& shell_application_manager,
         std::shared_ptr<CompositorState> const& state,
         std::shared_ptr<WindowController> const& window_controller,
         std::shared_ptr<Config> const& config,
         geom::Rectangle const& area,
         bool is_anchored = true) :
-        parent(std::make_shared<ParentContainer>(state, window_controller, config, area, workspace, nullptr, is_anchored))
+        parent(std::make_shared<ParentContainer>(shell_application_manager, state, window_controller, config, area, workspace, nullptr, is_anchored))
     {
     }
 
@@ -61,9 +64,11 @@ class ParentContainerTest : public Test
 public:
     [[nodiscard]] ParentContainerData make_parent(geom::Rectangle const& area, bool is_anchored = true) const
     {
-        return ParentContainerData { state, window_controller, config, area, is_anchored };
+        return ParentContainerData { shell_application_manager, state, window_controller, config, area, is_anchored };
     }
 
+    std::shared_ptr<ShellApplicationManager> shell_application_manager = std::make_shared<ShellApplicationManager>(
+        std::make_unique<NiceMock<test::MockShellApplicationSpawner>>());
     std::shared_ptr<CompositorState> state = std::make_shared<CompositorState>();
     std::shared_ptr<test::MockWindowController> window_controller = std::make_shared<testing::NiceMock<test::MockWindowController>>();
     std::shared_ptr<Config> config = std::make_shared<test::StubConfiguration>();

--- a/tests/test_resize_service.cpp
+++ b/tests/test_resize_service.cpp
@@ -20,10 +20,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "mock_output.h"
 #include "mock_output_factory.h"
 #include "mock_parent_container.h"
+#include "mock_shell_application_spawner.h"
 #include "mock_workspace.h"
 #include "mode_observer.h"
 #include "resize_service.h"
 #include "scratchpad.h"
+#include "shell_application_manager.h"
 #include "stub_window_controller.h"
 #include "workspace_manager.h"
 #include "workspace_observer.h"
@@ -76,9 +78,11 @@ public:
 
 TEST_F(ResizeServiceTest, CanStartResizing)
 {
+    auto shell_application_manager = std::make_shared<ShellApplicationManager>(
+        std::make_unique<::testing::NiceMock<test::MockShellApplicationSpawner>>());
     auto const container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
     auto const parent = std::make_shared<::testing::NiceMock<test::MockParentContainer>>(
-        state, window_controller, config, geom::Rectangle(), nullptr, nullptr, false);
+        shell_application_manager, state, window_controller, config, geom::Rectangle(), nullptr, nullptr, false);
 
     ON_CALL(*container, get_type())
         .WillByDefault(::testing::Return(ContainerType::leaf));
@@ -104,9 +108,11 @@ TEST_F(ResizeServiceTest, CanStartResizing)
 
 TEST_F(ResizeServiceTest, CannotResizeWhenParentHasMoreThanOneChild)
 {
+    auto shell_application_manager = std::make_shared<ShellApplicationManager>(
+        std::make_unique<::testing::NiceMock<test::MockShellApplicationSpawner>>());
     auto const container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
     auto const parent = std::make_shared<::testing::NiceMock<test::MockParentContainer>>(
-        state, window_controller, config, geom::Rectangle(), nullptr, nullptr, false);
+        shell_application_manager, state, window_controller, config, geom::Rectangle(), nullptr, nullptr, false);
 
     ON_CALL(*container, get_type())
         .WillByDefault(::testing::Return(ContainerType::leaf));
@@ -157,9 +163,11 @@ TEST_F(ResizeServiceTest, CannotResizeNonLeafContainer)
 
 TEST_F(ResizeServiceTest, ResizeNorthEdge)
 {
+    auto shell_application_manager = std::make_shared<ShellApplicationManager>(
+        std::make_unique<::testing::NiceMock<test::MockShellApplicationSpawner>>());
     auto const container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
     auto const parent = std::make_shared<::testing::NiceMock<test::MockParentContainer>>(
-        state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
+        shell_application_manager, state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
 
     ON_CALL(*container, get_type())
         .WillByDefault(::testing::Return(ContainerType::leaf));
@@ -185,8 +193,10 @@ TEST_F(ResizeServiceTest, ResizeNorthEdge)
 TEST_F(ResizeServiceTest, ResizeSouthEdge)
 {
     auto const container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
+    auto shell_application_manager = std::make_shared<ShellApplicationManager>(
+        std::make_unique<::testing::NiceMock<test::MockShellApplicationSpawner>>());
     auto const parent = std::make_shared<::testing::NiceMock<test::MockParentContainer>>(
-        state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
+        shell_application_manager, state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
 
     ON_CALL(*container, get_type())
         .WillByDefault(::testing::Return(ContainerType::leaf));
@@ -212,8 +222,10 @@ TEST_F(ResizeServiceTest, ResizeSouthEdge)
 TEST_F(ResizeServiceTest, ResizeEastEdge)
 {
     auto const container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
+    auto shell_application_manager = std::make_shared<ShellApplicationManager>(
+        std::make_unique<::testing::NiceMock<test::MockShellApplicationSpawner>>());
     auto const parent = std::make_shared<::testing::NiceMock<test::MockParentContainer>>(
-        state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
+        shell_application_manager, state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
 
     ON_CALL(*container, get_type())
         .WillByDefault(::testing::Return(ContainerType::leaf));
@@ -239,8 +251,10 @@ TEST_F(ResizeServiceTest, ResizeEastEdge)
 TEST_F(ResizeServiceTest, ResizeWestEdge)
 {
     auto const container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
+    auto shell_application_manager = std::make_shared<ShellApplicationManager>(
+        std::make_unique<::testing::NiceMock<test::MockShellApplicationSpawner>>());
     auto const parent = std::make_shared<::testing::NiceMock<test::MockParentContainer>>(
-        state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
+        shell_application_manager, state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
 
     ON_CALL(*container, get_type())
         .WillByDefault(::testing::Return(ContainerType::leaf));
@@ -266,8 +280,10 @@ TEST_F(ResizeServiceTest, ResizeWestEdge)
 TEST_F(ResizeServiceTest, ResizeNorthEastEdge)
 {
     auto const container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
+    auto shell_application_manager = std::make_shared<ShellApplicationManager>(
+        std::make_unique<::testing::NiceMock<test::MockShellApplicationSpawner>>());
     auto const parent = std::make_shared<::testing::NiceMock<test::MockParentContainer>>(
-        state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
+        shell_application_manager, state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
 
     ON_CALL(*container, get_type())
         .WillByDefault(::testing::Return(ContainerType::leaf));
@@ -293,8 +309,10 @@ TEST_F(ResizeServiceTest, ResizeNorthEastEdge)
 TEST_F(ResizeServiceTest, ResizeNorthWestEdge)
 {
     auto const container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
+    auto shell_application_manager = std::make_shared<ShellApplicationManager>(
+        std::make_unique<::testing::NiceMock<test::MockShellApplicationSpawner>>());
     auto const parent = std::make_shared<::testing::NiceMock<test::MockParentContainer>>(
-        state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
+        shell_application_manager, state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
 
     ON_CALL(*container, get_type())
         .WillByDefault(::testing::Return(ContainerType::leaf));
@@ -320,8 +338,10 @@ TEST_F(ResizeServiceTest, ResizeNorthWestEdge)
 TEST_F(ResizeServiceTest, ResizeSouthEastEdge)
 {
     auto const container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
+    auto shell_application_manager = std::make_shared<ShellApplicationManager>(
+        std::make_unique<::testing::NiceMock<test::MockShellApplicationSpawner>>());
     auto const parent = std::make_shared<::testing::NiceMock<test::MockParentContainer>>(
-        state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
+        shell_application_manager, state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
 
     ON_CALL(*container, get_type())
         .WillByDefault(::testing::Return(ContainerType::leaf));
@@ -347,8 +367,10 @@ TEST_F(ResizeServiceTest, ResizeSouthEastEdge)
 TEST_F(ResizeServiceTest, ResizeSouthWestEdge)
 {
     auto const container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
+    auto shell_application_manager = std::make_shared<ShellApplicationManager>(
+        std::make_unique<::testing::NiceMock<test::MockShellApplicationSpawner>>());
     auto const parent = std::make_shared<::testing::NiceMock<test::MockParentContainer>>(
-        state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
+        shell_application_manager, state, window_controller, config, geom::Rectangle(geom::Point(100, 100), geom::Size(200, 200)), nullptr, nullptr, false);
 
     ON_CALL(*container, get_type())
         .WillByDefault(::testing::Return(ContainerType::leaf));
@@ -374,8 +396,10 @@ TEST_F(ResizeServiceTest, ResizeSouthWestEdge)
 TEST_F(ResizeServiceTest, StopsResizingWhenButtonReleased)
 {
     auto const container = std::make_shared<::testing::NiceMock<test::MockContainer>>();
+    auto shell_application_manager = std::make_shared<ShellApplicationManager>(
+        std::make_unique<::testing::NiceMock<test::MockShellApplicationSpawner>>());
     auto const parent = std::make_shared<::testing::NiceMock<test::MockParentContainer>>(
-        state, window_controller, config, geom::Rectangle(), nullptr, nullptr, false);
+        shell_application_manager, state, window_controller, config, geom::Rectangle(), nullptr, nullptr, false);
 
     ON_CALL(*container, get_type())
         .WillByDefault(::testing::Return(ContainerType::leaf));

--- a/tests/test_workspace.cpp
+++ b/tests/test_workspace.cpp
@@ -19,9 +19,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "leaf_container.h"
 #include "mock_output.h"
 #include "mock_output_factory.h"
+#include "mock_shell_application_spawner.h"
 #include "output_manager.h"
 #include "parent_container.h"
 #include "passthrough_server_action_queue.h"
+#include "shell_application_manager.h"
 #include "stub_configuration.h"
 #include "stub_surface.h"
 #include "stub_window_controller.h"
@@ -71,7 +73,10 @@ public:
         state(std::make_shared<CompositorState>()),
         output(create_output(OUTPUT_SIZE)),
         window_controller(std::make_shared<StubWindowController>(pairs)),
+        shell_application_manager(std::make_shared<ShellApplicationManager>(
+            std::make_unique<NiceMock<test::MockShellApplicationSpawner>>())),
         workspace(std::make_shared<Workspace>(
+            shell_application_manager,
             output,
             0,
             0,
@@ -115,6 +120,7 @@ public:
     std::vector<StubWindowData> pairs;
     std::shared_ptr<test::MockOutput> output;
     std::shared_ptr<StubWindowController> window_controller;
+    std::shared_ptr<ShellApplicationManager> shell_application_manager;
     std::shared_ptr<WorkspaceObserverRegistrar> registry = std::make_shared<WorkspaceObserverRegistrar>();
     std::shared_ptr<Animator> animator = std::make_shared<Animator>();
     std::shared_ptr<PluginManager> plugin_manager = std::make_shared<PluginManager>();
@@ -227,6 +233,7 @@ TEST_F(WorkspaceTest, CanMoveContainerToContainerInOtherTree)
 {
     auto other_output = create_output(OTHER_OUTPUT_SIZE);
     auto const other = std::make_shared<Workspace>(
+        shell_application_manager,
         other_output,
         1,
         1,
@@ -253,6 +260,7 @@ TEST_F(WorkspaceTest, CanMoveContainerToTree)
 {
     auto const other_output = create_output(OTHER_OUTPUT_SIZE);
     auto other = std::make_shared<Workspace>(
+        shell_application_manager,
         other_output,
         1,
         1,
@@ -314,6 +322,7 @@ TEST_F(WorkspaceTest, WorkspaceBoundsAreInitializedToFirstZoneSizeWhenAppZonesAr
     ON_CALL(*output, get_app_zones())
         .WillByDefault(ReturnRef(zones));
     auto const other = std::make_shared<Workspace>(
+        shell_application_manager,
         output,
         1,
         1,


### PR DESCRIPTION
## What's new?
- Floating containers can now use a shell element as a background
- Introduced the `ShellApplicationManager` and `ShellApplicationSpawner`
- Hid the current implementation behind a feature flag, but it is functional

## What's next?
- [ ] Write tests
- [ ] Make it configurable (and maybe use opengl to render)
- [ ] Remove the feature flag