### PR TITLE
bugfix: fix long-standing bug where window state was not being propagated when a window was not on the focused workspace

### DIFF
--- a/src/freestyle_window_container.cpp
+++ b/src/freestyle_window_container.cpp
@@ -178,13 +178,28 @@ void FreestyleWindowContainer::handle_ready()
     window_controller->select_active_window(window_sync.lock()->window_);
 }
 
-void FreestyleWindowContainer::handle_modify(miral::WindowSpecification const& specification)
+void FreestyleWindowContainer::handle_modify(miral::WindowSpecification const& specification, bool hidden)
 {
     auto const w = window_sync.lock()->window_;
     auto mods = specification;
     if (mods.state().is_set())
     {
-        window_controller->change_state(w, mods.state().value());
+        if (hidden)
+        {
+            // This container's workspace is not being rendered. Defer the state change
+            // until the container is shown again (via restore_result) so the workspace
+            // stays hidden; non-state modifications below are still applied immediately.
+            auto s = sync.lock();
+            if (s->restore_result)
+                s->restore_result->state = mods.state().value();
+            else
+                s->restore_result = RestoreResult { mods.state().value(), w.top_left() };
+            mods.state().consume();
+        }
+        else
+        {
+            window_controller->change_state(w, mods.state().value());
+        }
     }
     window_controller->modify(w, mods);
 }

--- a/src/freestyle_window_container.h
+++ b/src/freestyle_window_container.h
@@ -54,7 +54,7 @@ public:
     size_t get_min_height() const override;
     size_t get_min_width() const override;
     void handle_ready() override;
-    void handle_modify(miral::WindowSpecification const&) override;
+    void handle_modify(miral::WindowSpecification const&, bool hidden) override;
     void handle_request_move(MirInputEvent const* input_event) override;
     void handle_raise() override;
     void on_focus_gained() override;

--- a/src/leaf_container.cpp
+++ b/src/leaf_container.cpp
@@ -273,7 +273,7 @@ void LeafContainer::handle_ready()
     }
 }
 
-void LeafContainer::handle_modify(miral::WindowSpecification const& modifications)
+void LeafContainer::handle_modify(miral::WindowSpecification const& modifications, bool hidden)
 {
     /// Note: This request comes from the client, so we may accept or ignore whatever
     /// it is that we find here.
@@ -291,37 +291,52 @@ void LeafContainer::handle_modify(miral::WindowSpecification const& modification
         case mir_window_state_horizmaximized:
         case mir_window_state_vertmaximized:
         case mir_window_state_minimized:
-        case mir_window_state_hidden: // Hidden window requests form the client are NOT respected.
+        case mir_window_state_hidden: // Hidden window requests from the client are NOT respected.
             mods.state() = mir_window_state_restored;
             break;
         default:
             break;
         }
 
-        cur_state = mods.state().value();
-        mods.depth_layer() = get_depth_layer(
-            mods.state().value() == mir_window_state_fullscreen);
-
-        if (info.state() != mods.state().value() && mods.state().value() == mir_window_state_restored)
+        if (hidden)
         {
-            /// If the next state if restored, set the area and depth layer.
-            mods.top_left() = visible_area.top_left;
-            mods.size() = visible_area.size;
+            // This container's workspace is not being rendered. Defer the state change
+            // until the container is shown again (via restore_result) so the workspace
+            // stays hidden; non-state modifications below are still applied immediately.
+            auto s = sync.lock();
+            if (s->restore_result)
+                s->restore_result->state = mods.state().value();
+            else
+                s->restore_result = RestoreResult { mods.state().value(), visible_area.top_left };
+            mods.state().consume();
         }
-
-        if (cur_state == mir_window_state_fullscreen
-            || window_controller->get_state(w) == mir_window_state_fullscreen)
-        {
-            for_each_observer([this](ContainerListener* observer)
-            {
-                observer->on_container_fullscreen(*this);
-            });
-        }
-
-        if (cur_state == mir_window_state_fullscreen)
-            window_controller->noclip(w);
         else
-            window_controller->clip(w, visible_area);
+        {
+            cur_state = mods.state().value();
+            mods.depth_layer() = get_depth_layer(
+                mods.state().value() == mir_window_state_fullscreen);
+
+            if (info.state() != mods.state().value() && mods.state().value() == mir_window_state_restored)
+            {
+                /// If the next state if restored, set the area and depth layer.
+                mods.top_left() = visible_area.top_left;
+                mods.size() = visible_area.size;
+            }
+
+            if (cur_state == mir_window_state_fullscreen
+                || window_controller->get_state(w) == mir_window_state_fullscreen)
+            {
+                for_each_observer([this](ContainerListener* observer)
+                {
+                    observer->on_container_fullscreen(*this);
+                });
+            }
+
+            if (cur_state == mir_window_state_fullscreen)
+                window_controller->noclip(w);
+            else
+                window_controller->clip(w, visible_area);
+        }
     }
 
     if (cur_state == mir_window_state_restored)

--- a/src/leaf_container.h
+++ b/src/leaf_container.h
@@ -62,7 +62,7 @@ public:
     size_t get_min_width() const override;
     size_t get_min_height() const override;
     void handle_ready() override;
-    void handle_modify(miral::WindowSpecification const&) override;
+    void handle_modify(miral::WindowSpecification const&, bool hidden) override;
     void handle_raise() override;
     bool resize(Direction direction, int pixels) override;
     bool set_size(std::optional<int> const& width, std::optional<int> const& height) override;

--- a/src/plugin_managed_container.cpp
+++ b/src/plugin_managed_container.cpp
@@ -189,7 +189,7 @@ void PluginManagedContainer::handle_ready()
     window_controller->select_active_window(w);
 }
 
-void PluginManagedContainer::handle_modify(miral::WindowSpecification const& specification)
+void PluginManagedContainer::handle_modify(miral::WindowSpecification const& specification, bool hidden)
 {
     auto const w = window_sync.lock()->window_;
     auto mods = specification;
@@ -201,12 +201,26 @@ void PluginManagedContainer::handle_modify(miral::WindowSpecification const& spe
             || new_state == mir_window_state_vertmaximized
             || new_state == mir_window_state_fullscreen;
         bool const allowed = window_sync.lock()->resizable_ && window_sync.lock()->movable_;
-        if (is_resize_state && !allowed)
-            window_controller->change_state(w, mir_window_state_restored);
+        auto const resolved_state = (is_resize_state && !allowed)
+            ? mir_window_state_restored
+            : new_state;
+        if (hidden)
+        {
+            // This container's workspace is not being rendered. Defer the state change
+            // until the container is shown again (via restore_result) so the workspace
+            // stays hidden; non-state modifications below are still applied immediately.
+            auto s = sync.lock();
+            if (s->restore_result)
+                s->restore_result->state = resolved_state;
+            else
+                s->restore_result = RestoreResult { resolved_state, w.top_left() };
+        }
         else
-            window_controller->change_state(w, new_state);
+        {
+            window_controller->change_state(w, resolved_state);
+            constrain();
+        }
         mods.state().consume();
-        constrain();
     }
     window_controller->modify(w, mods);
 }

--- a/src/plugin_managed_container.h
+++ b/src/plugin_managed_container.h
@@ -66,7 +66,7 @@ public:
     size_t get_min_height() const override;
     size_t get_min_width() const override;
     void handle_ready() override;
-    void handle_modify(const miral::WindowSpecification&) override;
+    void handle_modify(const miral::WindowSpecification&, bool hidden) override;
     void handle_request_move(const MirInputEvent* input_event) override;
     void handle_raise() override;
     void on_focus_gained() override;

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -886,23 +886,23 @@ void Policy::handle_modify_window(
         return;
     }
 
-    auto const workspace = container->get_workspace();
-    if (workspace)
+    // A container is "hidden" when it is genuinely not being rendered: either its
+    // workspace is not the active workspace on the workspace's OWN output (note: a
+    // workspace active on a non-focused output is still rendered), or it is a hidden
+    // scratchpad window. When hidden, the container defers any requested state change
+    // until it is shown again; all other modifications are always applied.
+    bool hidden = false;
+    if (auto const workspace = container->get_workspace())
     {
-        auto focused_output = output_manager->focused();
-        if (!focused_output)
-        {
-            mir::log_error("Policy::handle_modify_window: focused_output unavailable");
-            return;
-        }
-
-        if (workspace != focused_output->active())
-            return;
+        auto const output = workspace->get_output();
+        hidden = output && output->active().get() != workspace.get();
     }
     else if (scratchpad_->contains(container) && !scratchpad_->is_showing(container))
-        return;
+    {
+        hidden = true;
+    }
 
-    container->handle_modify(modifications);
+    container->handle_modify(modifications, hidden);
 }
 
 void Policy::handle_raise_window(miral::WindowInfo& window_info)

--- a/src/shell_component_container.cpp
+++ b/src/shell_component_container.cpp
@@ -106,8 +106,10 @@ void ShellComponentContainer::handle_ready()
         window_controller->select_active_window(window_);
 }
 
-void ShellComponentContainer::handle_modify(miral::WindowSpecification const& specification)
+void ShellComponentContainer::handle_modify(miral::WindowSpecification const& specification, bool /*hidden*/)
 {
+    // Shell components are output-level and are never on a hidden workspace, so there
+    // is nothing to defer.
     auto const window_ = window_sync.lock()->window_;
     window_controller->modify(window_, specification);
 }

--- a/src/shell_component_container.h
+++ b/src/shell_component_container.h
@@ -58,7 +58,7 @@ public:
     size_t get_min_height() const override;
     size_t get_min_width() const override;
     void handle_ready() override;
-    void handle_modify(miral::WindowSpecification const& specification) override;
+    void handle_modify(miral::WindowSpecification const& specification, bool hidden) override;
     void handle_request_move(MirInputEvent const* input_event) override;
     void handle_raise() override;
     bool resize(Direction direction, int pixels) override;

--- a/src/window_container.h
+++ b/src/window_container.h
@@ -41,7 +41,15 @@ public:
     WindowContainer(uint64_t id, std::shared_ptr<RenderDataManager> const& rdm, std::shared_ptr<WindowController> const& window_controller, bool enable_render_data = true);
     ~WindowContainer() override;
     virtual void handle_ready() = 0;
-    virtual void handle_modify(miral::WindowSpecification const&) = 0;
+
+    /// Handle a client-requested modification of this container's window.
+    ///
+    /// \param hidden true when this container's workspace is not currently
+    ///        rendered (a background workspace or a hidden scratchpad). When
+    ///        hidden, a requested window-state change must be deferred until the
+    ///        container is next shown, so its workspace is not revealed
+    ///        prematurely. Non-state modifications are still applied immediately.
+    virtual void handle_modify(miral::WindowSpecification const&, bool hidden) = 0;
     virtual void handle_request_move(MirInputEvent const* input_event) = 0;
     virtual void on_open();
     virtual bool needs_outline() const;

--- a/src/window_manager_tools_window_controller.cpp
+++ b/src/window_manager_tools_window_controller.cpp
@@ -329,12 +329,6 @@ RestoreResult WindowManagerToolsWindowController::hide(miral::Window const& wind
         .position = window.top_left()
     };
     move_to_offscreen_workspace(window);
-    // HACK: Move the window far offscreen to work around an X11 bug where windows
-    // assigned to the offscreen workspace may still be visible. This may be
-    // resolved in a future Mir release.
-    miral::WindowSpecification spec;
-    spec.top_left() = geom::Point { 1000000, 1000000 };
-    tools.modify_window(window, spec);
     change_state(window, mir_window_state_hidden);
     return result;
 }

--- a/tests/mock_container.h
+++ b/tests/mock_container.h
@@ -46,7 +46,7 @@ namespace test
         MOCK_METHOD(size_t, get_min_height, (), (const, override));
         MOCK_METHOD(size_t, get_min_width, (), (const, override));
         MOCK_METHOD(void, handle_ready, (), (override));
-        MOCK_METHOD(void, handle_modify, (miral::WindowSpecification const&), (override));
+        MOCK_METHOD(void, handle_modify, (miral::WindowSpecification const&, bool), (override));
         MOCK_METHOD(void, handle_request_move, (MirInputEvent const*), (override));
         MOCK_METHOD(void, handle_raise, (), (override));
         MOCK_METHOD(bool, resize, (Direction, int), (override));

--- a/tests/stub_container.h
+++ b/tests/stub_container.h
@@ -85,7 +85,7 @@ namespace test
         {
         }
 
-        void handle_modify(miral::WindowSpecification const& specification) override
+        void handle_modify(miral::WindowSpecification const& specification, bool hidden) override
         {
         }
 

--- a/tests/test_freestyle_window_container.cpp
+++ b/tests/test_freestyle_window_container.cpp
@@ -184,7 +184,21 @@ TEST_F(FreestyleWindowContainerTest, HandleModifyWithStateChangeCallsChangeState
     miral::WindowSpecification spec;
     spec.state() = mir_window_state_fullscreen;
     EXPECT_CALL(*window_controller, change_state(window, mir_window_state_fullscreen)).Times(1);
-    container_with_border->handle_modify(spec);
+    container_with_border->handle_modify(spec, false);
+}
+
+TEST_F(FreestyleWindowContainerTest, HandleModifyWhileHiddenDefersStateUntilShown)
+{
+    miral::WindowSpecification spec;
+    spec.state() = mir_window_state_fullscreen;
+
+    // While the workspace is hidden the state must NOT be applied to the live window...
+    EXPECT_CALL(*window_controller, change_state(_, _)).Times(0);
+    container_with_border->handle_modify(spec, true);
+
+    // ...it is applied via the restore mechanism when the container is next shown.
+    EXPECT_CALL(*window_controller, show(window, Field(&RestoreResult::state, mir_window_state_fullscreen))).Times(1);
+    container_with_border->show();
 }
 
 // ---- workspace ----

--- a/tests/test_leaf_container.cpp
+++ b/tests/test_leaf_container.cpp
@@ -167,7 +167,7 @@ TEST_F(LeafContainerTest, IfModifyingWindowToFullScreenThenNoclipIsCalled)
     miral::WindowSpecification spec;
     spec.state() = mir_window_state_fullscreen;
     EXPECT_CALL(*window_controller, noclip(testing::_));
-    leaf_container->handle_modify(spec);
+    leaf_container->handle_modify(spec, false);
 }
 
 TEST_F(LeafContainerTest, IfModifyingWindowToRestoredThenClipIsCalled)
@@ -175,7 +175,7 @@ TEST_F(LeafContainerTest, IfModifyingWindowToRestoredThenClipIsCalled)
     miral::WindowSpecification spec;
     spec.state() = mir_window_state_restored;
     EXPECT_CALL(*window_controller, clip(testing::_, testing::_));
-    leaf_container->handle_modify(spec);
+    leaf_container->handle_modify(spec, false);
 }
 
 namespace
@@ -200,13 +200,39 @@ TEST_P(LeafContainerMaximizedTest, CannotMaximizeWindowInHandleModify)
     spec.state() = state;
 
     EXPECT_CALL(*window_controller, modify(window, testing::Truly(has_restored_state)));
-    leaf_container->handle_modify(spec);
+    leaf_container->handle_modify(spec, false);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     LeafContainerMaximizedTest,
     LeafContainerMaximizedTest,
     ::testing::Values(mir_window_state_maximized, mir_window_state_vertmaximized, mir_window_state_horizmaximized, mir_window_state_minimized, mir_window_state_hidden));
+
+TEST_F(LeafContainerTest, HandleModifyWhileHiddenDefersStateUntilShown)
+{
+    miral::WindowSpecification spec;
+    spec.state() = mir_window_state_fullscreen;
+
+    // While the workspace is hidden, no live state change (hence no clip/noclip) happens now.
+    EXPECT_CALL(*window_controller, change_state(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(*window_controller, noclip(testing::_)).Times(0);
+    leaf_container->handle_modify(spec, true);
+
+    // The deferred state is applied via the restore mechanism when the container is shown.
+    EXPECT_CALL(*window_controller, show(window, testing::Field(&RestoreResult::state, mir_window_state_fullscreen))).Times(1);
+    leaf_container->show();
+}
+
+TEST_F(LeafContainerTest, HandleModifyWhileHiddenSanitizesMaximizeToRestored)
+{
+    miral::WindowSpecification spec;
+    spec.state() = mir_window_state_maximized;
+    leaf_container->handle_modify(spec, true);
+
+    // Only fullscreen is honoured for tiled windows; a maximize request defers as restored.
+    EXPECT_CALL(*window_controller, show(window, testing::Field(&RestoreResult::state, mir_window_state_restored))).Times(1);
+    leaf_container->show();
+}
 
 TEST_F(LeafContainerTest, ShowingContainerCausesRaise)
 {
@@ -517,7 +543,7 @@ TEST_F(LeafContainerTest, HandleModifyChangeStateToFullscreenTriggersObserver)
 
     miral::WindowSpecification spec;
     spec.state() = mir_window_state_fullscreen;
-    leaf_container->handle_modify(spec);
+    leaf_container->handle_modify(spec, false);
 }
 
 TEST_F(LeafContainerTest, SetStateToFullscreenTriggersObserver)

--- a/tests/test_plugin_managed_container.cpp
+++ b/tests/test_plugin_managed_container.cpp
@@ -179,7 +179,7 @@ TEST_F(PluginManagedContainerTest, HandleModifyBlocksFullscreenWhenNotResizable)
     miral::WindowSpecification spec;
     spec.state() = mir_window_state_fullscreen;
     EXPECT_CALL(*window_controller, change_state(window, mir_window_state_restored)).Times(1);
-    container_not_resizable->handle_modify(spec);
+    container_not_resizable->handle_modify(spec, false);
 }
 
 TEST_F(PluginManagedContainerTest, HandleModifyBlocksFullscreenWhenNotMovable)
@@ -187,7 +187,7 @@ TEST_F(PluginManagedContainerTest, HandleModifyBlocksFullscreenWhenNotMovable)
     miral::WindowSpecification spec;
     spec.state() = mir_window_state_fullscreen;
     EXPECT_CALL(*window_controller, change_state(window, mir_window_state_restored)).Times(1);
-    container_not_movable->handle_modify(spec);
+    container_not_movable->handle_modify(spec, false);
 }
 
 TEST_F(PluginManagedContainerTest, HandleModifyAllowsFullscreenWhenResizableAndMovable)
@@ -195,7 +195,7 @@ TEST_F(PluginManagedContainerTest, HandleModifyAllowsFullscreenWhenResizableAndM
     miral::WindowSpecification spec;
     spec.state() = mir_window_state_fullscreen;
     EXPECT_CALL(*window_controller, change_state(window, mir_window_state_fullscreen)).Times(1);
-    container_resizable_and_movable->handle_modify(spec);
+    container_resizable_and_movable->handle_modify(spec, false);
 }
 
 TEST_F(PluginManagedContainerTest, HandleModifyBlocksMaximizeWhenNotResizable)
@@ -203,7 +203,7 @@ TEST_F(PluginManagedContainerTest, HandleModifyBlocksMaximizeWhenNotResizable)
     miral::WindowSpecification spec;
     spec.state() = mir_window_state_maximized;
     EXPECT_CALL(*window_controller, change_state(window, mir_window_state_restored)).Times(1);
-    container_not_resizable->handle_modify(spec);
+    container_not_resizable->handle_modify(spec, false);
 }
 
 TEST_F(PluginManagedContainerTest, HandleModifyAllowsMaximizeWhenResizableAndMovable)
@@ -211,7 +211,7 @@ TEST_F(PluginManagedContainerTest, HandleModifyAllowsMaximizeWhenResizableAndMov
     miral::WindowSpecification spec;
     spec.state() = mir_window_state_maximized;
     EXPECT_CALL(*window_controller, change_state(window, mir_window_state_maximized)).Times(1);
-    container_resizable_and_movable->handle_modify(spec);
+    container_resizable_and_movable->handle_modify(spec, false);
 }
 
 TEST_F(PluginManagedContainerTest, HandleModifyBlocksMaximizeWhenNotMovable)
@@ -219,7 +219,21 @@ TEST_F(PluginManagedContainerTest, HandleModifyBlocksMaximizeWhenNotMovable)
     miral::WindowSpecification spec;
     spec.state() = mir_window_state_maximized;
     EXPECT_CALL(*window_controller, change_state(window, mir_window_state_restored)).Times(1);
-    container_not_movable->handle_modify(spec);
+    container_not_movable->handle_modify(spec, false);
+}
+
+TEST_F(PluginManagedContainerTest, HandleModifyWhileHiddenDefersStateUntilShown)
+{
+    miral::WindowSpecification spec;
+    spec.state() = mir_window_state_fullscreen;
+
+    // While hidden, no live state change is applied now...
+    EXPECT_CALL(*window_controller, change_state(_, _)).Times(0);
+    container_resizable_and_movable->handle_modify(spec, true);
+
+    // ...the deferred state is applied when the container is next shown.
+    EXPECT_CALL(*window_controller, show(window, Field(&RestoreResult::state, mir_window_state_fullscreen))).Times(1);
+    container_resizable_and_movable->show();
 }
 
 // ---- to_json ----


### PR DESCRIPTION
## Problem
When the window was not on the focused workspace, we were ignoring all modifications to it, which included the input shape (of course!). This has been like this for so long that I took it for granted.

The solution is to always allow modification, but stash any state change update for when the workspace will be shown.

What a mess!