### PR TITLE
HACK: Handle outputs without current mode

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -429,11 +429,14 @@ nlohmann::json Output::to_json(bool is_focused) const
         modes_node.push_back(mode_node);
     }
 
-    auto const& current_mode = output_config.modes[output_config.current_mode_index];
     nlohmann::json current_mode_node;
-    current_mode_node["width"] = current_mode.size.width.as_int();
-    current_mode_node["height"] = current_mode.size.height.as_int();
-    current_mode_node["refresh"] = current_mode.vrefresh_hz * 1000;
+    if (output_config.current_mode_index != std::numeric_limits<unsigned>::max())
+    {
+        auto const& current_mode = output_config.modes[output_config.current_mode_index];
+        current_mode_node["width"] = current_mode.size.width.as_int();
+        current_mode_node["height"] = current_mode.size.height.as_int();
+        current_mode_node["refresh"] = current_mode.vrefresh_hz * 1000;
+    }
 
     nlohmann::json transform;
     switch (output_config.orientation)
@@ -528,11 +531,14 @@ nlohmann::json Output::get_outputs_json(bool) const
         modes_node.push_back(mode_node);
     }
 
-    auto const& current_mode = output_config.modes[output_config.current_mode_index];
     nlohmann::json current_mode_node;
-    current_mode_node["width"] = current_mode.size.width.as_int();
-    current_mode_node["height"] = current_mode.size.height.as_int();
-    current_mode_node["refresh"] = current_mode.vrefresh_hz * 1000;
+    if (output_config.current_mode_index != std::numeric_limits<unsigned>::max())
+    {
+        auto const& current_mode = output_config.modes[output_config.current_mode_index];
+        current_mode_node["width"] = current_mode.size.width.as_int();
+        current_mode_node["height"] = current_mode.size.height.as_int();
+        current_mode_node["refresh"] = current_mode.vrefresh_hz * 1000;
+    }
 
     auto const primary = is_primary();
 

--- a/src/wlr-ouput-management-unstable-v1.cpp
+++ b/src/wlr-ouput-management-unstable-v1.cpp
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
+#include <limits>
 #define MIR_LOG_COMPONENT "wlr-output-management-unstable-v1"
 
 #include "wlr-ouput-management-unstable-v1.h"
@@ -505,7 +506,10 @@ void WlrOutputHeadV1::send_initial()
     send_description_event("");
     send_physical_size_event(output.physical_size_mm().width, output.physical_size_mm().height);
     send_enabled_event(output.used());
-    send_current_mode_event(modes[config.current_mode_index]->resource);
+    if (config.current_mode_index != std::numeric_limits<unsigned>::max())
+    {
+        send_current_mode_event(modes[config.current_mode_index]->resource);
+    }
     send_position_event(output.extents().top_left.x.as_int(), output.extents().top_left.y.as_int());
     // TODO: Send the transform event via send_transform_event()
     send_scale_event(output.scale());
@@ -526,7 +530,7 @@ void WlrOutputHeadV1::update(miral::Output const& updated, OutputConfigDetails c
     if (output.used() != updated.used())
         send_enabled_event(updated.used());
 
-    if (config.current_mode_index != updated_config.current_mode_index)
+    if (config.current_mode_index != updated_config.current_mode_index && updated_config.current_mode_index != std::numeric_limits<unsigned>::max())
         send_current_mode_event(modes[updated_config.current_mode_index]->resource);
 
     if (output.extents() != updated.extents())


### PR DESCRIPTION
This is something of an issue report, but I hackily fixed it locally so it's in the form of a PR.

Miracle crashes when an IPC client tries to get the display config if not all outputs have a current mode set, because it attempts to access `current_output.modes[4294967295]` (as an output without current mode has its current mode index set to `(unsigned int)-1`).