### PR TITLE
(#691) bugfix: enable data control manager to prevent phantom windows with wl-copy and grimshot

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -246,6 +246,12 @@ int main(int argc, char const* argv[])
                                                .enable(WaylandExtensions::zwlr_screencopy_manager_v1)
                                                .enable(WaylandExtensions::ext_session_lock_manager_v1);
 
+#if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 6, 0)
+    // Allows clients like wl-clipboard to access the clipboard without the
+    // focus-stealing popup-surface fallback (#691).
+    wayland_extensions.enable(WaylandExtensions::ext_data_control_manager_v1);
+#endif
+
     for (auto const& extension : { "zwp_pointer_constraints_v1", "zwp_relative_pointer_manager_v1" })
         wayland_extensions.enable(extension);
 


### PR DESCRIPTION
fixes #691 

## What's fixed?
`wl-copy` and `grimshot` would use a hack where they pop up a transparent window to gain focus when data-control wasn't available to them. This would cause the tiler to flash a random retile. The fix was to enable data control when it is available :tada: 