### PR TITLE
bugfix: lots of fixed to window management

### DIFF
--- a/src/abstract_workspace.h
+++ b/src/abstract_workspace.h
@@ -106,7 +106,7 @@ public:
     [[nodiscard]] virtual nlohmann::json to_json(bool is_output_focused) const = 0;
     [[nodiscard]] virtual std::string display_name() const = 0;
     [[nodiscard]] virtual std::shared_ptr<ParentContainer> get_root() const = 0;
-    virtual void add_other_container(std::shared_ptr<Container> const& container) = 0;
+    virtual void add_other_container(std::shared_ptr<Container> const& container, bool is_active) = 0;
     virtual void remove_other_container(std::shared_ptr<Container> const& container) = 0;
 };
 }

--- a/src/command_controller.cpp
+++ b/src/command_controller.cpp
@@ -231,7 +231,7 @@ std::shared_ptr<WindowContainer> CommandController::create_container(miral::Wind
             hint.alpha,
             hint.resizable,
             hint.movable);
-        workspace->add_other_container(container);
+        workspace->add_other_container(container, output_manager->focused()->active() == workspace);
     }
     break;
     case AllocationType::freestyle:
@@ -259,7 +259,7 @@ std::shared_ptr<WindowContainer> CommandController::create_container(miral::Wind
             workspace,
             config,
             has_border);
-        workspace->add_other_container(container);
+        workspace->add_other_container(container, output_manager->focused()->active() == workspace);
 
         spec.min_width() = mir::geometry::Width(0);
         spec.min_height() = mir::geometry::Height(0);
@@ -289,7 +289,11 @@ std::shared_ptr<WindowContainer> CommandController::create_container(miral::Wind
         break;
     }
 
-    container->set_animation_alpha(0.0f);
+    // If we already have a buffer, then we should maintain it being shown on screen.
+    if (!hint.has_buffer)
+    {
+        container->set_animation_alpha(0.0f);
+    }
     spec.userdata() = container;
     window_controller->modify(window_info.window(), spec);
 
@@ -1170,6 +1174,8 @@ bool CommandController::toggle_floating_internal(std::shared_ptr<Container> cons
         if (!focused_output)
             return false;
 
+        animator->remove_by_animation_handle(wc->animation_handle());
+
         // Remove the container from whatever workspace it is on.
         auto const workspace = wc->get_workspace();
         workspace->delete_container(container);
@@ -1179,24 +1185,35 @@ bool CommandController::toggle_floating_internal(std::shared_ptr<Container> cons
         // of cleanup around the `miral::Window` in particular.
         state->remove(wc);
         scratchpad_->remove(wc);
-        animator->remove_by_animation_handle(wc->animation_handle());
 
-        auto const& window_info = window_controller->info_for(wc->window().value());
+        auto& window_info = window_controller->info_for(wc->window().value());
         if (auto const leaf = Container::as_leaf(wc))
         {
             // We are in a grid, let's remove it and make it a freestyle container.
-            auto const new_container = create_container(window_info, AllocationHint { .container_type = AllocationType::freestyle, .workspace = workspace.get() });
-            new_container->handle_ready();
+            auto const old_area = wc->get_visible_area();
+            auto const new_container = create_container(window_info, AllocationHint { .container_type = AllocationType::freestyle, .workspace = workspace.get(), .has_buffer = true });
+            if (!new_container)
+            {
+                mir::log_error("Cannot float the currently selected window");
+                return false;
+            }
+
             auto const& output_area = focused_output->get_area();
             auto constexpr floated_size = 0.85f;
             auto constexpr gap_size = 1.f - floated_size;
             auto const gap_x = output_area.size.width.as_int() * gap_size / 2.f;
             auto const gap_y = output_area.size.height.as_int() * gap_size / 2.f;
-            new_container->set_logical_area(geom::Rectangle {
-                                                geom::Point { output_area.top_left.x.as_int() + gap_x,        output_area.top_left.y.as_int() + gap_y         },
-                                                geom::Size { output_area.size.width.as_int() * floated_size, output_area.size.height.as_int() * floated_size }
+            miral::WindowSpecification spec;
+            window_controller->modify(window_info.window(), spec);
+            window_controller->set_rectangle(
+                window_info.window(),
+                old_area,
+                geom::Rectangle {
+                    geom::Point { output_area.top_left.x.as_int() + gap_x,        output_area.top_left.y.as_int() + gap_y         },
+                    geom::Size { output_area.size.width.as_int() * floated_size, output_area.size.height.as_int() * floated_size }
             },
                 true);
+            window_controller->select_active_window(new_container->window().value());
         }
         else
         {
@@ -1208,8 +1225,14 @@ bool CommandController::toggle_floating_internal(std::shared_ptr<Container> cons
             auto const floating_area = wc->get_visible_area();
 
             auto const active = focused_output->active()->get_root();
-            auto const new_container = create_container(window_info, AllocationHint { AllocationType::grid, active.get(), workspace.get() });
-            new_container->handle_ready();
+            auto hint = AllocationHint { AllocationType::grid, active.get(), workspace.get() };
+            hint.has_buffer = true;
+            auto const new_container = create_container(window_info, hint);
+            if (!new_container)
+            {
+                mir::log_error("Cannot unfloat the currently selected window");
+                return false;
+            }
 
             // Animate from the floating position to the new grid position.
             miral::WindowSpecification spec;
@@ -1279,7 +1302,7 @@ bool CommandController::toggle_pinned_to_workspace(std::vector<ContainerScope> c
             {
                 if (auto const workspace = output_manager->focused()->active())
                 {
-                    workspace->add_other_container(container);
+                    workspace->add_other_container(container, true);
                     container->set_workspace(workspace);
                 }
             }
@@ -1313,7 +1336,7 @@ bool CommandController::set_is_pinned(bool pinned, std::vector<ContainerScope> c
             {
                 if (auto const workspace = output_manager->focused()->active())
                 {
-                    workspace->add_other_container(container);
+                    workspace->add_other_container(container, true);
                     container->set_workspace(workspace);
                 }
             }

--- a/src/freestyle_window_container.cpp
+++ b/src/freestyle_window_container.cpp
@@ -80,7 +80,10 @@ geom::Rectangle FreestyleWindowContainer::get_visible_area() const
 void FreestyleWindowContainer::constrain()
 {
     auto const w = window_sync.lock()->window_;
-    window_controller->noclip(w);
+    if (is_fullscreen() || !has_border_)
+        window_controller->noclip(w);
+    else
+        window_controller->clip(w, get_visible_area());
 }
 
 std::weak_ptr<ParentContainer> FreestyleWindowContainer::get_parent() const

--- a/src/freestyle_window_container.cpp
+++ b/src/freestyle_window_container.cpp
@@ -47,17 +47,18 @@ FreestyleWindowContainer::FreestyleWindowContainer(
 void FreestyleWindowContainer::show()
 {
     auto const w = window_sync.lock()->window_;
-    auto show_state = sync.lock()->cached_state.value_or(mir_window_state_restored);
-    if (show_state == mir_window_state_hidden)
-        show_state = mir_window_state_restored;
-    window_controller->change_state(w, show_state);
+    auto restore = sync.lock()->restore_result;
+    sync.lock()->restore_result.reset();
+    if (restore)
+        window_controller->show(w, restore.value());
+    else
+        window_controller->show(w, { mir_window_state_restored, w.top_left() });
 }
 
 void FreestyleWindowContainer::hide()
 {
     auto const w = window_sync.lock()->window_;
-    sync.lock()->cached_state = window_controller->info_for(w).state();
-    window_controller->change_state(w, mir_window_state_hidden);
+    sync.lock()->restore_result = window_controller->hide(w);
 }
 
 geom::Rectangle FreestyleWindowContainer::get_logical_area() const
@@ -79,10 +80,7 @@ geom::Rectangle FreestyleWindowContainer::get_visible_area() const
 void FreestyleWindowContainer::constrain()
 {
     auto const w = window_sync.lock()->window_;
-    if (is_fullscreen() || sync.lock()->is_dragging_)
-        window_controller->noclip(w);
-    else
-        window_controller->clip(w, get_visible_area());
+    window_controller->noclip(w);
 }
 
 std::weak_ptr<ParentContainer> FreestyleWindowContainer::get_parent() const

--- a/src/freestyle_window_container.h
+++ b/src/freestyle_window_container.h
@@ -20,10 +20,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "synchronized_recursive.h"
 #include "window_container.h"
+#include "window_controller.h"
 
 namespace miracle
 {
-class WindowController;
 class CompositorState;
 class Config;
 
@@ -103,7 +103,7 @@ private:
     struct State
     {
         std::weak_ptr<AbstractWorkspace> workspace_;
-        std::optional<MirWindowState> cached_state;
+        std::optional<RestoreResult> restore_result;
         std::optional<MirWindowState> next_state;
         std::optional<geom::Rectangle> pre_fullscreen_area;
         std::optional<MirDepthLayer> next_depth_layer;

--- a/src/leaf_container.cpp
+++ b/src/leaf_container.cpp
@@ -396,23 +396,18 @@ bool LeafContainer::set_size(std::optional<int> const& width, std::optional<int>
 
 void LeafContainer::show()
 {
-    {
-        auto s = sync.lock();
-        s->next_state = s->before_shown_state;
-        s->before_shown_state.reset();
-    }
-    commit_changes();
-    window_controller->raise(window_sync.lock()->window_);
+    auto const w = window_sync.lock()->window_;
+    auto restore = sync.lock()->restore_result;
+    sync.lock()->restore_result.reset();
+    if (restore)
+        window_controller->show(w, restore.value());
+    window_controller->raise(w);
 }
 
 void LeafContainer::hide()
 {
     auto const w = window_sync.lock()->window_;
-    auto s = sync.lock();
-    s->before_shown_state = window_controller->get_state(w);
-    s->next_state = mir_window_state_hidden;
-    s.drop();
-    commit_changes();
+    sync.lock()->restore_result = window_controller->hide(w);
     window_controller->send_to_back(w);
 }
 

--- a/src/leaf_container.h
+++ b/src/leaf_container.h
@@ -116,7 +116,7 @@ private:
         std::optional<geom::Rectangle> next_logical_area;
         bool next_with_animations = true;
         std::weak_ptr<ParentContainer> parent;
-        std::optional<MirWindowState> before_shown_state;
+        std::optional<RestoreResult> restore_result;
         std::optional<MirWindowState> next_state;
         std::optional<MirDepthLayer> next_depth_layer;
         bool is_dragging_ = false;

--- a/src/plugin_bridge.cpp
+++ b/src/plugin_bridge.cpp
@@ -578,7 +578,7 @@ int32_t PluginBridge::window_set_workspace(uint64_t window_internal, uint64_t wo
     if (auto const old_ws = container->get_workspace())
         old_ws->remove_other_container(container);
 
-    new_ws->add_other_container(container);
+    new_ws->add_other_container(container, output_manager->focused()->active() == new_ws);
     return 0;
 }
 

--- a/src/plugin_managed_container.cpp
+++ b/src/plugin_managed_container.cpp
@@ -53,7 +53,6 @@ PluginManagedContainer::PluginManagedContainer(
     compositor_state { compositor_state },
     config { config },
     sync { State {
-        .cached = window_controller->info_for(window).state(),
         .workspace_ = workspace,
     } }
 {
@@ -67,17 +66,18 @@ PluginManagedContainer::PluginManagedContainer(
 void PluginManagedContainer::show()
 {
     auto const w = window_sync.lock()->window_;
-    auto show_state = sync.lock()->cached.value_or(mir_window_state_restored);
-    if (show_state == mir_window_state_hidden)
-        show_state = mir_window_state_restored;
-    window_controller->change_state(w, show_state);
+    auto restore = sync.lock()->restore_result;
+    sync.lock()->restore_result.reset();
+    if (restore)
+        window_controller->show(w, restore.value());
+    else
+        window_controller->show(w, { mir_window_state_restored, w.top_left() });
 }
 
 void PluginManagedContainer::hide()
 {
     auto const w = window_sync.lock()->window_;
-    sync.lock()->cached = window_controller->info_for(w).state();
-    window_controller->change_state(w, mir_window_state_hidden);
+    sync.lock()->restore_result = window_controller->hide(w);
 }
 
 geom::Rectangle PluginManagedContainer::get_logical_area() const

--- a/src/plugin_managed_container.h
+++ b/src/plugin_managed_container.h
@@ -22,10 +22,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "render_data_manager.h"
 #include "synchronized_recursive.h"
 #include "window_container.h"
+#include "window_controller.h"
 
 namespace miracle
 {
-class WindowController;
 class CompositorState;
 class Config;
 
@@ -113,7 +113,7 @@ public:
 private:
     struct State
     {
-        std::optional<MirWindowState> cached;
+        std::optional<RestoreResult> restore_result;
         std::optional<MirWindowState> next_state;
         std::optional<geom::Rectangle> pre_fullscreen_area;
         std::optional<MirDepthLayer> next_depth_layer;

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -106,12 +106,6 @@ public:
         if (old)
         {
             auto const& last_workspace = policy.workspace_manager->workspace(old.value());
-            if (!last_workspace)
-            {
-                mir::log_error("Policy::Self::on_focused missing last workspace");
-                return;
-            }
-
             auto const& next_workspace = policy.workspace_manager->workspace(next);
             if (!next_workspace)
             {
@@ -119,7 +113,7 @@ public:
                 return;
             }
 
-            if (last_workspace->get_output() != next_workspace->get_output())
+            if (last_workspace && last_workspace->get_output() != next_workspace->get_output())
                 policy.command_controller->move_cursor_to_output(*next_workspace->get_output());
         }
 

--- a/src/window_allocation.h
+++ b/src/window_allocation.h
@@ -58,6 +58,7 @@ struct AllocationHint
     float alpha = 1.f;
     bool resizable = true;
     bool movable = true;
+    bool has_buffer = false;
 };
 }
 

--- a/src/window_controller.h
+++ b/src/window_controller.h
@@ -31,6 +31,12 @@ namespace miracle
 class Container;
 class WindowContainer;
 
+struct RestoreResult
+{
+    MirWindowState state;
+    geom::Point position;
+};
+
 /**
  * The sole interface for making changes to a window. This interface allows
  * all interactions with a window to be testable.
@@ -59,6 +65,10 @@ public:
     virtual miral::Window window_at(float x, float y) = 0;
     virtual void process_animation(AnimationFrameResult const&, std::shared_ptr<Container> const&) = 0;
     virtual void invoke_under_lock(std::function<void()> const& f) = 0;
+    virtual void move_to_offscreen_workspace(miral::Window const&) = 0;
+    virtual void move_to_onscreen_workspace(miral::Window const&) = 0;
+    virtual RestoreResult hide(miral::Window const&) = 0;
+    virtual void show(miral::Window const&, RestoreResult const&) = 0;
 };
 
 }

--- a/src/window_manager_tools_window_controller.cpp
+++ b/src/window_manager_tools_window_controller.cpp
@@ -321,3 +321,54 @@ void WindowManagerToolsWindowController::invoke_under_lock(std::function<void()>
 {
     tools.invoke_under_lock(f);
 }
+
+RestoreResult WindowManagerToolsWindowController::hide(miral::Window const& window)
+{
+    RestoreResult result {
+        .state = get_state(window),
+        .position = window.top_left()
+    };
+    move_to_offscreen_workspace(window);
+    // HACK: Move the window far offscreen to work around an X11 bug where windows
+    // assigned to the offscreen workspace may still be visible. This may be
+    // resolved in a future Mir release.
+    miral::WindowSpecification spec;
+    spec.top_left() = geom::Point { 1000000, 1000000 };
+    tools.modify_window(window, spec);
+    change_state(window, mir_window_state_hidden);
+    return result;
+}
+
+void WindowManagerToolsWindowController::show(miral::Window const& window, RestoreResult const& result)
+{
+    move_to_onscreen_workspace(window);
+    miral::WindowSpecification spec;
+    spec.top_left() = result.position;
+    tools.modify_window(window, spec);
+    auto const restore_state = result.state == mir_window_state_hidden
+        ? mir_window_state_restored
+        : result.state;
+    change_state(window, restore_state);
+}
+
+void WindowManagerToolsWindowController::move_to_offscreen_workspace(miral::Window const& window)
+{
+    if (!offscreen)
+        offscreen = tools.create_workspace();
+
+    if (onscreen)
+        tools.remove_tree_from_workspace(window, onscreen);
+
+    tools.add_tree_to_workspace(window, offscreen);
+}
+
+void WindowManagerToolsWindowController::move_to_onscreen_workspace(miral::Window const& window)
+{
+    if (!onscreen)
+        onscreen = tools.create_workspace();
+
+    if (offscreen)
+        tools.remove_tree_from_workspace(window, offscreen);
+
+    tools.add_tree_to_workspace(window, onscreen);
+}

--- a/src/window_manager_tools_window_controller.h
+++ b/src/window_manager_tools_window_controller.h
@@ -23,6 +23,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "window_controller.h"
 #include <miral/window_manager_tools.h>
 
+namespace miral
+{
+class Workspace;
+}
+
 namespace miracle
 {
 class CompositorState;
@@ -60,6 +65,10 @@ public:
     miral::Window window_at(float x, float y) override;
     void process_animation(AnimationFrameResult const&, std::shared_ptr<Container> const&) override;
     void invoke_under_lock(std::function<void()> const& f) override;
+    void move_to_offscreen_workspace(miral::Window const&) override;
+    void move_to_onscreen_workspace(miral::Window const&) override;
+    RestoreResult hide(miral::Window const&) override;
+    void show(miral::Window const&, RestoreResult const&) override;
 
 private:
     miral::WindowManagerTools tools;
@@ -69,6 +78,9 @@ private:
     std::shared_ptr<CompositorState> state;
     std::shared_ptr<Config> config;
     std::shared_ptr<WindowIdMap> window_id_map;
+
+    std::shared_ptr<miral::Workspace> onscreen;
+    std::shared_ptr<miral::Workspace> offscreen;
 };
 }
 

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -209,7 +209,7 @@ void Workspace::show(geom::Point const& origin)
 {
     if (!config->are_animations_enabled() || origin == geom::Point(0, 0))
     {
-        on_animation_end(false);
+        on_animation_start(false);
         return;
     }
 
@@ -459,7 +459,8 @@ void Workspace::graft(std::shared_ptr<Container> const& container)
 {
     if (container->plugin_handle().has_value() || std::dynamic_pointer_cast<FreestyleWindowContainer>(container))
     {
-        add_other_container(container);
+        // TODO: Assuming that this is always called on the active workspace
+        add_other_container(container, true);
     }
     else if (auto const leaf = Container::as_leaf(container))
     {
@@ -531,20 +532,20 @@ float Workspace::alpha() const
 
 void Workspace::on_animation_start(bool is_hiding)
 {
-    // HACK: miral will try to select a newly visible window if none is currently
-    // selected. In most instances, we do not want this, as we would rather
-    // select our [last_selected_container] instead. To work around this, we set
-    // a flag that tells miral not to select the last focused container while we
-    // are in the process of becoming visible.
-    sync.lock()->is_showing = true;
-    for_each_container([](auto const& container)
-    {
-        container->show();
-    });
-    sync.lock()->is_showing = false;
-
     if (!is_hiding)
     {
+        // HACK: miral will try to select a newly visible window if none is currently
+        // selected. In most instances, we do not want this, as we would rather
+        // select our [last_selected_container] instead. To work around this, we set
+        // a flag that tells miral not to select the last focused container while we
+        // are in the process of becoming visible.
+        sync.lock()->is_showing = true;
+        for_each_container([](auto const& container)
+        {
+            container->show();
+        });
+        sync.lock()->is_showing = false;
+
         if (auto const sh_last_selected = sync.lock()->last_selected_container.lock())
         {
             if (sh_last_selected->window().has_value())
@@ -552,7 +553,7 @@ void Workspace::on_animation_start(bool is_hiding)
             return;
         }
 
-        for_each_window([&](std::shared_ptr<WindowContainer> const& container)
+        if (!for_each_window([&](std::shared_ptr<WindowContainer> const& container)
         {
             if (container->window().has_value())
             {
@@ -561,7 +562,10 @@ void Workspace::on_animation_start(bool is_hiding)
             }
 
             return false;
-        });
+        }))
+        {
+            window_controller->select_active_window({});
+        }
     }
 }
 
@@ -591,11 +595,11 @@ ParentContainer* Workspace::get_layout_container() const
     return parent.get();
 }
 
-void Workspace::add_other_container(std::shared_ptr<Container> const& container)
+void Workspace::add_other_container(std::shared_ptr<Container> const& container, bool is_active)
 {
     container->set_workspace(shared_from_this());
     other_containers.push_back(container);
-    if (sync.lock()->is_showing)
+    if (is_active)
         container->show();
     else
         container->hide();
@@ -611,7 +615,9 @@ void Workspace::remove_other_container(std::shared_ptr<Container> const& contain
 
 void Workspace::for_each_container(std::function<void(std::shared_ptr<Container> const&)> const& f)
 {
-    f(root_);
+    if (root_)
+        f(root_);
+
     for (auto const& other : other_containers)
     {
         if (auto const lock = other.lock())

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -91,7 +91,7 @@ public:
     [[nodiscard]] std::string display_name() const override;
     [[nodiscard]] std::shared_ptr<ParentContainer> get_root() const override;
     ParentContainer* get_layout_container() const override;
-    void add_other_container(std::shared_ptr<Container> const& container) override;
+    void add_other_container(std::shared_ptr<Container> const& container, bool is_active) override;
     void remove_other_container(std::shared_ptr<Container> const& container) override;
 
 private:

--- a/tests/mock_window_controller.h
+++ b/tests/mock_window_controller.h
@@ -32,6 +32,10 @@ namespace test
         MOCK_METHOD(miral::Window, window_at, (float, float), (override));
         MOCK_METHOD(void, process_animation, (AnimationFrameResult const&, std::shared_ptr<Container> const&), (override));
         MOCK_METHOD(void, invoke_under_lock, (std::function<void()> const&), (override));
+        MOCK_METHOD(void, move_to_offscreen_workspace, (miral::Window const&), (override));
+        MOCK_METHOD(void, move_to_onscreen_workspace, (miral::Window const&), (override));
+        MOCK_METHOD(RestoreResult, hide, (miral::Window const&), (override));
+        MOCK_METHOD(void, show, (miral::Window const&, RestoreResult const&), (override));
     };
 
 } // namespace test

--- a/tests/mock_workspace.h
+++ b/tests/mock_workspace.h
@@ -78,7 +78,7 @@ namespace test
 
         MOCK_METHOD(ParentContainer*, get_layout_container, (), (const, override));
 
-        MOCK_METHOD(void, add_other_container, (std::shared_ptr<Container> const&), (override));
+        MOCK_METHOD(void, add_other_container, (std::shared_ptr<Container> const&, bool), (override));
         MOCK_METHOD(void, remove_other_container, (std::shared_ptr<Container> const&), (override));
     };
 }

--- a/tests/stub_window_controller.h
+++ b/tests/stub_window_controller.h
@@ -143,6 +143,11 @@ public:
         f();
     }
 
+    void move_to_offscreen_workspace(miral::Window const&) override { }
+    void move_to_onscreen_workspace(miral::Window const&) override { }
+    miracle::RestoreResult hide(miral::Window const&) override { return { mir_window_state_restored, {} }; }
+    void show(miral::Window const&, miracle::RestoreResult const&) override { }
+
 private:
     std::vector<StubWindowData>& pairs;
     miral::WindowInfo stub_win_info;

--- a/tests/test_workspace.cpp
+++ b/tests/test_workspace.cpp
@@ -391,14 +391,14 @@ TEST_F(WorkspaceTest, AddOtherContainer_MakesWorkspaceNonEmpty)
 {
     auto container = std::make_shared<NiceMock<test::MockContainer>>();
     EXPECT_TRUE(workspace->is_empty());
-    workspace->add_other_container(container);
+    workspace->add_other_container(container, false);
     EXPECT_FALSE(workspace->is_empty());
 }
 
 TEST_F(WorkspaceTest, RemoveOtherContainer_EmptiesWorkspaceWhenTilingRootAlsoEmpty)
 {
     auto container = std::make_shared<NiceMock<test::MockContainer>>();
-    workspace->add_other_container(container);
+    workspace->add_other_container(container, false);
     workspace->remove_other_container(container);
     EXPECT_TRUE(workspace->is_empty());
 }
@@ -415,7 +415,7 @@ TEST_F(WorkspaceTest, DeleteOtherContainer_NotifiesEmpty)
     registry->register_interest(observer);
 
     auto container = std::make_shared<NiceMock<test::MockContainer>>();
-    workspace->add_other_container(container);
+    workspace->add_other_container(container, false);
 
     EXPECT_CALL(*observer, on_workspace_empty);
     workspace->delete_container(container);
@@ -425,7 +425,7 @@ TEST_F(WorkspaceTest, IsEmpty_FalseWhenTiledWindowExistsAlongsideOtherContainer)
 {
     auto leaf = create_leaf();
     auto container = std::make_shared<NiceMock<test::MockContainer>>();
-    workspace->add_other_container(container);
+    workspace->add_other_container(container, false);
     EXPECT_FALSE(workspace->is_empty());
 }
 
@@ -441,7 +441,7 @@ TEST_F(WorkspaceTest, ToJson_OtherContainerAppearsInFloatingNodes)
 
     auto container = std::make_shared<NiceMock<test::MockContainer>>();
     ON_CALL(*container, to_json(_)).WillByDefault(Return(nlohmann::json::object()));
-    workspace->add_other_container(container);
+    workspace->add_other_container(container, false);
 
     auto const j = workspace->to_json(false);
     EXPECT_EQ(j["floating_nodes"].size(), 1u);


### PR DESCRIPTION
- Fixing window flicker when windows are floated
- Fixing poor selection of windows when switching workspaces
- Introducing a huge hack to move windows offscreen when they are hidden so that X11 parent windows do not interfere in input
- Fixing a bug where plugins might miss a workspace notif