### PR TITLE
bugfix: keep WasmEdge out of main build so that we don't accidentally bring in two version of llvm which cause us to fail to render

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,8 @@ add_library(miracle-wm-implementation STATIC
         src/binding_event.cpp
         src/magnifier_wrapper.cpp
         src/math_helpers.cpp
-        src/plugin_manager.cpp
+        src/plugin_manager_null.cpp
+        src/plugin_manager_loader.cpp
         src/plugin_bridge.h src/plugin_bridge.cpp
         src/shell_application_manager.cpp src/shell_application_manager.h
         src/shell_application_spawner.h
@@ -199,7 +200,10 @@ add_library(miracle-wm-implementation STATIC
         src/sampler_registry.h src/sampler_registry.cpp
 )
 
-target_compile_definitions(miracle-wm-implementation PRIVATE COMPILING_AGAINST_DEV=${COMPILING_AGAINST_DEV} FEATURE_PLUGIN_SYSTEM=${FEATURE_PLUGIN_SYSTEM})
+target_compile_definitions(miracle-wm-implementation PRIVATE
+        COMPILING_AGAINST_DEV=${COMPILING_AGAINST_DEV}
+        FEATURE_PLUGIN_SYSTEM=${FEATURE_PLUGIN_SYSTEM}
+        MIRACLE_PLUGIN_MODULE_PATH="${CMAKE_INSTALL_FULL_LIBDIR}/libmiracle-wm-plugins.so")
 
 # ----------------------------------------
 # Precompiled headers for speed
@@ -251,10 +255,6 @@ target_include_directories(miracle-wm-implementation PUBLIC SYSTEM
         ${CMAKE_CURRENT_BINARY_DIR}/src
 )
 
-if (FEATURE_PLUGIN_SYSTEM)
-  target_include_directories(miracle-wm-implementation PRIVATE ${WASMEDGE_INCLUDE_DIR})
-endif()
-
 target_link_libraries(miracle-wm-implementation
         ${MIRAL_LDFLAGS}
         ${MIRRENDERER_LDFLAGS}
@@ -274,8 +274,37 @@ target_link_libraries(miracle-wm-implementation
         xdg-shell-protocol
 )
 
+# ----------------------------------------
+# miracle-wm-plugins shared module (WasmEdge-backed plugin system)
+# ----------------------------------------
+# The WasmEdge runtime links LLVM. When that LLVM sits in the process's global
+# symbol scope it interposes on Mesa's software renderer (llvmpipe), which also
+# uses LLVM, and breaks rendering (issue #865 — black screen in QEMU). To avoid
+# this, the WasmEdge-backed PluginManager lives in its own shared module that the
+# main binary loads with dlopen()/RTLD_LOCAL only when needed, so libwasmedge and
+# its LLVM never enter the global scope. The module resolves host symbols against
+# the main executable at load time (hence ENABLE_EXPORTS on miracle-wm below).
 if (FEATURE_PLUGIN_SYSTEM)
-  target_link_libraries(miracle-wm-implementation ${WASMEDGE_LIB})
+  add_library(miracle-wm-plugins SHARED src/plugin_manager_impl.cpp)
+
+  target_compile_definitions(miracle-wm-plugins PRIVATE
+          COMPILING_AGAINST_DEV=${COMPILING_AGAINST_DEV}
+          FEATURE_PLUGIN_SYSTEM=1)
+
+  target_include_directories(miracle-wm-plugins PRIVATE SYSTEM
+          $<TARGET_PROPERTY:miracle-wm-implementation,INTERFACE_INCLUDE_DIRECTORIES>
+          ${WASMEDGE_INCLUDE_DIR})
+
+  # miracle-wm-c provides config-cpp headers/symbols; nlohmann is header-only.
+  # The host (miracle-wm-implementation) symbols are intentionally NOT linked
+  # here — they are resolved against the main executable at dlopen() time.
+  target_link_libraries(miracle-wm-plugins
+          PkgConfig::YAML
+          nlohmann_json::nlohmann_json
+          miracle-wm-c
+          ${WASMEDGE_LIB})
+
+  install(TARGETS miracle-wm-plugins DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 # ----------------------------------------
@@ -283,7 +312,13 @@ endif()
 # ----------------------------------------
 add_executable(miracle-wm src/main.cpp)
 target_include_directories(miracle-wm PUBLIC SYSTEM ${MIRAL_INCLUDE_DIRS})
-target_link_libraries(miracle-wm PUBLIC ${MIRAL_LDFLAGS} PRIVATE miracle-wm-implementation)
+# Export the executable's dynamic symbols so the dlopen'd plugin module can
+# resolve host symbols against the main binary, and force every object of the
+# (static) implementation library into the executable so none are dropped.
+set_target_properties(miracle-wm PROPERTIES ENABLE_EXPORTS ON)
+target_link_libraries(miracle-wm
+        PUBLIC ${MIRAL_LDFLAGS}
+        PRIVATE -Wl,--whole-archive miracle-wm-implementation -Wl,--no-whole-archive)
 
 # ----------------------------------------
 # Install rules

--- a/src/plugin_manager.h
+++ b/src/plugin_manager.h
@@ -30,9 +30,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace miral
 {
-class ApplicationInfo;
+struct ApplicationInfo;
 class WindowSpecification;
-class WindowInfo;
+struct WindowInfo;
 }
 
 namespace miracle

--- a/src/plugin_manager.h
+++ b/src/plugin_manager.h
@@ -21,8 +21,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "layout_scheme.h"
 #include "plugin_handle.h"
 #include <glm/glm.hpp>
+#include <memory>
 #include <mir/geometry/rectangle.h>
 #include <miracle/cpp/config-cpp.h>
+#include <miral/toolkit_event.h>
+#include <optional>
+#include <string>
+
+namespace miral
+{
+class ApplicationInfo;
+class WindowSpecification;
+class WindowInfo;
+}
+
 namespace miracle
 {
 class Container;
@@ -68,22 +80,8 @@ struct PluginWindowPlacement
     TiledPlacement tiled;
     FreestylePlacement freestyle;
 };
-}
 
-namespace miracle
-{
 struct AnimationData;
-}
-
-#if FEATURE_PLUGIN_SYSTEM
-#include <memory>
-#include <mir/geometry/point.h>
-#include <mutex>
-#include <vector>
-#include <wasmedge/wasmedge.h>
-
-namespace miracle
-{
 class PluginBridge;
 
 struct PluginLoadResult
@@ -93,18 +91,24 @@ struct PluginLoadResult
     std::string error;
 };
 
+/// Abstract interface to the plugin system.
+///
+/// The concrete, WasmEdge-backed implementation lives in a separate shared
+/// library (libmiracle-wm-plugins.so) that is loaded with `dlopen`/`RTLD_LOCAL`
+/// at runtime by #load_plugin_manager(). Keeping the implementation out of the
+/// main binary keeps WasmEdge's bundled LLVM out of the global symbol scope,
+/// where it would otherwise interpose on Mesa's software renderer (llvmpipe)
+/// and break rendering (see issue #865). All callers interact with the plugin
+/// system through this interface so the main binary never links WasmEdge.
 class PluginManager
 {
 public:
-    ~PluginManager();
+    virtual ~PluginManager() = default;
 
     /// Initialize the plugin bridge.
     ///
     /// This must be called after construction.
-    ///
-    /// TODO: This is a slightly unfortunate thing that I may want to alleviate someday, but
-    ///  for now its not a huge deal.
-    void initialize(std::unique_ptr<PluginBridge> bridge);
+    virtual void initialize(std::unique_ptr<PluginBridge> bridge) = 0;
 
     /// Load a WebAssembly module from the provided \p path.
     ///
@@ -113,23 +117,24 @@ public:
     /// \param path The filesystem path to the WebAssembly module.
     /// \param userdata_json Optional JSON-encoded user data to associate with the plugin.
     /// \returns a load result.
-    PluginLoadResult load_wasm_module(std::string const& path, std::string const& userdata_json = "");
+    virtual PluginLoadResult load_wasm_module(std::string const& path, std::string const& userdata_json = "") = 0;
 
     /// Attempt to unload the WebAssembly module associated with \p handle.
     ///
     /// \returns `true` if the module was unloaded, `false` otherwise.
-    bool unload_wasm_module(PluginHandle handle);
+    virtual bool unload_wasm_module(PluginHandle handle) = 0;
 
     /// Unload all loaded WebAssembly modules.
-    void unload_all();
+    virtual void unload_all() = 0;
 
     /// Animate a frame via the plugin system.
     ///
     /// \param data The animation data to animate.
     /// \param runtime_seconds The current runtime of the animation in seconds.
     /// \returns The result of the animation frame, or none if none is set.
-    std::optional<miracle_plugin_animation_frame_result_t> animate(
-        AnimationData const& data, float runtime_seconds);
+    virtual std::optional<miracle_plugin_animation_frame_result_t> animate(
+        AnimationData const& data, float runtime_seconds)
+        = 0;
 
     /// Tick a custom animation for the given plugin.
     ///
@@ -137,214 +142,66 @@ public:
     /// \param animation_id The host-generated animation ID.
     /// \param dt The time delta in seconds since the last tick.
     /// \param elapsed_seconds The cumulative elapsed time in seconds since the animation started.
-    void custom_animate(PluginHandle plugin_handle, uint32_t animation_id, float dt, float elapsed_seconds);
+    virtual void custom_animate(PluginHandle plugin_handle, uint32_t animation_id, float dt, float elapsed_seconds) = 0;
 
     /// Try to place a new window using a plugin.
     ///
     /// \param app_info The application info.
     /// \param spec The window specification.
     /// \returns the placement
-    std::optional<PluginWindowPlacement> place_new_window(
+    virtual std::optional<PluginWindowPlacement> place_new_window(
         miral::ApplicationInfo const& app_info,
         miral::WindowSpecification const& spec,
-        uint64_t window_id);
+        uint64_t window_id)
+        = 0;
 
     /// Notify all plugins that a window has been deleted.
-    ///
-    /// \param window_info The window info for the deleted window.
-    void window_deleted(miral::WindowInfo const& window_info);
+    virtual void window_deleted(miral::WindowInfo const& window_info) = 0;
 
     /// Notify all plugins that a window has been focused.
-    ///
-    /// \param window_info The window info for the focused window.
-    void window_focused(miral::WindowInfo const& window_info);
+    virtual void window_focused(miral::WindowInfo const& window_info) = 0;
 
     /// Notify all plugins that a window has been unfocused.
-    ///
-    /// \param window_info The window info for the unfocused window.
-    void window_unfocused(miral::WindowInfo const& window_info);
+    virtual void window_unfocused(miral::WindowInfo const& window_info) = 0;
 
     /// Notify all plugins that a workspace has been created.
-    ///
-    /// \param id The ID of the created workspace.
-    void workspace_created(uint32_t id);
+    virtual void workspace_created(uint32_t id) = 0;
 
     /// Notify all plugins that a workspace has been removed.
-    ///
-    /// \param id The ID of the removed workspace.
-    void workspace_removed(uint32_t id);
+    virtual void workspace_removed(uint32_t id) = 0;
 
     /// Notify all plugins that a workspace has gained focus.
-    ///
-    /// \param previous_id The ID of the previously focused workspace, if any.
-    /// \param current_id The ID of the newly focused workspace.
-    void workspace_focused(std::optional<uint32_t> previous_id, uint32_t current_id);
+    virtual void workspace_focused(std::optional<uint32_t> previous_id, uint32_t current_id) = 0;
 
     /// Notify all plugins that a workspace's area has changed.
-    ///
-    /// \param id The ID of the workspace whose area changed.
-    void workspace_area_changed(uint32_t id);
+    virtual void workspace_area_changed(uint32_t id) = 0;
 
     /// Notify all plugins that a window's workspace has changed.
-    ///
-    /// \param window_info The window info for the window that moved.
-    /// \param workspace_id The ID of the new workspace.
-    void window_workspace_changed(miral::WindowInfo const& window_info, uint32_t workspace_id);
+    virtual void window_workspace_changed(miral::WindowInfo const& window_info, uint32_t workspace_id) = 0;
 
     /// Check if the plugin handles a keyboard event.
     ///
-    /// \param event the incoming keyboard event
     /// \returns `true` if the keyboard event was consumed, otherwise `false`
-    bool handle_keyboard_event(MirKeyboardEvent const& event);
+    virtual bool handle_keyboard_event(MirKeyboardEvent const& event) = 0;
 
     /// Check if the plugin handles a pointer event.
     ///
-    /// \param event the incoming pointer event
     /// \returns `true` if the pointer event was consumed, otherwise `false`
-    bool handle_pointer_event(MirPointerEvent const& event);
+    virtual bool handle_pointer_event(MirPointerEvent const& event) = 0;
 
     /// Call the configure() export on every loaded plugin and merge all of their
-    /// results into a single PluginConfigData. Plugins that do not export configure()
-    /// are silently skipped. The plugins and includes fields are never set.
-    PluginConfigData configure();
-
-    /// Data passed to host functions that need both the bridge and the manager.
-    struct HostFunctionData
-    {
-        PluginBridge* bridge = nullptr;
-        PluginManager* manager = nullptr;
-    };
-
-private:
-    struct Self
-    {
-        template <auto DeleteFn>
-        struct WasmEdgeDeleter
-        {
-            template <typename T>
-            void operator()(T* ptr) const noexcept
-            {
-                if (ptr)
-                {
-                    DeleteFn(ptr);
-                }
-            }
-        };
-
-        using ConfigurePtr = std::unique_ptr<WasmEdge_ConfigureContext,
-            WasmEdgeDeleter<WasmEdge_ConfigureDelete>>;
-
-        using StorePtr = std::unique_ptr<WasmEdge_StoreContext,
-            WasmEdgeDeleter<WasmEdge_StoreDelete>>;
-
-        using VMPtr = std::unique_ptr<WasmEdge_VMContext,
-            WasmEdgeDeleter<WasmEdge_VMDelete>>;
-
-        using LoaderPtr = std::unique_ptr<WasmEdge_LoaderContext,
-            WasmEdgeDeleter<WasmEdge_LoaderDelete>>;
-
-        using ValidtorPtr = std::unique_ptr<WasmEdge_ValidatorContext,
-            WasmEdgeDeleter<WasmEdge_ValidatorDelete>>;
-
-        using ExecutorPtr = std::unique_ptr<WasmEdge_ExecutorContext,
-            WasmEdgeDeleter<WasmEdge_ExecutorDelete>>;
-
-        using ModuleInstancePtr = std::unique_ptr<WasmEdge_ModuleInstanceContext,
-            WasmEdgeDeleter<WasmEdge_ModuleInstanceDelete>>;
-
-        using FunctionTypePtr = std::unique_ptr<WasmEdge_FunctionTypeContext,
-            WasmEdgeDeleter<WasmEdge_FunctionTypeDelete>>;
-
-        struct ModuleInstance
-        {
-            std::shared_ptr<WasmEdge_ModuleInstanceContext> module_context;
-            PluginHandle handle;
-            std::string name;
-        };
-
-        explicit Self(std::unique_ptr<PluginBridge> bridge);
-        ~Self();
-        void create_host_module();
-
-        std::unique_ptr<PluginBridge> bridge;
-        ConfigurePtr configure_context;
-        StorePtr store_context;
-        LoaderPtr loader_context;
-        ValidtorPtr validator_context;
-        ExecutorPtr executor_context;
-        ModuleInstancePtr wasi_module_instance;
-        ModuleInstancePtr host_module;
-
-        PluginHandle next_plugin_handle = 1;
-        std::vector<ModuleInstance> loaded_modules;
-        HostFunctionData host_fn_data;
-    };
-
-    PluginWindowPlacement from_c(miracle_placement_t placement, PluginHandle plugin_handle);
-
-    /// Broadcast a window-info-only callback (export \p fn_name) to every loaded plugin.
-    /// Writes the window_info struct followed by its name into each module's memory.
-    void dispatch_window_event(char const* fn_name, miral::WindowInfo const& window_info);
-
-    /// Broadcast a workspace-info-only callback (export \p fn_name) to every loaded plugin.
-    /// Writes the workspace struct followed by its name into each module's memory.
-    void dispatch_workspace_event(char const* fn_name, uint32_t id);
-
-    std::mutex mutex_;
-    std::unique_ptr<Self> self;
+    /// results into a single PluginConfigData.
+    virtual PluginConfigData configure() = 0;
 };
+
+/// Returns a no-op PluginManager. Used when the plugin feature is disabled at
+/// compile time, or as a fallback when the plugin module cannot be loaded.
+std::shared_ptr<PluginManager> make_null_plugin_manager();
+
+/// Loads the real, WasmEdge-backed PluginManager from the isolated plugin module
+/// (libmiracle-wm-plugins.so) when the plugin feature is enabled; otherwise, or
+/// on any failure, returns make_null_plugin_manager().
+std::shared_ptr<PluginManager> load_plugin_manager();
 }
-#else
-#include "../miracle-plugin-rs/plugin.h"
-#include "plugin_bridge.h"
-#include <cstdint>
-#include <mir/geometry/point.h>
-#include <miral/toolkit_event.h>
-#include <string>
-namespace miracle
-{
-typedef uint32_t PluginHandle;
-class PluginBridge;
-
-struct PluginLoadResult
-{
-    bool success = false;
-    PluginHandle handle = 0;
-    std::string error;
-};
-
-class PluginManager
-{
-public:
-    ~PluginManager() = default;
-    void initialize(std::unique_ptr<PluginBridge>) {};
-    PluginLoadResult load_wasm_module(std::string const&, std::string const& = "") { return PluginLoadResult {
-        .success = false,
-        .error = "Platform does not support plugins"
-    }; }
-    void unload_all() { }
-    PluginHandle get_wasm_module(std::string const&) { return 0; }
-    bool unload_wasm_module(PluginHandle) { return false; }
-    std::optional<miracle_plugin_animation_frame_result_t> animate(
-        AnimationData const&, float) { return std::nullopt; }
-    void custom_animate(PluginHandle, uint32_t, float, float) { }
-    std::optional<PluginWindowPlacement> place_new_window(
-        miral::ApplicationInfo const&,
-        miral::WindowSpecification const&,
-        uint64_t) { return std::nullopt; }
-    void window_deleted(miral::WindowInfo const&) { }
-    void window_focused(miral::WindowInfo const&) { }
-    void window_unfocused(miral::WindowInfo const&) { }
-    void workspace_created(uint32_t) { }
-    void workspace_removed(uint32_t) { }
-    void workspace_focused(std::optional<uint32_t>, uint32_t) { }
-    void workspace_area_changed(uint32_t) { }
-    void window_workspace_changed(miral::WindowInfo const&, uint32_t) { }
-    bool handle_keyboard_event(MirKeyboardEvent const&) { return false; }
-    bool handle_pointer_event(MirPointerEvent const&) { return false; }
-    PluginConfigData configure() { return PluginConfigData {}; }
-};
-}
-#endif
 
 #endif // MIRACLEWM_PLUGIN_MANAGER_H

--- a/src/plugin_manager_impl.cpp
+++ b/src/plugin_manager_impl.cpp
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
 #define MIR_LOG_COMPONENT "plugin_manager"
-#include "plugin_manager.h"
+#include "plugin_manager_impl.h"
 
 #include "animation.h"
 #include "compositor_state.h"
@@ -757,7 +757,7 @@ WasmEdge_Result host_miracle_queue_custom_animation(
     WasmEdge_Value const* params,
     WasmEdge_Value* returns)
 {
-    auto* ctx = static_cast<PluginManager::HostFunctionData*>(data);
+    auto* ctx = static_cast<PluginManagerImpl::HostFunctionData*>(data);
     auto* memory = get_memory_from_frame(frame, "host_miracle_queue_custom_animation");
     if (!memory)
     {
@@ -871,7 +871,7 @@ void add_host_function(
 }
 }
 
-PluginManager::Self::Self(std::unique_ptr<PluginBridge> bridge) :
+PluginManagerImpl::Self::Self(std::unique_ptr<PluginBridge> bridge) :
     bridge(std::move(bridge)),
     configure_context(create_configure_context()),
     store_context(WasmEdge_StoreCreate()),
@@ -909,17 +909,17 @@ PluginManager::Self::Self(std::unique_ptr<PluginBridge> bridge) :
     create_host_module();
 }
 
-PluginManager::Self::~Self() = default;
+PluginManagerImpl::Self::~Self() = default;
 
-PluginManager::~PluginManager() = default;
+PluginManagerImpl::~PluginManagerImpl() = default;
 
-void PluginManager::initialize(std::unique_ptr<PluginBridge> bridge)
+void PluginManagerImpl::initialize(std::unique_ptr<PluginBridge> bridge)
 {
     self = std::make_unique<Self>(std::move(bridge));
     self->host_fn_data.manager = this;
 }
 
-void PluginManager::Self::create_host_module()
+void PluginManagerImpl::Self::create_host_module()
 {
     // Create the "env" module which is the standard import module name for C/C++ compiled WASM
     auto const module_name = WasmEdge_StringCreateByCString("env");
@@ -1053,7 +1053,7 @@ void PluginManager::Self::create_host_module()
     mir::log_info("Host module 'env' registered with %d functions", 24);
 }
 
-PluginLoadResult PluginManager::load_wasm_module(std::string const& path, std::string const& userdata_json)
+PluginLoadResult PluginManagerImpl::load_wasm_module(std::string const& path, std::string const& userdata_json)
 {
     std::lock_guard lock(mutex_);
     auto const erased = std::erase_if(self->loaded_modules, [&path](auto const& module)
@@ -1138,7 +1138,7 @@ PluginLoadResult PluginManager::load_wasm_module(std::string const& path, std::s
     };
 }
 
-bool PluginManager::unload_wasm_module(PluginHandle handle)
+bool PluginManagerImpl::unload_wasm_module(PluginHandle handle)
 {
     std::lock_guard lock(mutex_);
     auto const erased = std::erase_if(self->loaded_modules, [handle](auto const& module)
@@ -1150,7 +1150,7 @@ bool PluginManager::unload_wasm_module(PluginHandle handle)
     return erased > 0;
 }
 
-void PluginManager::unload_all()
+void PluginManagerImpl::unload_all()
 {
     std::lock_guard lock(mutex_);
     for (auto const& module : self->loaded_modules)
@@ -1158,7 +1158,7 @@ void PluginManager::unload_all()
     self->loaded_modules.clear();
 }
 
-std::optional<miracle_plugin_animation_frame_result_t> PluginManager::animate(
+std::optional<miracle_plugin_animation_frame_result_t> PluginManagerImpl::animate(
     AnimationData const& data, float runtime_seconds)
 {
     std::lock_guard lock(mutex_);
@@ -1302,7 +1302,7 @@ std::optional<miracle_plugin_animation_frame_result_t> PluginManager::animate(
     return std::nullopt;
 }
 
-void PluginManager::custom_animate(PluginHandle plugin_handle, uint32_t animation_id, float dt, float elapsed_seconds)
+void PluginManagerImpl::custom_animate(PluginHandle plugin_handle, uint32_t animation_id, float dt, float elapsed_seconds)
 {
     std::lock_guard lock(mutex_);
     for (auto const& target_module : self->loaded_modules)
@@ -1376,7 +1376,7 @@ void PluginManager::custom_animate(PluginHandle plugin_handle, uint32_t animatio
     mir::log_warning("custom_animate: no plugin found with handle %u", plugin_handle);
 }
 
-std::optional<PluginWindowPlacement> PluginManager::place_new_window(
+std::optional<PluginWindowPlacement> PluginManagerImpl::place_new_window(
     miral::ApplicationInfo const& app_info,
     miral::WindowSpecification const& spec,
     uint64_t window_id)
@@ -1492,7 +1492,7 @@ std::optional<PluginWindowPlacement> PluginManager::place_new_window(
     return std::nullopt;
 }
 
-void PluginManager::dispatch_window_event(char const* fn_name, miral::WindowInfo const& window_info)
+void PluginManagerImpl::dispatch_window_event(char const* fn_name, miral::WindowInfo const& window_info)
 {
     std::lock_guard lock(mutex_);
     auto const bridge_handle = self->bridge->existing_window_info(window_info);
@@ -1525,22 +1525,22 @@ void PluginManager::dispatch_window_event(char const* fn_name, miral::WindowInfo
     }
 }
 
-void PluginManager::window_deleted(miral::WindowInfo const& window_info)
+void PluginManagerImpl::window_deleted(miral::WindowInfo const& window_info)
 {
     dispatch_window_event("window_deleted", window_info);
 }
 
-void PluginManager::window_focused(miral::WindowInfo const& window_info)
+void PluginManagerImpl::window_focused(miral::WindowInfo const& window_info)
 {
     dispatch_window_event("window_focused", window_info);
 }
 
-void PluginManager::window_unfocused(miral::WindowInfo const& window_info)
+void PluginManagerImpl::window_unfocused(miral::WindowInfo const& window_info)
 {
     dispatch_window_event("window_unfocused", window_info);
 }
 
-void PluginManager::dispatch_workspace_event(char const* fn_name, uint32_t id)
+void PluginManagerImpl::dispatch_workspace_event(char const* fn_name, uint32_t id)
 {
     std::lock_guard lock(mutex_);
     auto const result = self->bridge->workspace_by_id(id);
@@ -1573,17 +1573,17 @@ void PluginManager::dispatch_workspace_event(char const* fn_name, uint32_t id)
     }
 }
 
-void PluginManager::workspace_created(uint32_t id)
+void PluginManagerImpl::workspace_created(uint32_t id)
 {
     dispatch_workspace_event("workspace_created", id);
 }
 
-void PluginManager::workspace_removed(uint32_t id)
+void PluginManagerImpl::workspace_removed(uint32_t id)
 {
     dispatch_workspace_event("workspace_removed", id);
 }
 
-void PluginManager::workspace_focused(std::optional<uint32_t> previous_id, uint32_t current_id)
+void PluginManagerImpl::workspace_focused(std::optional<uint32_t> previous_id, uint32_t current_id)
 {
     std::lock_guard lock(mutex_);
     auto const result = self->bridge->workspace_by_id(current_id);
@@ -1665,7 +1665,7 @@ void PluginManager::workspace_focused(std::optional<uint32_t> previous_id, uint3
     }
 }
 
-void PluginManager::workspace_area_changed(uint32_t id)
+void PluginManagerImpl::workspace_area_changed(uint32_t id)
 {
     std::lock_guard lock(mutex_);
     auto const result = self->bridge->workspace_by_id(id);
@@ -1742,7 +1742,7 @@ void PluginManager::workspace_area_changed(uint32_t id)
     }
 }
 
-void PluginManager::window_workspace_changed(miral::WindowInfo const& window_info, uint32_t workspace_id)
+void PluginManagerImpl::window_workspace_changed(miral::WindowInfo const& window_info, uint32_t workspace_id)
 {
     std::lock_guard lock(mutex_);
     auto const bridge_window = self->bridge->existing_window_info(window_info);
@@ -1857,7 +1857,7 @@ void PluginManager::window_workspace_changed(miral::WindowInfo const& window_inf
     }
 }
 
-bool PluginManager::handle_keyboard_event(MirKeyboardEvent const& event)
+bool PluginManagerImpl::handle_keyboard_event(MirKeyboardEvent const& event)
 {
     std::lock_guard lock(mutex_);
     miracle_keyboard_event_t const keyboard_event = {
@@ -1926,7 +1926,7 @@ bool PluginManager::handle_keyboard_event(MirKeyboardEvent const& event)
     return false;
 }
 
-bool PluginManager::handle_pointer_event(MirPointerEvent const& event)
+bool PluginManagerImpl::handle_pointer_event(MirPointerEvent const& event)
 {
     std::lock_guard lock(mutex_);
     miracle_pointer_event_t const pointer_event = {
@@ -1996,7 +1996,7 @@ bool PluginManager::handle_pointer_event(MirPointerEvent const& event)
     return false;
 }
 
-miracle::PluginConfigData PluginManager::configure()
+miracle::PluginConfigData PluginManagerImpl::configure()
 {
     // Accumulate config overrides from all loaded plugins into a single ConfigData,
     // then return it as PluginConfigData. The plugins and includes fields are never set.
@@ -2105,7 +2105,7 @@ miracle::PluginConfigData PluginManager::configure()
     return result;
 }
 
-PluginWindowPlacement PluginManager::from_c(miracle_placement_t placement, PluginHandle plugin_handle)
+PluginWindowPlacement PluginManagerImpl::from_c(miracle_placement_t placement, PluginHandle plugin_handle)
 {
     PluginWindowPlacement result;
     result.strategy = static_cast<miracle_window_management_strategy_t>(placement.strategy);
@@ -2136,6 +2136,14 @@ PluginWindowPlacement PluginManager::from_c(miracle_placement_t placement, Plugi
         break;
     }
     return result;
+}
+
+/// Factory entry point resolved by the host via dlsym(). Returns a heap-allocated
+/// PluginManagerImpl; the host owns it and deletes it before dlclose()-ing the
+/// module. Declared extern "C" to keep the symbol name stable and unmangled.
+extern "C" miracle::PluginManager* miracle_wm_create_plugin_manager()
+{
+    return new miracle::PluginManagerImpl();
 }
 
 #endif

--- a/src/plugin_manager_impl.h
+++ b/src/plugin_manager_impl.h
@@ -1,0 +1,154 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef MIRACLEWM_PLUGIN_MANAGER_IMPL_H
+#define MIRACLEWM_PLUGIN_MANAGER_IMPL_H
+
+#include "plugin_manager.h"
+
+#include <memory>
+#include <mir/geometry/point.h>
+#include <mutex>
+#include <vector>
+#include <wasmedge/wasmedge.h>
+
+namespace miracle
+{
+class PluginBridge;
+
+/// Concrete, WasmEdge-backed implementation of #PluginManager.
+///
+/// This class (and everything it pulls in, notably WasmEdge and its bundled
+/// LLVM) lives exclusively in the libmiracle-wm-plugins.so shared library so it
+/// can be loaded with RTLD_LOCAL and never pollutes the main binary's global
+/// symbol scope. See plugin_manager.h for the rationale (issue #865).
+class PluginManagerImpl final : public PluginManager
+{
+public:
+    ~PluginManagerImpl() override;
+
+    void initialize(std::unique_ptr<PluginBridge> bridge) override;
+    PluginLoadResult load_wasm_module(std::string const& path, std::string const& userdata_json) override;
+    bool unload_wasm_module(PluginHandle handle) override;
+    void unload_all() override;
+    std::optional<miracle_plugin_animation_frame_result_t> animate(
+        AnimationData const& data, float runtime_seconds) override;
+    void custom_animate(PluginHandle plugin_handle, uint32_t animation_id, float dt, float elapsed_seconds) override;
+    std::optional<PluginWindowPlacement> place_new_window(
+        miral::ApplicationInfo const& app_info,
+        miral::WindowSpecification const& spec,
+        uint64_t window_id) override;
+    void window_deleted(miral::WindowInfo const& window_info) override;
+    void window_focused(miral::WindowInfo const& window_info) override;
+    void window_unfocused(miral::WindowInfo const& window_info) override;
+    void workspace_created(uint32_t id) override;
+    void workspace_removed(uint32_t id) override;
+    void workspace_focused(std::optional<uint32_t> previous_id, uint32_t current_id) override;
+    void workspace_area_changed(uint32_t id) override;
+    void window_workspace_changed(miral::WindowInfo const& window_info, uint32_t workspace_id) override;
+    bool handle_keyboard_event(MirKeyboardEvent const& event) override;
+    bool handle_pointer_event(MirPointerEvent const& event) override;
+    PluginConfigData configure() override;
+
+    /// Data passed to host functions that need both the bridge and the manager.
+    struct HostFunctionData
+    {
+        PluginBridge* bridge = nullptr;
+        PluginManager* manager = nullptr;
+    };
+
+private:
+    struct Self
+    {
+        template <auto DeleteFn>
+        struct WasmEdgeDeleter
+        {
+            template <typename T>
+            void operator()(T* ptr) const noexcept
+            {
+                if (ptr)
+                {
+                    DeleteFn(ptr);
+                }
+            }
+        };
+
+        using ConfigurePtr = std::unique_ptr<WasmEdge_ConfigureContext,
+            WasmEdgeDeleter<WasmEdge_ConfigureDelete>>;
+
+        using StorePtr = std::unique_ptr<WasmEdge_StoreContext,
+            WasmEdgeDeleter<WasmEdge_StoreDelete>>;
+
+        using VMPtr = std::unique_ptr<WasmEdge_VMContext,
+            WasmEdgeDeleter<WasmEdge_VMDelete>>;
+
+        using LoaderPtr = std::unique_ptr<WasmEdge_LoaderContext,
+            WasmEdgeDeleter<WasmEdge_LoaderDelete>>;
+
+        using ValidtorPtr = std::unique_ptr<WasmEdge_ValidatorContext,
+            WasmEdgeDeleter<WasmEdge_ValidatorDelete>>;
+
+        using ExecutorPtr = std::unique_ptr<WasmEdge_ExecutorContext,
+            WasmEdgeDeleter<WasmEdge_ExecutorDelete>>;
+
+        using ModuleInstancePtr = std::unique_ptr<WasmEdge_ModuleInstanceContext,
+            WasmEdgeDeleter<WasmEdge_ModuleInstanceDelete>>;
+
+        using FunctionTypePtr = std::unique_ptr<WasmEdge_FunctionTypeContext,
+            WasmEdgeDeleter<WasmEdge_FunctionTypeDelete>>;
+
+        struct ModuleInstance
+        {
+            std::shared_ptr<WasmEdge_ModuleInstanceContext> module_context;
+            PluginHandle handle;
+            std::string name;
+        };
+
+        explicit Self(std::unique_ptr<PluginBridge> bridge);
+        ~Self();
+        void create_host_module();
+
+        std::unique_ptr<PluginBridge> bridge;
+        ConfigurePtr configure_context;
+        StorePtr store_context;
+        LoaderPtr loader_context;
+        ValidtorPtr validator_context;
+        ExecutorPtr executor_context;
+        ModuleInstancePtr wasi_module_instance;
+        ModuleInstancePtr host_module;
+
+        PluginHandle next_plugin_handle = 1;
+        std::vector<ModuleInstance> loaded_modules;
+        HostFunctionData host_fn_data;
+    };
+
+    PluginWindowPlacement from_c(miracle_placement_t placement, PluginHandle plugin_handle);
+
+    /// Broadcast a window-info-only callback (export \p fn_name) to every loaded plugin.
+    /// Writes the window_info struct followed by its name into each module's memory.
+    void dispatch_window_event(char const* fn_name, miral::WindowInfo const& window_info);
+
+    /// Broadcast a workspace-info-only callback (export \p fn_name) to every loaded plugin.
+    /// Writes the workspace struct followed by its name into each module's memory.
+    void dispatch_workspace_event(char const* fn_name, uint32_t id);
+
+    std::mutex mutex_;
+    std::unique_ptr<Self> self;
+};
+}
+
+#endif // MIRACLEWM_PLUGIN_MANAGER_IMPL_H

--- a/src/plugin_manager_loader.cpp
+++ b/src/plugin_manager_loader.cpp
@@ -1,0 +1,110 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#define MIR_LOG_COMPONENT "plugin_manager_loader"
+
+#include "feature_flags.h"
+#include "plugin_manager.h"
+
+#include <cstdlib>
+#include <dlfcn.h>
+#include <memory>
+#include <mir/log.h>
+
+#ifndef MIRACLE_PLUGIN_MODULE_PATH
+#define MIRACLE_PLUGIN_MODULE_PATH ""
+#endif
+
+namespace miracle
+{
+namespace
+{
+    constexpr char const* soname = "libmiracle-wm-plugins.so";
+
+    /// dlopen the plugin module from the first location that works:
+    ///   1. the $MIRACLE_WM_PLUGIN_MODULE override (handy for the build tree / tests),
+    ///   2. the configured install path, then
+    ///   3. the bare soname (resolved via the normal loader search path).
+    ///
+    /// RTLD_LOCAL is essential: it keeps the module and its dependencies
+    /// (libwasmedge -> libLLVM) out of the global symbol scope, so they cannot
+    /// interpose on Mesa's software renderer (llvmpipe), which also uses LLVM.
+    /// That interposition is what broke rendering in #865.
+    void* open_module()
+    {
+        char const* const candidates[] = {
+            std::getenv("MIRACLE_WM_PLUGIN_MODULE"),
+            MIRACLE_PLUGIN_MODULE_PATH,
+            soname,
+        };
+
+        for (char const* candidate : candidates)
+        {
+            if (!candidate || candidate[0] == '\0')
+                continue;
+
+            if (void* handle = dlopen(candidate, RTLD_NOW | RTLD_LOCAL))
+                return handle;
+
+            mir::log_debug("Could not load plugin module from '%s': %s", candidate, dlerror());
+        }
+
+        return nullptr;
+    }
+}
+
+std::shared_ptr<PluginManager> load_plugin_manager()
+{
+    if (!feature::plugin_system)
+        return make_null_plugin_manager();
+
+    void* handle = open_module();
+    if (!handle)
+    {
+        mir::log_error("Failed to load plugin module %s; plugins disabled", soname);
+        return make_null_plugin_manager();
+    }
+
+    using factory_t = PluginManager* (*)();
+    auto const factory = reinterpret_cast<factory_t>(
+        dlsym(handle, "miracle_wm_create_plugin_manager"));
+    if (!factory)
+    {
+        mir::log_error("Plugin module is missing miracle_wm_create_plugin_manager: %s; plugins disabled", dlerror());
+        dlclose(handle);
+        return make_null_plugin_manager();
+    }
+
+    PluginManager* raw = factory();
+    if (!raw)
+    {
+        mir::log_error("Plugin module failed to create a PluginManager; plugins disabled");
+        dlclose(handle);
+        return make_null_plugin_manager();
+    }
+
+    mir::log_info("Loaded plugin module %s", soname);
+
+    // The deleter must destroy the manager (whose code lives in the module)
+    // before dlclose()-ing the module.
+    return std::shared_ptr<PluginManager>(raw, [handle](PluginManager* p)
+    {
+        delete p;
+        dlclose(handle);
+    });
+}
+}

--- a/src/plugin_manager_null.cpp
+++ b/src/plugin_manager_null.cpp
@@ -1,0 +1,70 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#include "plugin_manager.h"
+
+#include <memory>
+
+namespace miracle
+{
+namespace
+{
+    /// A PluginManager that does nothing. Used when the plugin feature is compiled
+    /// out, or as a safe fallback when the plugin module fails to load, so the rest
+    /// of the compositor keeps working (and rendering) without plugins.
+    class NullPluginManager final : public PluginManager
+    {
+    public:
+        void initialize(std::unique_ptr<PluginBridge>) override { }
+        PluginLoadResult load_wasm_module(std::string const&, std::string const&) override
+        {
+            return PluginLoadResult { .success = false, .error = "Plugin system is not available" };
+        }
+        bool unload_wasm_module(PluginHandle) override { return false; }
+        void unload_all() override { }
+        std::optional<miracle_plugin_animation_frame_result_t> animate(
+            AnimationData const&, float) override
+        {
+            return std::nullopt;
+        }
+        void custom_animate(PluginHandle, uint32_t, float, float) override { }
+        std::optional<PluginWindowPlacement> place_new_window(
+            miral::ApplicationInfo const&,
+            miral::WindowSpecification const&,
+            uint64_t) override
+        {
+            return std::nullopt;
+        }
+        void window_deleted(miral::WindowInfo const&) override { }
+        void window_focused(miral::WindowInfo const&) override { }
+        void window_unfocused(miral::WindowInfo const&) override { }
+        void workspace_created(uint32_t) override { }
+        void workspace_removed(uint32_t) override { }
+        void workspace_focused(std::optional<uint32_t>, uint32_t) override { }
+        void workspace_area_changed(uint32_t) override { }
+        void window_workspace_changed(miral::WindowInfo const&, uint32_t) override { }
+        bool handle_keyboard_event(MirKeyboardEvent const&) override { return false; }
+        bool handle_pointer_event(MirPointerEvent const&) override { return false; }
+        PluginConfigData configure() override { return PluginConfigData {}; }
+    };
+}
+
+std::shared_ptr<PluginManager> make_null_plugin_manager()
+{
+    return std::make_shared<NullPluginManager>();
+}
+}

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -229,7 +229,7 @@ Policy::Policy(
     output_listener { output_listener },
     config_observer_registrar { config_observer_registrar },
     animator(std::make_shared<Animator>()),
-    plugin_manager(std::make_shared<PluginManager>()),
+    plugin_manager(load_plugin_manager()),
     window_id_map_(std::make_shared<WindowIdMap>()),
     application_id_map_(std::make_shared<ApplicationIdMap>()),
     window_controller(std::make_shared<WindowManagerToolsWindowController>(

--- a/tests/test_dying_surface_manager.cpp
+++ b/tests/test_dying_surface_manager.cpp
@@ -50,7 +50,7 @@ public:
             compositor_state,
             config,
             animator,
-            std::make_shared<PluginManager>(),
+            make_null_plugin_manager(),
             window_controller)
     {
     }

--- a/tests/test_output.cpp
+++ b/tests/test_output.cpp
@@ -76,7 +76,7 @@ protected:
             config,
             window_controller,
             animator,
-            std::make_shared<PluginManager>());
+            make_null_plugin_manager());
 
         auto const registrar = std::make_shared<WorkspaceObserverRegistrar>();
         output->advise_new_workspace(WorkspaceCreationData {
@@ -163,7 +163,7 @@ TEST_F(OutputIntersectTest, ReturnsNullWhenOnContainerIsAnimating)
         AnimationData(),
         [](auto const& asr)
     { (void)asr; },
-        std::make_shared<PluginManager>()));
+        make_null_plugin_manager()));
     EXPECT_CALL(*mock_container, animation_handle())
         .WillRepeatedly(Return(1));
 
@@ -262,7 +262,7 @@ TEST_F(OutputTest, OutputToJsonWithUnsetCurrentMode)
         config,
         window_controller,
         animator,
-        std::make_shared<PluginManager>());
+        make_null_plugin_manager());
     EXPECT_THAT(output->get_outputs_json(false)["current_mode"], testing::Eq(nlohmann::json({
                                                                      { "width",   0 },
                                                                      { "height",  0 },
@@ -292,7 +292,7 @@ TEST_F(OutputTest, OutputToJsonWithInvalidCurrentMode)
         config,
         window_controller,
         animator,
-        std::make_shared<PluginManager>());
+        make_null_plugin_manager());
     EXPECT_THAT(output->get_outputs_json(false)["current_mode"], testing::Eq(nlohmann::json({
                                                                      { "width",   0 },
                                                                      { "height",  0 },

--- a/tests/test_workspace.cpp
+++ b/tests/test_workspace.cpp
@@ -125,7 +125,7 @@ public:
     std::shared_ptr<ShellApplicationManager> shell_application_manager;
     std::shared_ptr<WorkspaceObserverRegistrar> registry = std::make_shared<WorkspaceObserverRegistrar>();
     std::shared_ptr<Animator> animator = std::make_shared<Animator>();
-    std::shared_ptr<PluginManager> plugin_manager = std::make_shared<PluginManager>();
+    std::shared_ptr<PluginManager> plugin_manager = make_null_plugin_manager();
     std::shared_ptr<Workspace> workspace;
 };
 


### PR DESCRIPTION
Well, this one was weird, but I think it should fix two tricky bugs that have come up recently. If either @OPNA2608 or @notritsuwu wants to confirm on their end, I would greatly appreciate it. This fix will ship in 0.10, which is just around the corner.

fixes https://github.com/miracle-wm-org/miracle-wm/issues/865
fixes https://github.com/miracle-wm-org/miracle-wm/issues/888

## The Problem

- **Symptom:** With `FEATURE_PLUGIN_SYSTEM=ON`, the screen is black inside a QEMU VM, even though the compositor runs, accepts commands, and launches apps. With plugins off, the same VM renders fine.

- **The plugin system links LLVM through WasmEdge.** The plugin runtime is WasmEdge, and `libwasmedge.so` depends on `libLLVM.so`. Because the main library linked WasmEdge directly (`target_link_libraries(... ${WASMEDGE_LIB})`), the `miracle-wm` executable pulled `libwasmedge.so` **and `libLLVM.so` into the process's global symbol scope at startup**.

- **Mesa's software renderer also uses LLVM.** A QEMU VM has no GPU, so Mir renders with Mesa's software rasterizer, **llvmpipe**, which JIT-compiles its rendering through LLVM and is `dlopen`ed at runtime.

- **Two LLVMs in one process collide.** With WasmEdge's libLLVM already sitting in the global scope, Mesa's later-loaded llvmpipe binds its LLVM symbols against the *wrong* copy. On @OPNA2608's machine, the two are built against **different LLVM versions**, so the mismatch silently corrupts llvmpipe's codegen and it produces nothing → black screen.

- **This explains every symptom:** QEMU-only (software rendering = LLVM), plugin-only (only WasmEdge drags LLVM into the process), and the compositor otherwise being fully alive (only the GL/render path breaks). It doesn't reproduce on a real GPU (no llvmpipe), nor on a machine where WasmEdge and Mesa happen to share the same system libLLVM.

## The Fix

- **Keep WasmEdge (and its LLVM) out of the main binary entirely.** All WasmEdge-touching code now lives in a separate shared module, `libmiracle-wm-plugins.so`, which is the only thing that links WasmEdge.

- **Load it isolated at runtime.** The main binary talks to an abstract `PluginManager` interface and loads the real implementation with `dlopen(RTLD_NOW | RTLD_LOCAL)`. `RTLD_LOCAL` keeps the module and its dependencies (libwasmedge → libLLVM) **out of the global symbol scope**, so they can no longer interpose on Mesa's llvmpipe. When plugins aren't compiled in, libLLVM is never loaded at all.

## Verification
  - `ldd build/miracle-wm` now lists **neither libwasmedge nor libLLVM** (both appear only under `libmiracle-wm-plugins.so`)