### PR TITLE
bugfix: turn off surface occlusion while overview is on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ add_library(miracle-wm-implementation STATIC
         src/overview_scene_override.cpp src/overview_scene_override.h
         src/overview_scene_override_delegate.h
         src/workspace_preview.cpp src/workspace_preview.h
+        src/occlusion_bypass.cpp src/occlusion_bypass.h
 )
 
 target_compile_definitions(miracle-wm-implementation PRIVATE

--- a/src/occlusion_bypass.cpp
+++ b/src/occlusion_bypass.cpp
@@ -1,0 +1,86 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#include "occlusion_bypass.h"
+#include "window_container.h"
+
+#include <algorithm>
+#include <mir/scene/surface.h>
+
+using namespace miracle;
+
+namespace
+{
+mir::scene::Surface const* surface_key(std::shared_ptr<WindowContainer> const& container)
+{
+    auto const window = container->window();
+    if (!window)
+        return nullptr;
+
+    return window->operator std::shared_ptr<mir::scene::Surface>().get();
+}
+}
+
+OcclusionBypass::~OcclusionBypass()
+{
+    release();
+}
+
+void OcclusionBypass::acquire(std::vector<std::shared_ptr<WindowContainer>> const& containers)
+{
+    for (auto const& container : containers)
+    {
+        if (!container)
+            continue;
+
+        auto const already_acquired = std::ranges::find_if(flagged, [&](auto const& f)
+        {
+            return container == f.container.lock();
+        }) != flagged.end();
+
+        if (already_acquired)
+            continue;
+
+        flagged.push_back({ container, surface_key(container) });
+        container->set_occlusion_bypass(true);
+    }
+}
+
+void OcclusionBypass::forget(mir::scene::Surface const* surface)
+{
+    std::erase_if(flagged, [&](auto const& f)
+    {
+        return f.key == surface;
+    });
+}
+
+void OcclusionBypass::release()
+{
+    auto const to_clear = std::move(flagged);
+    flagged.clear();
+
+    for (auto const& entry : to_clear)
+    {
+        if (auto const container = entry.container.lock())
+            container->set_occlusion_bypass(false);
+    }
+}
+
+bool OcclusionBypass::held() const
+{
+    return !flagged.empty();
+}

--- a/src/occlusion_bypass.h
+++ b/src/occlusion_bypass.h
@@ -33,12 +33,7 @@ class WindowContainer;
 /// Keeps windows that are covered up out of the compositor's occlusion cull for
 /// as long as the bypass is held.
 ///
-/// Mir drops a surface that something else completely covers before miracle's
-/// renderer ever sees it, so an effect that draws a window somewhere other than
-/// where it really is - an overview, a switcher, a wall of thumbnails - has to
-/// ask for it back first. Holding one of these instead of driving
-/// [WindowContainer::set_occlusion_bypass] directly means the bypass is always
-/// undone exactly once, for exactly the windows it was applied to.
+/// TODO: This is largely a hack for the wffects system.
 ///
 /// Every method must be called on the window management thread. An effect whose
 /// teardown runs elsewhere (the animator thread, say) should hand the release

--- a/src/occlusion_bypass.h
+++ b/src/occlusion_bypass.h
@@ -1,0 +1,92 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef OCCLUSION_BYPASS_H
+#define OCCLUSION_BYPASS_H
+
+#include <memory>
+#include <vector>
+
+namespace mir::scene
+{
+class Surface;
+}
+
+namespace miracle
+{
+class WindowContainer;
+
+/// Keeps windows that are covered up out of the compositor's occlusion cull for
+/// as long as the bypass is held.
+///
+/// Mir drops a surface that something else completely covers before miracle's
+/// renderer ever sees it, so an effect that draws a window somewhere other than
+/// where it really is - an overview, a switcher, a wall of thumbnails - has to
+/// ask for it back first. Holding one of these instead of driving
+/// [WindowContainer::set_occlusion_bypass] directly means the bypass is always
+/// undone exactly once, for exactly the windows it was applied to.
+///
+/// Every method must be called on the window management thread. An effect whose
+/// teardown runs elsewhere (the animator thread, say) should hand the release
+/// to [WindowController::invoke_under_lock].
+class OcclusionBypass
+{
+public:
+    OcclusionBypass() = default;
+    OcclusionBypass(OcclusionBypass const&) = delete;
+    OcclusionBypass& operator=(OcclusionBypass const&) = delete;
+
+    /// Releases the bypass, in case the holder forgot to.
+    ~OcclusionBypass();
+
+    /// Bypasses the cull for every container in \p containers that is not
+    /// already bypassed, remembering the ones it flagged.
+    ///
+    /// Additive and idempotent, so an effect can call this again as windows
+    /// join it.
+    void acquire(std::vector<std::shared_ptr<WindowContainer>> const& containers);
+
+    /// Forgets the container holding \p surface without touching it.
+    ///
+    /// For a window that is going away under us: its transform belongs to
+    /// whoever is animating it out, and clearing the bypass would fight them.
+    void forget(mir::scene::Surface const* surface);
+
+    /// Puts everything [acquire] flagged back into the cull. Idempotent.
+    void release();
+
+    /// Whether anything is currently bypassed.
+    [[nodiscard]] bool held() const;
+
+private:
+    struct Flagged
+    {
+        /// Held weakly: a container that is destroyed mid-bypass simply stops
+        /// resolving, and there is nothing left to undo - its surface is dying
+        /// and its transform is no longer ours.
+        std::weak_ptr<WindowContainer> container;
+
+        /// The container's surface, kept for identity only so that [forget] can
+        /// find it without resolving the container.
+        mir::scene::Surface const* key = nullptr;
+    };
+
+    std::vector<Flagged> flagged;
+};
+}
+
+#endif

--- a/src/overview_scene_override.cpp
+++ b/src/overview_scene_override.cpp
@@ -447,19 +447,6 @@ OverviewSceneOverride::OverviewSceneOverride(
 OverviewSceneOverride::~OverviewSceneOverride()
 {
     animator->remove_by_animation_handle(animation_handle);
-
-    // The preview is deliberately not released here: this destructor may run on
-    // the animator thread, and concealing a workspace is window management. Every
-    // exit path releases it on the window management thread before getting here.
-    //
-    // The occlusion bypass is not released here either, for the same reason -
-    // but its own destructor is load bearing rather than merely a safety net.
-    // [SceneOverrideManager::try_override] takes the override by value and
-    // destroys it inside itself when something else already holds the scene, on
-    // the window management thread: the constructor has applied the bypass by
-    // then and no exit path ever runs. On the ordinary outro the shared pointer
-    // has already been handed to the exit lambda, so there is nothing left here
-    // to undo.
 }
 
 std::vector<mir::scene::Surface const*> OverviewSceneOverride::window_strip_keys(size_t group) const

--- a/src/overview_scene_override.cpp
+++ b/src/overview_scene_override.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "animator.h"
 #include "compositor_state.h"
 #include "config.h"
+#include "occlusion_bypass.h"
 #include "output_manager.h"
 #include "overview_scene_override_delegate.h"
 #include "shell_component_container.h"
@@ -353,6 +354,7 @@ OverviewSceneOverride::OverviewSceneOverride(
     window_controller { window_controller },
     compositor_state { compositor_state },
     preview { std::make_shared<WorkspacePreview>() },
+    bypass { std::make_shared<OcclusionBypass>() },
     delegate { &delegate },
     animation_handle { animator->register_animateable() },
     primary_modifier { config->get_input_event_modifier() }
@@ -428,6 +430,18 @@ OverviewSceneOverride::OverviewSceneOverride(
                 entry.from[i] = entry.current[i] = entry.target[i];
         }
     }
+
+    // Nothing else can see the state yet, so no lock is needed. This happens
+    // before any [WorkspacePreview::acquire], and the reveal's recomposition of
+    // each window's transform carries the bypass along rather than clobbering it.
+    std::vector<miral::Window> to_bypass;
+    to_bypass.reserve(state->entries.size() + state->shell_entries.size());
+    for (auto const& [key, entry] : state->entries)
+        to_bypass.push_back(entry.window);
+    for (auto const& [key, entry] : state->shell_entries)
+        to_bypass.push_back(entry.window);
+
+    bypass_occlusion(to_bypass);
 }
 
 OverviewSceneOverride::~OverviewSceneOverride()
@@ -437,6 +451,15 @@ OverviewSceneOverride::~OverviewSceneOverride()
     // The preview is deliberately not released here: this destructor may run on
     // the animator thread, and concealing a workspace is window management. Every
     // exit path releases it on the window management thread before getting here.
+    //
+    // The occlusion bypass is not released here either, for the same reason -
+    // but its own destructor is load bearing rather than merely a safety net.
+    // [SceneOverrideManager::try_override] takes the override by value and
+    // destroys it inside itself when something else already holds the scene, on
+    // the window management thread: the constructor has applied the bypass by
+    // then and no exit path ever runs. On the ordinary outro the shared pointer
+    // has already been handed to the exit lambda, so there is nothing left here
+    // to undo.
 }
 
 std::vector<mir::scene::Surface const*> OverviewSceneOverride::window_strip_keys(size_t group) const
@@ -751,6 +774,10 @@ void OverviewSceneOverride::enter_workspaces()
         preview->acquire(to_reveal);
     }
 
+    // The windows the reveal brought with it, to be kept out of the occlusion
+    // cull once the state lock is released.
+    std::vector<miral::Window> joined;
+
     {
         std::lock_guard lock(state->mutex);
         state->level = Level::workspaces;
@@ -800,12 +827,16 @@ void OverviewSceneOverride::enter_workspaces()
 
                 state->order.push_back(key);
                 state->entries.emplace(key, Entry { .window = window, .real = real, .from = placement, .target = placement, .current = placement, .group = group, .workspace = workspace });
+                joined.push_back(window);
             }
         }
 
         for (size_t group = 0; group < groups.size(); ++group)
             retarget(group);
     }
+
+    // Window management, so it waits until the state lock is out of the way.
+    bypass_occlusion(joined);
 
     settle();
 }
@@ -825,6 +856,19 @@ void OverviewSceneOverride::return_to_windows()
     }
 
     settle();
+}
+
+void OverviewSceneOverride::bypass_occlusion(std::vector<miral::Window> const& windows)
+{
+    std::vector<std::shared_ptr<WindowContainer>> containers;
+    containers.reserve(windows.size());
+    for (auto const& window : windows)
+    {
+        if (auto const container = window_controller->get_window_container(window))
+            containers.push_back(container);
+    }
+
+    bypass->acquire(containers);
 }
 
 void OverviewSceneOverride::commit_and_exit()
@@ -920,11 +964,12 @@ void OverviewSceneOverride::begin_exit()
     auto const s = state;
     auto* const d = delegate;
     auto const held_preview = preview;
+    auto const held_bypass = bypass;
     auto const controller = window_controller;
     auto const selected = selected_workspace;
-    animate([s, d, held_preview, controller, selected]
+    animate([s, d, held_preview, held_bypass, controller, selected]
     {
-        controller->invoke_under_lock([s, d, held_preview, selected]
+        controller->invoke_under_lock([s, d, held_preview, held_bypass, selected]
         {
             {
                 std::lock_guard lock(s->mutex);
@@ -936,6 +981,10 @@ void OverviewSceneOverride::begin_exit()
                 d->on_workspace_selected(*selected);
 
             held_preview->release();
+
+            // Last, so that the workspace switch above - which recomposes the
+            // transforms of everything it touches - cannot put the bypass back.
+            held_bypass->release();
 
             std::lock_guard lock(s->mutex);
             s->phase = Phase::done;
@@ -1146,6 +1195,10 @@ void OverviewSceneOverride::place(
 
 void OverviewSceneOverride::handle_window_added(miral::Window const& window)
 {
+    // Resolved under the lock, but kept until after it so that the occlusion
+    // bypass - window management - happens outside it.
+    std::shared_ptr<WindowContainer> joined;
+
     {
         std::lock_guard lock(state->mutex);
         if (state->phase == Phase::outro || state->phase == Phase::done)
@@ -1157,7 +1210,8 @@ void OverviewSceneOverride::handle_window_added(miral::Window const& window)
 
         geom::Rectangle const real { window.top_left(), window.size() };
 
-        auto const location = locate(window_controller->get_window_container(window));
+        joined = window_controller->get_window_container(window);
+        auto const location = locate(joined);
         if (!location)
             return;
 
@@ -1200,6 +1254,8 @@ void OverviewSceneOverride::handle_window_added(miral::Window const& window)
         retarget(group);
     }
 
+    bypass->acquire({ joined });
+
     auto const s = state;
     animate([s]
     {
@@ -1229,6 +1285,7 @@ void OverviewSceneOverride::cancel()
     // There is no outro to hand the workspaces back at the end of, so put them
     // away now. Cancellation always reaches us on the window management thread.
     conceal_workspaces();
+    bypass->release();
 
     // [begin_exit] has already announced the exit if the outro was running.
     if (!was_exiting)
@@ -1248,6 +1305,10 @@ void OverviewSceneOverride::handle_window_closed(miral::Window const& window)
             return;
 
         auto const* key = surface_key(window);
+
+        // Dropped rather than cleared: the surface is dying, and its transform
+        // belongs to whoever is animating it out from here on.
+        bypass->forget(key);
 
         // The group comes from whichever kind of entry the surface was, so that
         // losing a panel retargets the output it belonged to rather than the first.

--- a/src/overview_scene_override.h
+++ b/src/overview_scene_override.h
@@ -40,6 +40,7 @@ class AbstractWorkspace;
 class Animator;
 class CompositorState;
 class Config;
+class OcclusionBypass;
 class OutputManager;
 class OverviewSceneOverrideDelegate;
 class WindowContainer;
@@ -327,6 +328,17 @@ private:
     /// that flipping between levels stays cheap.
     void return_to_windows();
 
+    /// Keeps \p windows out of the compositor's occlusion cull for as long as
+    /// the overview is up.
+    ///
+    /// A window that something else completely covers where it really is - one
+    /// buried behind a maximised window, or the wallpaper behind everything -
+    /// would otherwise never reach the renderer, and so would be missing from
+    /// the strip. Windows with no container are skipped.
+    ///
+    /// Must run on the window management thread, and outside `state->mutex`.
+    void bypass_occlusion(std::vector<miral::Window> const& windows);
+
     /// Focuses whatever is front and center on the active output's window
     /// strip, then exits.
     void commit_and_exit();
@@ -366,6 +378,7 @@ private:
     std::shared_ptr<WindowController> window_controller;
     std::shared_ptr<CompositorState> compositor_state;
     std::shared_ptr<WorkspacePreview> preview;
+    std::shared_ptr<OcclusionBypass> bypass;
     OverviewSceneOverrideDelegate* delegate;
     AnimationHandle animation_handle;
     AnimationDefinition definition;

--- a/src/overview_scene_override.h
+++ b/src/overview_scene_override.h
@@ -331,10 +331,7 @@ private:
     /// Keeps \p windows out of the compositor's occlusion cull for as long as
     /// the overview is up.
     ///
-    /// A window that something else completely covers where it really is - one
-    /// buried behind a maximised window, or the wallpaper behind everything -
-    /// would otherwise never reach the renderer, and so would be missing from
-    /// the strip. Windows with no container are skipped.
+    /// TODO: This is largely a hack for the wffects system.
     ///
     /// Must run on the window management thread, and outside `state->mutex`.
     void bypass_occlusion(std::vector<miral::Window> const& windows);

--- a/src/window_container.cpp
+++ b/src/window_container.cpp
@@ -21,6 +21,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "render_data_manager.h"
 #include "window_controller.h"
 
+#include <glm/gtc/matrix_transform.hpp>
+
+namespace
+{
+/// A transform that Mir's occlusion test refuses to cull through, but that no
+/// shader can tell apart from the identity.
+///
+/// Every vertex miracle hands the GPU has `z == 0`, and the transform is
+/// applied to the position before it becomes `gl_Position`, so scaling z scales
+/// nothing at all. A translation in z would move the vertex within the clip
+/// test, and anything touching the bottom-right element would introduce a
+/// perspective divide that shrinks the surface - a z-scale is the only choice
+/// that is inert for every transform it is composed with.
+glm::mat4 const OCCLUSION_BYPASS = glm::scale(glm::mat4(1.f), glm::vec3(1.f, 1.f, 1.0001f));
+}
+
 miracle::WindowContainer::WindowContainer(
     uint64_t id,
     std::shared_ptr<RenderDataManager> const& rdm,
@@ -204,14 +220,31 @@ void miracle::WindowContainer::on_focus_lost()
             rdm_locked->focus_change(render_id_.value(), false);
 }
 
+void miracle::WindowContainer::set_occlusion_bypass(bool bypass)
+{
+    if (occlusion_bypass_ == bypass)
+        return;
+
+    occlusion_bypass_ = bypass;
+    rerender();
+}
+
+glm::mat4 miracle::WindowContainer::occlusion_bypass_transform()
+{
+    return OCCLUSION_BYPASS;
+}
+
 void miracle::WindowContainer::rerender()
 {
     // A hack to trigger a rerender on the surface by re-applying its transformation.
     auto const w = window().value();
     if (auto const surface = w.operator std::shared_ptr<mir::scene::Surface>())
     {
+        // Composed on the right so that it only changes how the input z - which
+        // is always zero - contributes, whatever the composed transform is.
         auto const combined = workspace_effect.blend(window_effect.blend(animation_effect));
-        surface->set_transformation(combined.transform);
+        surface->set_transformation(
+            occlusion_bypass_ ? combined.transform * OCCLUSION_BYPASS : combined.transform);
         surface->set_alpha(combined.alpha);
     }
 }

--- a/src/window_container.h
+++ b/src/window_container.h
@@ -133,20 +133,7 @@ public:
     /// Keep this container's window in the render list even when something
     /// else completely covers it.
     ///
-    /// Mir's compositor drops fully occluded surfaces before miracle's renderer
-    /// ever sees them, so a window buried behind a maximised one - or the
-    /// wallpaper behind everything - cannot be drawn somewhere else. Its
-    /// occlusion test bails out early for any surface whose transformation is
-    /// not the identity, so a transform that changes nothing about how the
-    /// surface is drawn is enough to opt out of the culling. Windows that are
-    /// bypassed also keep producing frames, so an overview draws live content
-    /// rather than a stale buffer.
-    ///
-    /// The bypass is composed into the transform this container pushes to its
-    /// surface rather than written to the surface directly, because every
-    /// effect change recomposes that transform from scratch and would otherwise
-    /// wipe the bypass out. It is deliberately kept out of the render data, so
-    /// a tracked window's renderer state stays clean.
+    /// TODO: This is largely a hack for the wffects system.
     ///
     /// \param bypass whether to keep the window out of the occlusion cull
     void set_occlusion_bypass(bool bypass);

--- a/src/window_container.h
+++ b/src/window_container.h
@@ -130,6 +130,33 @@ public:
     /// Check if animations are turned on for this type of window.
     virtual bool can_animate();
 
+    /// Keep this container's window in the render list even when something
+    /// else completely covers it.
+    ///
+    /// Mir's compositor drops fully occluded surfaces before miracle's renderer
+    /// ever sees them, so a window buried behind a maximised one - or the
+    /// wallpaper behind everything - cannot be drawn somewhere else. Its
+    /// occlusion test bails out early for any surface whose transformation is
+    /// not the identity, so a transform that changes nothing about how the
+    /// surface is drawn is enough to opt out of the culling. Windows that are
+    /// bypassed also keep producing frames, so an overview draws live content
+    /// rather than a stale buffer.
+    ///
+    /// The bypass is composed into the transform this container pushes to its
+    /// surface rather than written to the surface directly, because every
+    /// effect change recomposes that transform from scratch and would otherwise
+    /// wipe the bypass out. It is deliberately kept out of the render data, so
+    /// a tracked window's renderer state stays clean.
+    ///
+    /// \param bypass whether to keep the window out of the occlusion cull
+    void set_occlusion_bypass(bool bypass);
+
+    /// Whether this container's window is opted out of occlusion culling.
+    [[nodiscard]] bool occlusion_bypass() const { return occlusion_bypass_; }
+
+    /// The visually inert matrix that [set_occlusion_bypass] composes in.
+    [[nodiscard]] static glm::mat4 occlusion_bypass_transform();
+
     /// Change the urgency of the window.
     ///
     /// \param urgent new urgency
@@ -160,6 +187,7 @@ protected:
 private:
     bool enable_render_data_ = true;
     bool urgent_ = false;
+    bool occlusion_bypass_ = false;
 };
 
 } // namespace miracle

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES
     test_carousel_layout.cpp
     test_overview_scene_override.cpp
     test_workspace_preview.cpp
+    test_occlusion_bypass.cpp
     mock_workspace.h
     test_sampler_registry.cpp
     test_output_manager.cpp

--- a/tests/test_leaf_container.cpp
+++ b/tests/test_leaf_container.cpp
@@ -33,8 +33,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "mock_workspace.h"
 #include "stub_configuration.h"
 #include "gmock/gmock.h"
+#include <glm/gtc/matrix_transform.hpp>
 #include <gtest/gtest.h>
 #include <memory>
+#include <vector>
 
 using namespace miracle;
 
@@ -918,4 +920,80 @@ TEST_F(LeafContainerTest, ToJsonReportsUrgency)
 
     leaf_container->set_urgent(true);
     EXPECT_TRUE(leaf_container->to_json(true)["urgent"]);
+}
+
+// ---- occlusion bypass ----
+
+TEST_F(LeafContainerTest, OcclusionBypassPutsANonIdentityTransformOnTheSurface)
+{
+    // Mir culls a fully covered surface before the renderer sees it, unless its
+    // transformation is something other than the identity.
+    glm::mat4 last(1.f);
+    EXPECT_CALL(*surface, set_transformation(testing::_))
+        .WillRepeatedly(testing::SaveArg<0>(&last));
+
+    EXPECT_FALSE(leaf_container->occlusion_bypass());
+    leaf_container->set_occlusion_bypass(true);
+
+    EXPECT_TRUE(leaf_container->occlusion_bypass());
+    EXPECT_NE(last, glm::mat4(1.f));
+}
+
+TEST_F(LeafContainerTest, OcclusionBypassSurvivesALaterEffectChange)
+{
+    // Every effect setter recomposes the surface's transform from scratch, so a
+    // bypass written straight to the surface would be wiped out by the next one.
+    auto const workspace_transform = glm::translate(glm::mat4(1.f), glm::vec3(100.f, 0.f, 0.f));
+    glm::mat4 last(1.f);
+    EXPECT_CALL(*surface, set_transformation(testing::_))
+        .WillRepeatedly(testing::SaveArg<0>(&last));
+
+    leaf_container->set_occlusion_bypass(true);
+    leaf_container->set_workspace_transform(workspace_transform);
+
+    EXPECT_EQ(last, workspace_transform * WindowContainer::occlusion_bypass_transform());
+    EXPECT_NE(last, glm::mat4(1.f));
+}
+
+TEST_F(LeafContainerTest, ClearingTheOcclusionBypassRestoresTheComposedTransform)
+{
+    auto const workspace_transform = glm::translate(glm::mat4(1.f), glm::vec3(100.f, 0.f, 0.f));
+    glm::mat4 last(1.f);
+    EXPECT_CALL(*surface, set_transformation(testing::_))
+        .WillRepeatedly(testing::SaveArg<0>(&last));
+
+    leaf_container->set_occlusion_bypass(true);
+    leaf_container->set_workspace_transform(workspace_transform);
+    leaf_container->set_occlusion_bypass(false);
+
+    EXPECT_FALSE(leaf_container->occlusion_bypass());
+    EXPECT_EQ(last, workspace_transform);
+}
+
+TEST_F(LeafContainerTest, TheOcclusionBypassTransformIsVisuallyInert)
+{
+    // Every vertex miracle tessellates has z == 0, so a scale in z moves nothing.
+    // This is the whole reason the bypass is free, and it must survive being
+    // composed with whatever the effects happen to be.
+    auto const bypass = WindowContainer::occlusion_bypass_transform();
+    ASSERT_NE(bypass, glm::mat4(1.f));
+
+    std::vector<glm::mat4> const matrices {
+        glm::mat4(1.f),
+        glm::translate(glm::mat4(1.f), glm::vec3(-320.f, 47.f, 0.f)),
+        glm::scale(glm::mat4(1.f), glm::vec3(0.4f, 0.4f, 1.f))
+    };
+
+    std::vector<glm::vec4> const corners {
+        { 0.f,   0.f,   0.f, 1.f },
+        { 400.f, 0.f,   0.f, 1.f },
+        { 0.f,   300.f, 0.f, 1.f },
+        { 400.f, 300.f, 0.f, 1.f }
+    };
+
+    for (auto const& matrix : matrices)
+    {
+        for (auto const& corner : corners)
+            EXPECT_EQ(matrix * bypass * corner, matrix * corner);
+    }
 }

--- a/tests/test_occlusion_bypass.cpp
+++ b/tests/test_occlusion_bypass.cpp
@@ -1,0 +1,176 @@
+/**
+Copyright (C) 2025  Matthew Kosarek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#include "occlusion_bypass.h"
+
+#include "mock_container.h"
+#include "mock_session.h"
+#include "mock_surface.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <mir/scene/surface.h>
+
+using namespace miracle;
+using namespace testing;
+
+namespace
+{
+using MockContainerPtr = std::shared_ptr<NiceMock<test::MockContainer>>;
+}
+
+class OcclusionBypassTest : public Test
+{
+public:
+    OcclusionBypassTest() :
+        session { std::make_shared<NiceMock<test::MockSession>>() },
+        app { session }
+    {
+    }
+
+protected:
+    /// A container wrapping a window of its own, so that each one has a
+    /// distinct surface for [OcclusionBypass::forget] to key on.
+    MockContainerPtr bypassable()
+    {
+        auto const surface = std::make_shared<NiceMock<test::MockSurface>>();
+        surfaces.push_back(surface);
+
+        auto container = std::make_shared<NiceMock<test::MockContainer>>();
+        ON_CALL(*container, window())
+            .WillByDefault(Return(std::optional {
+                miral::Window { app, surface }
+        }));
+        return container;
+    }
+
+    static mir::scene::Surface const* key_of(MockContainerPtr const& container)
+    {
+        auto const window = container->window().value();
+        return window.operator std::shared_ptr<mir::scene::Surface>().get();
+    }
+
+    std::shared_ptr<test::MockSession> session;
+    miral::Application app;
+    /// The windows hold their surfaces weakly, so someone has to own them.
+    std::vector<std::shared_ptr<test::MockSurface>> surfaces;
+};
+
+TEST_F(OcclusionBypassTest, AcquireFlagsEveryContainer)
+{
+    auto const first = bypassable();
+    auto const second = bypassable();
+
+    OcclusionBypass bypass;
+    bypass.acquire({ first, second });
+
+    EXPECT_TRUE(bypass.held());
+    EXPECT_TRUE(first->occlusion_bypass());
+    EXPECT_TRUE(second->occlusion_bypass());
+}
+
+TEST_F(OcclusionBypassTest, AcquireIsAdditiveAndIdempotent)
+{
+    auto const first = bypassable();
+    auto const second = bypassable();
+
+    OcclusionBypass bypass;
+    bypass.acquire({ first });
+    bypass.acquire({ first, second });
+
+    EXPECT_TRUE(first->occlusion_bypass());
+    EXPECT_TRUE(second->occlusion_bypass());
+
+    // Both are remembered exactly once, so one release puts both back.
+    bypass.release();
+    EXPECT_FALSE(first->occlusion_bypass());
+    EXPECT_FALSE(second->occlusion_bypass());
+}
+
+TEST_F(OcclusionBypassTest, ReleaseClearsEveryContainer)
+{
+    auto const first = bypassable();
+    auto const second = bypassable();
+
+    OcclusionBypass bypass;
+    bypass.acquire({ first, second });
+    bypass.release();
+
+    EXPECT_FALSE(bypass.held());
+    EXPECT_FALSE(first->occlusion_bypass());
+    EXPECT_FALSE(second->occlusion_bypass());
+}
+
+TEST_F(OcclusionBypassTest, ReleaseIsIdempotent)
+{
+    auto const container = bypassable();
+
+    OcclusionBypass bypass;
+    bypass.acquire({ container });
+    bypass.release();
+
+    // A second release must not undo a bypass somebody else has since applied.
+    container->set_occlusion_bypass(true);
+    bypass.release();
+
+    EXPECT_TRUE(container->occlusion_bypass());
+}
+
+TEST_F(OcclusionBypassTest, DestructorReleases)
+{
+    auto const container = bypassable();
+
+    {
+        OcclusionBypass bypass;
+        bypass.acquire({ container });
+        EXPECT_TRUE(container->occlusion_bypass());
+    }
+
+    EXPECT_FALSE(container->occlusion_bypass());
+}
+
+TEST_F(OcclusionBypassTest, AContainerThatDiedIsSkipped)
+{
+    auto container = bypassable();
+    auto const survivor = bypassable();
+
+    OcclusionBypass bypass;
+    bypass.acquire({ container, survivor });
+
+    // The surface is dying with it, and its transform is no longer ours.
+    container.reset();
+
+    bypass.release();
+    EXPECT_FALSE(survivor->occlusion_bypass());
+}
+
+TEST_F(OcclusionBypassTest, ForgetDropsAContainerWithoutClearingIt)
+{
+    auto const container = bypassable();
+    auto const other = bypassable();
+
+    OcclusionBypass bypass;
+    bypass.acquire({ container, other });
+
+    bypass.forget(key_of(container));
+
+    bypass.release();
+
+    // Forgotten, so the release left it exactly as it was.
+    EXPECT_TRUE(container->occlusion_bypass());
+    EXPECT_FALSE(other->occlusion_bypass());
+}

--- a/tests/test_overview_scene_override.cpp
+++ b/tests/test_overview_scene_override.cpp
@@ -37,7 +37,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <linux/input-event-codes.h>
+#include <mir/events/event_builders.h>
+#include <mir/scene/surface.h>
 #include <miral/window_specification.h>
+#include <unordered_map>
+#include <xkbcommon/xkbcommon-keysyms.h>
 
 using namespace miracle;
 using namespace testing;
@@ -118,6 +123,23 @@ public:
             std::make_shared<WorkspaceObserverRegistrar>(), config, output_manager);
         output_manager->create("Output1", 1, OUTPUT_AREA, *workspace_manager);
         output_manager->focus(1);
+
+        // The occlusion bypass reaches a window's container through the
+        // controller, so without this it silently flags nothing.
+        ON_CALL(*window_controller, get_window_container(_))
+            .WillByDefault(Invoke([this](miral::Window const& window)
+        {
+            auto const it = containers_by_surface.find(
+                window.operator std::shared_ptr<mir::scene::Surface>().get());
+            return it == containers_by_surface.end() ? nullptr : it->second;
+        }));
+
+        // The real one is synchronous, and the outro does its cleanup inside it.
+        ON_CALL(*window_controller, invoke_under_lock(_))
+            .WillByDefault(Invoke([](std::function<void()> const& f)
+        {
+            f();
+        }));
     }
 
     std::unique_ptr<OverviewSceneOverride> create()
@@ -143,7 +165,7 @@ public:
             compositor_state);
         leaf->associate_to_window(window);
         compositor_state->add(leaf);
-        containers.push_back(leaf);
+        remember(window, leaf);
         return window;
     }
 
@@ -174,11 +196,25 @@ public:
             output_manager,
             compositor_state);
         compositor_state->add(container);
-        containers.push_back(container);
+        remember(window, container);
         return window;
     }
 
+    /// The container the overview is expected to have flagged for \p window.
+    std::shared_ptr<WindowContainer> container_of(miral::Window const& window)
+    {
+        return containers_by_surface.at(
+            window.operator std::shared_ptr<mir::scene::Surface>().get());
+    }
+
 protected:
+    void remember(miral::Window const& window, std::shared_ptr<WindowContainer> const& container)
+    {
+        containers.push_back(container);
+        containers_by_surface.emplace(
+            window.operator std::shared_ptr<mir::scene::Surface>().get(), container);
+    }
+
     miral::Window make_window()
     {
         auto const surface = std::make_shared<NiceMock<test::MockSurface>>();
@@ -209,6 +245,7 @@ protected:
     std::vector<std::shared_ptr<test::MockSurface>> surfaces;
     /// The compositor state holds its windows weakly, so someone has to own them.
     std::vector<std::shared_ptr<WindowContainer>> containers;
+    std::unordered_map<mir::scene::Surface const*, std::shared_ptr<WindowContainer>> containers_by_surface;
     std::unique_ptr<miral::WindowInfo> background_info;
 };
 
@@ -261,4 +298,115 @@ TEST_F(OverviewSceneOverrideTest, ClosingTheLastSurfaceOfAnyKindTearsTheOverview
     // Nothing left to draw at any level, so the overview goes away.
     EXPECT_TRUE(delegate.done);
     EXPECT_TRUE(delegate.exit_started);
+}
+
+// ---- occlusion bypass ----
+
+namespace
+{
+/// An Escape key press, which backs out of the window strip and exits.
+mir::EventUPtr escape_press()
+{
+    return mir::events::make_key_event(
+        mir_input_event_type_key,
+        std::chrono::nanoseconds { 0 },
+        mir_keyboard_action_down,
+        XKB_KEY_Escape,
+        KEY_ESC,
+        mir_input_event_modifier_none);
+}
+}
+
+TEST_F(OverviewSceneOverrideTest, OpeningKeepsEverythingItDrawsOutOfTheOcclusionCull)
+{
+    report_windows_as_backgrounds();
+
+    auto const background = add_background();
+    auto const toplevel = add_toplevel();
+
+    auto const override_ = create();
+    ASSERT_NE(nullptr, override_);
+
+    // A window buried behind a maximised one, and the wallpaper behind
+    // everything, are both fully covered where they really are, so Mir would
+    // otherwise never hand them to the renderer.
+    EXPECT_TRUE(container_of(toplevel)->occlusion_bypass());
+    EXPECT_TRUE(container_of(background)->occlusion_bypass());
+}
+
+TEST_F(OverviewSceneOverrideTest, CancellingPutsEverythingBackIntoTheOcclusionCull)
+{
+    report_windows_as_backgrounds();
+
+    auto const background = add_background();
+    auto const toplevel = add_toplevel();
+
+    auto const override_ = create();
+    ASSERT_NE(nullptr, override_);
+    ASSERT_TRUE(container_of(toplevel)->occlusion_bypass());
+    ASSERT_TRUE(container_of(background)->occlusion_bypass());
+
+    override_->handle_output_changed();
+
+    EXPECT_FALSE(container_of(toplevel)->occlusion_bypass());
+    EXPECT_FALSE(container_of(background)->occlusion_bypass());
+}
+
+TEST_F(OverviewSceneOverrideTest, DestroyingAnOverrideThatWasNeverInstalledRestoresTheCull)
+{
+    report_windows_as_backgrounds();
+
+    auto const background = add_background();
+    auto const toplevel = add_toplevel();
+
+    // The scene override manager takes the override by value and destroys it
+    // where something else already holds the scene, so no exit path ever runs.
+    auto override_ = create();
+    ASSERT_NE(nullptr, override_);
+    ASSERT_TRUE(container_of(toplevel)->occlusion_bypass());
+
+    override_.reset();
+
+    EXPECT_FALSE(container_of(toplevel)->occlusion_bypass());
+    EXPECT_FALSE(container_of(background)->occlusion_bypass());
+}
+
+TEST_F(OverviewSceneOverrideTest, AWindowThatAppearsWhileTheOverviewIsUpIsBypassedToo)
+{
+    report_windows_as_backgrounds();
+
+    add_background();
+    add_toplevel();
+
+    auto const override_ = create();
+    ASSERT_NE(nullptr, override_);
+
+    auto const joined = add_toplevel();
+    override_->handle_window_added(joined);
+
+    EXPECT_TRUE(container_of(joined)->occlusion_bypass());
+}
+
+TEST_F(OverviewSceneOverrideTest, ExitingPutsEverythingBackIntoTheOcclusionCull)
+{
+    report_windows_as_backgrounds();
+
+    auto const background = add_background();
+    auto const toplevel = add_toplevel();
+
+    auto const override_ = create();
+    ASSERT_NE(nullptr, override_);
+
+    ASSERT_TRUE(container_of(toplevel)->occlusion_bypass());
+    ASSERT_TRUE(container_of(background)->occlusion_bypass());
+
+    override_->handle_keyboard_event(mir_input_event_get_keyboard_event(
+        mir_event_get_input_event(escape_press().get())));
+
+    // The outro clears the bypass at the very end of the exit animation.
+    animator->tick(10.f);
+    animator->tick(10.f);
+
+    EXPECT_FALSE(container_of(toplevel)->occlusion_bypass());
+    EXPECT_FALSE(container_of(background)->occlusion_bypass());
 }


### PR DESCRIPTION
This fixes an error in overview mode where occluded surfaces would _not_ be rendered by the overview